### PR TITLE
Bottom navigation and toolbar behavior changes

### DIFF
--- a/app/src/main/java/com/github/libretube/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/MainActivity.kt
@@ -107,7 +107,19 @@ class MainActivity : AppCompatActivity() {
             false
         }
 
-
+        navController.addOnDestinationChangedListener {_, destination, _ ->
+            if (destination.id == R.id.settings) {
+                toolbar.setNavigationIcon(R.drawable.ic_round_arrow_back_24)
+                toolbar.setNavigationOnClickListener {
+                    onBackPressed()
+                }
+            } else {
+                toolbar.setNavigationIcon(R.drawable.ic_settings)
+                toolbar.setNavigationOnClickListener {
+                    navController.navigate(R.id.settings)
+                }
+            }
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/github/libretube/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/MainActivity.kt
@@ -75,6 +75,11 @@ class MainActivity : AppCompatActivity() {
             }
             false
         }
+        bottomNavigationView.setOnItemReselectedListener {
+            // Nothing, I think is better UX like this, as we implemented the SwipeRefresLayout
+            // in home and subscriptions (in library will be too?) and I think it useless to refresh
+            // constantly the fragments when the user reselect a tab
+        }
 
         toolbar = findViewById(R.id.toolbar)
         val hexColor = String.format("#%06X", 0xFFFFFF and 0xcc322d)

--- a/app/src/main/java/com/github/libretube/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.net.Uri
+import android.opengl.Visibility
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -25,6 +26,7 @@ import androidx.core.view.ViewCompat.getWindowInsetsController
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
@@ -288,6 +290,10 @@ class MainActivity : AppCompatActivity() {
             @Suppress("DEPRECATION")
             window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_VISIBLE or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
         }
+    }
+
+    fun setBottomNavigationViewVisibility(visibility: Int) {
+        bottomNavigationView.visibility = visibility
     }
 
 }

--- a/app/src/main/java/com/github/libretube/Settings.kt
+++ b/app/src/main/java/com/github/libretube/Settings.kt
@@ -34,34 +34,13 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.zip.ZipFile
 
-/**
- * FIXME: After implemented the back button in the toolbar, when changing the theme, the navigation
- *  icon and listener resets to the default one instead, idk how the theme changer works so I can't
- *  help with it
- */
 class Settings : PreferenceFragmentCompat() {
 
     companion object {
         lateinit var getContent: ActivityResultLauncher<String>
     }
 
-    private var toolbar: MaterialToolbar? = null
-    private var parentActivity: FragmentActivity? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
-        // We save now the activity because when this fragment is detached it can't get the activity
-        // to rollback the navigationListener
-        parentActivity = requireActivity()
-
-        toolbar = parentActivity?.findViewById(R.id.toolbar)
-        toolbar?.setNavigationIcon(R.drawable.ic_round_arrow_back_24)
-        toolbar?.setNavigationOnClickListener {
-            parentFragmentManager.popBackStack()
-        }
-
-        //TODO: Hide the bottomNavigationView when user is in the settings fragment (idk why I can't hide it from here)
-        (parentActivity as MainActivity).setBottomNavigationViewVisibility(View.GONE)
-
         getContent = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
 
             if (uri != null) {
@@ -242,18 +221,5 @@ class Settings : PreferenceFragmentCompat() {
             }
         }
         run()
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-
-        // Sincerely I don't know if this is the correct way to do this, but is working :/
-        toolbar?.setNavigationIcon(R.drawable.ic_settings)
-        toolbar?.setNavigationOnClickListener {
-            val navController: NavController = parentActivity!!.findNavController(R.id.fragment)
-            navController.navigate(R.id.settings)
-        }
-
-        (parentActivity as MainActivity).setBottomNavigationViewVisibility(View.VISIBLE)
     }
 }

--- a/app/src/main/java/com/github/libretube/Settings.kt
+++ b/app/src/main/java/com/github/libretube/Settings.kt
@@ -10,32 +10,58 @@ import android.os.Bundle
 import android.os.Environment
 import android.text.TextUtils
 import android.util.Log
+import android.view.View
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavController
+import androidx.navigation.findNavController
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
 import com.blankj.utilcode.util.UriUtils
 import com.github.libretube.obj.Subscribe
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import retrofit2.HttpException
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.zip.ZipFile
 
+/**
+ * FIXME: After implemented the back button in the toolbar, when changing the theme, the navigation
+ *  icon and listener resets to the default one instead, idk how the theme changer works so I can't
+ *  help with it
+ */
 class Settings : PreferenceFragmentCompat() {
 
     companion object {
         lateinit var getContent: ActivityResultLauncher<String>
     }
 
+    private var toolbar: MaterialToolbar? = null
+    private var parentActivity: FragmentActivity? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // We save now the activity because when this fragment is detached it can't get the activity
+        // to rollback the navigationListener
+        parentActivity = requireActivity()
+
+        toolbar = parentActivity?.findViewById(R.id.toolbar)
+        toolbar?.setNavigationIcon(R.drawable.ic_round_arrow_back_24)
+        toolbar?.setNavigationOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+
+        //TODO: Hide the bottomNavigationView when user is in the settings fragment (idk why I can't hide it from here)
+        (parentActivity as MainActivity).setBottomNavigationViewVisibility(View.GONE)
+
         getContent = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
 
             if (uri != null) {
@@ -217,5 +243,17 @@ class Settings : PreferenceFragmentCompat() {
         }
         run()
     }
-}
 
+    override fun onDetach() {
+        super.onDetach()
+
+        // Sincerely I don't know if this is the correct way to do this, but is working :/
+        toolbar?.setNavigationIcon(R.drawable.ic_settings)
+        toolbar?.setNavigationOnClickListener {
+            val navController: NavController = parentActivity!!.findNavController(R.id.fragment)
+            navController.navigate(R.id.settings)
+        }
+
+        (parentActivity as MainActivity).setBottomNavigationViewVisibility(View.VISIBLE)
+    }
+}

--- a/app/src/main/res/drawable/ic_round_arrow_back_24.xml
+++ b/app/src/main/res/drawable/ic_round_arrow_back_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,11H7.83l4.88,-4.88c0.39,-0.39 0.39,-1.03 0,-1.42 -0.39,-0.39 -1.02,-0.39 -1.41,0l-6.59,6.59c-0.39,0.39 -0.39,1.02 0,1.41l6.59,6.59c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L7.83,13H19c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1z"/>
+</vector>


### PR DESCRIPTION
Disabled the reselect behavior in BottomNavigationView, I think the feature to reselect the tabs is now I bit useless, since we have added the SwipeRefreshLayout.

Changes the toolbar navigation behavior to go back when in the settings fragment. Now there is only remains to hide the bottomNavigationView when on settings