### PR TITLE
Fixed dynamic color on Android 12+

### DIFF
--- a/app/src/main/java/com/github/libretube/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : AppCompatActivity() {
     lateinit var navController : NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        DynamicColors.applyToActivitiesIfAvailable(application)
         super.onCreate(savedInstanceState)
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         RetrofitInstance.url = sharedPreferences.getString("instance", "https://pipedapi.kavin.rocks/")!!
@@ -49,7 +50,7 @@ class MainActivity : AppCompatActivity() {
         SponsorBlockSettings.sponsorsEnabled = sharedPreferences.getBoolean("sponsors_category_key", false)
         SponsorBlockSettings.outroEnabled = sharedPreferences.getBoolean("outro_category_key", false)
 
-        DynamicColors.applyToActivitiesIfAvailable(application)
+        
         val languageName = sharedPreferences.getString("language", "sys")
         if (languageName != "") {
             var locale = if (languageName != "sys" && "$languageName".length < 3 ){

--- a/app/src/main/java/com/github/libretube/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : AppCompatActivity() {
     lateinit var navController : NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        DynamicColors.applyToActivitiesIfAvailable(application)
+        DynamicColors.applyToActivityIfAvailable(this)
         super.onCreate(savedInstanceState)
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         RetrofitInstance.url = sharedPreferences.getString("instance", "https://pipedapi.kavin.rocks/")!!

--- a/app/src/main/java/com/github/libretube/Player.kt
+++ b/app/src/main/java/com/github/libretube/Player.kt
@@ -12,6 +12,7 @@ class Player : Activity() {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        DynamicColors.applyToActivityIfAvailable(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_player)
 

--- a/app/src/main/java/com/github/libretube/Player.kt
+++ b/app/src/main/java/com/github/libretube/Player.kt
@@ -3,7 +3,7 @@ package com.github.libretube
 import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
-import android.content.Intent.
+import android.content.Intent
 import com.google.android.material.color.DynamicColors
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle

--- a/app/src/main/java/com/github/libretube/Player.kt
+++ b/app/src/main/java/com/github/libretube/Player.kt
@@ -3,7 +3,8 @@ package com.github.libretube
 import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
-import android.content.Intent
+import android.content.Intent.
+import com.google.android.material.color.DynamicColors
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 

--- a/app/src/main/java/com/github/libretube/SettingsActivity.kt
+++ b/app/src/main/java/com/github/libretube/SettingsActivity.kt
@@ -36,6 +36,7 @@ class SettingsActivity : AppCompatActivity(),
     SharedPreferences.OnSharedPreferenceChangeListener{
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        DynamicColors.applyToActivityIfAvailable(this)
         super.onCreate(savedInstanceState)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             overridePendingTransition(50, 50);

--- a/app/src/main/java/com/github/libretube/SettingsActivity.kt
+++ b/app/src/main/java/com/github/libretube/SettingsActivity.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.google.android.material.color.DynamicColors
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.ListPreference
 import androidx.preference.Preference


### PR DESCRIPTION
Note to contributors/developers: 
> For each new activity that you add, add this before the `super.onCreate()`: `DynamicColors.applyToActivityIfAvailable(this)`
Or else dynamic color won't be applied.