### PR TITLE
add aspect ratio toggle button in exoplayer

### DIFF
--- a/app/src/main/java/com/github/libretube/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/PlayerFragment.kt
@@ -287,7 +287,7 @@ class PlayerFragment : Fragment() {
 
         // switching between original aspect ratio (black bars) and zoomed to fill device screen
         view.findViewById<ImageButton>(R.id.aspect_ratio_button).setOnClickListener {
-            if(isZoomed) {
+            if (isZoomed) {
                 exoPlayerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                 isZoomed = false
             } else {

--- a/app/src/main/java/com/github/libretube/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/PlayerFragment.kt
@@ -65,6 +65,7 @@ import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import com.google.android.exoplayer2.source.MediaSource
 import com.google.android.exoplayer2.source.MergingMediaSource
 import com.google.android.exoplayer2.source.ProgressiveMediaSource
+import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.PlayerNotificationManager
 import com.google.android.exoplayer2.ui.StyledPlayerView
 import com.google.android.exoplayer2.upstream.DataSource
@@ -93,6 +94,7 @@ class PlayerFragment : Fragment() {
     private var eId: Int = 0
     private var paused = false
     private var whichQuality = 0
+    private var isZoomed: Boolean = false
 
     var isSubscribed: Boolean = false
 
@@ -280,6 +282,17 @@ class PlayerFragment : Fragment() {
                 val mainActivity = activity as MainActivity
                 mainActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                 isFullScreen = false
+            }
+        }
+
+        // switching between original aspect ratio (black bars) and zoomed to fill device screen
+        view.findViewById<ImageButton>(R.id.aspect_ratio_button).setOnClickListener {
+            if(isZoomed) {
+                exoPlayerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                isZoomed = false
+            } else {
+                exoPlayerView.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                isZoomed = true
             }
         }
 

--- a/app/src/main/res/drawable/ic_aspect_ratio.xml
+++ b/app/src/main/res/drawable/ic_aspect_ratio.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,12h-2v3h-3v2h5v-5zM7,9h3L10,7L5,7v5h2L7,9zM21,3L3,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h18c1.1,0 2,-0.9 2,-2L23,5c0,-1.1 -0.9,-2 -2,-2zM21,19.01L3,19.01L3,4.99h18v14.02z"/>
+</vector>

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -48,13 +48,10 @@
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_close2"
                 android:padding="@dimen/exo_icon_padding"
-                android:background="#00FFFFFF"
-
-                />
+                android:background="#00FFFFFF"/>
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/quality"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingStart="@dimen/exo_styled_bottom_bar_time_padding"
@@ -63,14 +60,23 @@
             android:paddingRight="@dimen/exo_styled_bottom_bar_time_padding"
             android:layout_gravity="center_vertical|end"
             android:layoutDirection="ltr">
+            <ImageButton
+                android:id="@+id/aspect_ratio_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_aspect_ratio"
+                android:padding="@dimen/exo_icon_padding"
+                android:layout_marginEnd="12dp"
+                android:background="#00FFFFFF"/>
 
             <TextView
                 android:id="@+id/quality_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="@dimen/exo_icon_padding"
                 android:text="HLS"
-                android:textColor="#FFFFFF" />
+                android:textColor="#FFFFFF"/>
             <ImageButton
                 android:id="@+id/quality_select"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
This commit adds a simple button to the video player which allows toggling between the videos aspect ratio (black bars) and zooming into the video to fill the whole screen. Also I've fixed the alignment of the resolution switcher text and icon.

Closes #109 and #188