### PR TITLE
Fix fullscreen button and keyboard search button

### DIFF
--- a/app/src/main/java/com/github/libretube/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/PlayerFragment.kt
@@ -192,7 +192,6 @@ class PlayerFragment : Fragment() {
                 view.findViewById<LinearLayout>(R.id.linLayout).visibility=View.GONE
                 val mainActivity = activity as MainActivity
                 mainActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-                mainActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
                 isFullScreen=true
 
             }else{

--- a/app/src/main/java/com/github/libretube/SearchFragment.kt
+++ b/app/src/main/java/com/github/libretube/SearchFragment.kt
@@ -9,9 +9,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
+import android.widget.TextView.OnEditorActionListener
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -75,6 +77,17 @@ class SearchFragment : Fragment() {
                 }
 
             })
+        autoTextView.setOnEditorActionListener(OnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                hideKeyboard();
+                autoTextView.dismissDropDown();
+                return@OnEditorActionListener true
+            }
+            false
+        })
+        autoTextView.setOnDismissListener {
+            hideKeyboard();
+        }
     }
 
     private fun fetchSuggestions(query: String, autoTextView: AutoCompleteTextView){


### PR DESCRIPTION
Current behavior:
When we click the full screen button, the orientation changes to landscape and again shifts to portrait.
After we type something in the search and press search button on keyboard, nothing happens.

Expectation:
When we click the full screen button, the orientation should remain in landscape mode until the button is clicked again.
After we type something in the search and press search button on keyboard, the keyboard, search suggestions should close.