### PR TITLE
Fix settings not showing up below android 10 (Q)

### DIFF
--- a/app/src/main/java/com/github/libretube/SettingsActivity.kt
+++ b/app/src/main/java/com/github/libretube/SettingsActivity.kt
@@ -38,7 +38,9 @@ class SettingsActivity : AppCompatActivity(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        overridePendingTransition(50, 50);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            overridePendingTransition(50, 50);
+        }
         val view = this.findViewById<View>(android.R.id.content)
         view.setAlpha(0F);
         view.animate().alpha(1F).setDuration(300);


### PR DESCRIPTION
Added a check to see if the user is on android 10 or above if so then use animation otherwise it would end up not showing settings until you go home and back to the app. This was caused by #196 