### PR TITLE
Ignore case for username id

### DIFF
--- a/app/src/main/java/com/github/libretube/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/PlaylistFragment.kt
@@ -73,7 +73,7 @@ class PlaylistFragment : Fragment() {
                     val sharedPref2 = context?.getSharedPreferences("username", Context.MODE_PRIVATE)
                     val user = sharedPref2?.getString("username","")
                     var isOwner = false
-                    if(response.uploaderUrl == null && response.uploader == user){
+                    if(response.uploaderUrl == null && response.uploader.equals(user, true)){
                         isOwner = true
                     }
                     playlistAdapter = PlaylistAdapter(response.relatedStreams!!.toMutableList(), playlist_id!!, isOwner, requireActivity())


### PR DESCRIPTION
Fixes #198 
Sometimes? The shared preferences username has different case letters than the response.uploader which causes the delete button to not show up!
In my testing, the last 3 characters in my user id were all upper case where shared preference had them lowercase