### PR TITLE
Open links in description and copy description text

### DIFF
--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -87,6 +87,8 @@
                     android:padding="8dp"
                     android:textSize="14sp"
                     android:visibility="gone"
+                    android:autoLink="web"
+                    android:textIsSelectable="true"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/player_title_layout" />


### PR DESCRIPTION
Added ability to open links in the video description and copy the description text as requested in Issue #138