### PR TITLE
Added Audio Focus to Exo Player

### DIFF
--- a/app/src/main/java/com/github/libretube/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/PlayerFragment.kt
@@ -2,7 +2,6 @@ package com.github.libretube
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -15,7 +14,6 @@ import android.os.Bundle
 import android.os.Environment
 import android.text.Html
 import android.util.Log
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -37,11 +35,13 @@ import com.github.libretube.adapters.CommentsAdapter
 import com.github.libretube.adapters.TrendingAdapter
 import com.github.libretube.obj.PipedStream
 import com.github.libretube.obj.Subscribe
+import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.MediaItem.SubtitleConfiguration
 import com.google.android.exoplayer2.MediaItem.fromUri
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.audio.AudioAttributes
 import com.google.android.exoplayer2.ext.cronet.CronetDataSource
 import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import com.google.android.exoplayer2.source.MediaSource
@@ -323,6 +323,10 @@ class PlayerFragment : Fragment() {
                         cronetDataSourceFactory
                     )
 
+                    val audioAttributes = AudioAttributes.Builder()
+                        .setUsage(C.USAGE_MEDIA)
+                        .setContentType(C.CONTENT_TYPE_MOVIE)
+                        .build()
 
                     exoPlayer = ExoPlayer.Builder(view.context)
                         .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
@@ -334,6 +338,7 @@ class PlayerFragment : Fragment() {
                     exoPlayerView.setShowPreviousButton(false)
                     // exoPlayerView.controllerShowTimeoutMs = 1500
                     exoPlayerView.controllerHideOnTouch = true
+                    exoPlayer.setAudioAttributes(audioAttributes,true);
                     exoPlayerView.player = exoPlayer
                     val sharedPreferences =
                         PreferenceManager.getDefaultSharedPreferences(requireContext())


### PR DESCRIPTION
Makes Exo Player mute other audio when started and mutes itself when other audio is played. Fixes multiple audio lines playing at the same time (e.g. with description links)