### PR TITLE
Have separate retrofit instance for authenticated calls

### DIFF
--- a/app/src/main/java/com/github/libretube/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/activities/MainActivity.kt
@@ -61,6 +61,8 @@ class MainActivity : AppCompatActivity() {
 
         RetrofitInstance.url =
             PreferenceHelper.getString(this, "selectInstance", "https://pipedapi.kavin.rocks/")!!
+        RetrofitInstance.authUrl =
+            PreferenceHelper.getString(this, "selectAuthInstance", "https://pipedapi.kavin.rocks/")!!
 
         ThemeHelper.updateTheme(this)
         LocaleHelper.updateLanguage(this)

--- a/app/src/main/java/com/github/libretube/adapters/PlaylistAdapter.kt
+++ b/app/src/main/java/com/github/libretube/adapters/PlaylistAdapter.kt
@@ -91,7 +91,7 @@ class PlaylistAdapter(
         fun run() {
             CoroutineScope(Dispatchers.IO).launch {
                 val response = try {
-                    RetrofitInstance.api.removeFromPlaylist(
+                    RetrofitInstance.authApi.removeFromPlaylist(
                         token,
                         PlaylistId(playlistId = playlistId, index = position)
                     )

--- a/app/src/main/java/com/github/libretube/adapters/PlaylistsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/adapters/PlaylistsAdapter.kt
@@ -76,7 +76,7 @@ class PlaylistsAdapter(
         fun run() {
             GlobalScope.launch {
                 val response = try {
-                    RetrofitInstance.api.deletePlaylist(token, PlaylistId(id))
+                    RetrofitInstance.authApi.deletePlaylist(token, PlaylistId(id))
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/adapters/SubscriptionChannelAdapter.kt
+++ b/app/src/main/java/com/github/libretube/adapters/SubscriptionChannelAdapter.kt
@@ -70,7 +70,7 @@ class SubscriptionChannelAdapter(private val subscriptions: MutableList<Subscrip
             CoroutineScope(Dispatchers.IO).launch {
                 val response = try {
                     val token = PreferenceHelper.getToken(context)
-                    RetrofitInstance.api.subscribe(
+                    RetrofitInstance.authApi.subscribe(
                         token,
                         Subscribe(channelId)
                     )
@@ -92,7 +92,7 @@ class SubscriptionChannelAdapter(private val subscriptions: MutableList<Subscrip
             CoroutineScope(Dispatchers.IO).launch {
                 val response = try {
                     val token = PreferenceHelper.getToken(context)
-                    RetrofitInstance.api.unsubscribe(
+                    RetrofitInstance.authApi.unsubscribe(
                         token,
                         Subscribe(channelId)
                     )

--- a/app/src/main/java/com/github/libretube/dialogs/AddtoPlaylistDialog.kt
+++ b/app/src/main/java/com/github/libretube/dialogs/AddtoPlaylistDialog.kt
@@ -55,7 +55,7 @@ class AddtoPlaylistDialog : DialogFragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.playlists(token)
+                    RetrofitInstance.authApi.playlists(token)
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")
@@ -95,7 +95,7 @@ class AddtoPlaylistDialog : DialogFragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.addToPlaylist(token, PlaylistId(playlistId, videoId))
+                    RetrofitInstance.authApi.addToPlaylist(token, PlaylistId(playlistId, videoId))
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/dialogs/CreatePlaylistDialog.kt
+++ b/app/src/main/java/com/github/libretube/dialogs/CreatePlaylistDialog.kt
@@ -63,7 +63,7 @@ class CreatePlaylistDialog : DialogFragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.createPlaylist(token, Playlists(name = name))
+                    RetrofitInstance.authApi.createPlaylist(token, Playlists(name = name))
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/dialogs/DeleteAccountDialog.kt
+++ b/app/src/main/java/com/github/libretube/dialogs/DeleteAccountDialog.kt
@@ -57,7 +57,7 @@ class DeleteAccountDialog : DialogFragment() {
                 val token = PreferenceHelper.getToken(requireContext())
 
                 try {
-                    RetrofitInstance.api.deleteAccount(token, DeleteUserRequest(password))
+                    RetrofitInstance.authApi.deleteAccount(token, DeleteUserRequest(password))
                 } catch (e: Exception) {
                     Log.e(TAG, e.toString())
                     Toast.makeText(context, R.string.unknown_error, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/github/libretube/dialogs/LoginDialog.kt
+++ b/app/src/main/java/com/github/libretube/dialogs/LoginDialog.kt
@@ -70,7 +70,7 @@ class LoginDialog : DialogFragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.login(login)
+                    RetrofitInstance.authApi.login(login)
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")
@@ -102,7 +102,7 @@ class LoginDialog : DialogFragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.register(login)
+                    RetrofitInstance.authApi.register(login)
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/dialogs/PlaylistOptionsDialog.kt
+++ b/app/src/main/java/com/github/libretube/dialogs/PlaylistOptionsDialog.kt
@@ -70,7 +70,7 @@ class PlaylistOptionsDialog(
         fun run() {
             CoroutineScope(Dispatchers.IO).launch {
                 val response = try {
-                    RetrofitInstance.api.importPlaylist(token, PlaylistId(playlistId))
+                    RetrofitInstance.authApi.importPlaylist(token, PlaylistId(playlistId))
                 } catch (e: IOException) {
                     println(e)
                     return@launch

--- a/app/src/main/java/com/github/libretube/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/fragments/ChannelFragment.kt
@@ -87,7 +87,7 @@ class ChannelFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.isSubscribed(
+                    RetrofitInstance.authApi.isSubscribed(
                         channelId!!,
                         token
                     )
@@ -127,7 +127,7 @@ class ChannelFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.subscribe(
+                    RetrofitInstance.authApi.subscribe(
                         token,
                         Subscribe(channelId)
                     )
@@ -150,7 +150,7 @@ class ChannelFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.unsubscribe(
+                    RetrofitInstance.authApi.unsubscribe(
                         token,
                         Subscribe(channelId)
                     )

--- a/app/src/main/java/com/github/libretube/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/libretube/fragments/LibraryFragment.kt
@@ -87,7 +87,7 @@ class LibraryFragment : Fragment() {
             binding.playlistRefresh.isRefreshing = true
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.playlists(token)
+                    RetrofitInstance.authApi.playlists(token)
                 } catch (e: IOException) {
                     println(e)
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/fragments/PlayerFragment.kt
@@ -1025,7 +1025,7 @@ class PlayerFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.isSubscribed(
+                    RetrofitInstance.authApi.isSubscribed(
                         channel_id,
                         token
                     )
@@ -1065,7 +1065,7 @@ class PlayerFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.subscribe(
+                    RetrofitInstance.authApi.subscribe(
                         token,
                         Subscribe(channel_id)
                     )
@@ -1088,7 +1088,7 @@ class PlayerFragment : Fragment() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.unsubscribe(
+                    RetrofitInstance.authApi.unsubscribe(
                         token,
                         Subscribe(channel_id)
                     )

--- a/app/src/main/java/com/github/libretube/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/fragments/SubscriptionsFragment.kt
@@ -109,7 +109,7 @@ class SubscriptionsFragment : Fragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.getFeed(token)
+                    RetrofitInstance.authApi.getFeed(token)
                 } catch (e: IOException) {
                     Log.e(TAG, e.toString())
                     Log.e(TAG, "IOException, you might not have internet connection")
@@ -148,7 +148,7 @@ class SubscriptionsFragment : Fragment() {
         fun run() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
-                    RetrofitInstance.api.subscriptions(token)
+                    RetrofitInstance.authApi.subscriptions(token)
                 } catch (e: IOException) {
                     Log.e(TAG, e.toString())
                     Log.e(TAG, "IOException, you might not have internet connection")

--- a/app/src/main/java/com/github/libretube/preferences/InstanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/preferences/InstanceSettings.kt
@@ -120,6 +120,7 @@ class InstanceSettings : PreferenceFragmentCompat() {
         instance?.setOnPreferenceChangeListener { _, newValue ->
             requireMainActivityRestart = true
             RetrofitInstance.url = newValue.toString()
+            RetrofitInstance.authUrl = newValue.toString()
             RetrofitInstance.lazyMgr.reset()
             logout()
             true
@@ -302,7 +303,7 @@ class InstanceSettings : PreferenceFragmentCompat() {
             lifecycleScope.launchWhenCreated {
                 val response = try {
                     val token = PreferenceHelper.getToken(requireContext())
-                    RetrofitInstance.api.importSubscriptions(
+                    RetrofitInstance.authApi.importSubscriptions(
                         false,
                         token,
                         channels

--- a/app/src/main/java/com/github/libretube/util/RetrofitInstance.kt
+++ b/app/src/main/java/com/github/libretube/util/RetrofitInstance.kt
@@ -5,10 +5,18 @@ import retrofit2.converter.jackson.JacksonConverterFactory
 
 object RetrofitInstance {
     lateinit var url: String
+    lateinit var authUrl: String
     val lazyMgr = resettableManager()
     val api: PipedApi by resettableLazy(lazyMgr) {
         Retrofit.Builder()
             .baseUrl(url)
+            .addConverterFactory(JacksonConverterFactory.create())
+            .build()
+            .create(PipedApi::class.java)
+    }
+    val authApi: PipedApi by resettableLazy(lazyMgr) {
+        Retrofit.Builder()
+            .baseUrl(authUrl)
             .addConverterFactory(JacksonConverterFactory.create())
             .build()
             .create(PipedApi::class.java)


### PR DESCRIPTION
See: #332

To set a different instance for authenticated calls, you just have to set `RetrofitInstance.authUrl`