### PR TITLE
Fix search suggestions/keyboard disappearing while typing

### DIFF
--- a/app/src/main/java/com/github/libretube/SearchFragment.kt
+++ b/app/src/main/java/com/github/libretube/SearchFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
+import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import android.widget.TextView.OnEditorActionListener
@@ -85,8 +86,8 @@ class SearchFragment : Fragment() {
             }
             false
         })
-        autoTextView.setOnDismissListener {
-            hideKeyboard();
+        autoTextView.setOnItemClickListener { _, _, _, _ ->
+            hideKeyboard()
         }
     }
 


### PR DESCRIPTION
The onDismiss event is called automatically sometimes that leads to search results and keyboard closing automatically.

This is caused by my commit: https://github.com/libre-tube/LibreTube/pull/115/commits/89937f4ef6b1860ea8b215e42ebe70abf854cae2

Now I am implementing onItemClickListener.