### PR TITLE
Continue on error in apk signing process.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           ./gradlew assembleDebug
 
       - name: Sign Apk
+        continue-on-error: true
         id: sign_apk
         uses: ilharp/sign-android-release@v1
         with:


### PR DESCRIPTION
This will fix ci failing for every new pr. 