### PR TITLE
fix: handle duration string timestamps

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/RouterActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/RouterActivity.kt
@@ -10,6 +10,7 @@ import com.github.libretube.constants.IntentData
 import com.github.libretube.extensions.TAG
 import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.util.NavigationHelper
+import kotlin.time.Duration
 
 class RouterActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -75,14 +76,14 @@ class RouterActivity : BaseActivity() {
 
                 intent.putExtra(IntentData.videoId, videoId)
                 uri.getQueryParameter("t")
-                    ?.let { intent.putExtra(IntentData.timeStamp, it.toLong()) }
+                    ?.let { intent.putExtra(IntentData.timeStamp, parseTimestamp(it)) }
             }
             else -> {
                 val videoId = uri.path!!.replace("/", "")
 
                 intent.putExtra(IntentData.videoId, videoId)
                 uri.getQueryParameter("t")
-                    ?.let { intent.putExtra(IntentData.timeStamp, it.toLong()) }
+                    ?.let { intent.putExtra(IntentData.timeStamp, parseTimestamp(it)) }
             }
         }
         return intent
@@ -98,5 +99,13 @@ class RouterActivity : BaseActivity() {
             resolveType(intent!!, uri)
         )
         this.finishAndRemoveTask()
+    }
+
+    private fun parseTimestamp(t: String): Long? {
+        if (t.all { c -> c.isDigit() }) {
+            return t.toLong()
+        }
+
+        return Duration.parseOrNull(t)?.inWholeSeconds
     }
 }


### PR DESCRIPTION
fixes #1275.
tested with the following cases:
| URL | expected result | pass/fail |
| --- | --- | --- |
| https://youtu.be/RDkWagIW6gw | video continues playback | pass |
| https://youtu.be/RDkWagIW6gw?t=123 | starts at 02:03 | pass |
| https://youtu.be/RDkWagIW6gw?t=9m14s | starts at 09:14 | pass |
| https://youtube.com/watch?v=RDkWagIW6gw | video continues playback | pass |
| https://youtube.com/watch?v=RDkWagIW6gw&t=123 |  starts at 02:03 | pass |
| https://youtube.com/watch?v=RDkWagIW6gw&t=9m14s | starts at 09:14 | pass |