### PR TITLE
fix: hide "Show more" button when hiding comment replies

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
@@ -111,7 +111,10 @@ class CommentsAdapter(
                                 }
                             }
                         }
-                        else -> repliesAdapter.clear()
+                        else -> {
+                            repliesAdapter.clear()
+                            showMore.visibility = View.GONE
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Before fix: "Show more" button sticks around when collapsing a comment's replies, if said comment has enough replies that it needs to be paginated

https://user-images.githubusercontent.com/848000/198214985-aedbbfac-8fc3-43af-bab0-f858b19886c0.mp4

After fix: "Show more" button is unconditionally hidden when collapsing a comment's replies

https://user-images.githubusercontent.com/848000/198214997-e832a32c-47dd-4167-af7d-2774d8e9a3b5.mp4

