### PR TITLE
Fix navigation and backstack issues

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -143,12 +143,17 @@ class MainActivity : BaseActivity() {
                     }
                 }
 
-                if (navController.currentDestination?.id == startFragmentId) {
-                    moveTaskToBack(true)
-                } else {
-                    navController.popBackStack(R.id.searchResultFragment, false) ||
+                when (navController.currentDestination?.id) {
+                    startFragmentId -> {
+                        moveTaskToBack(true)
+                    }
+                    R.id.searchResultFragment -> {
                         navController.popBackStack(R.id.searchFragment, true) ||
+                            navController.popBackStack()
+                    }
+                    else -> {
                         navController.popBackStack()
+                    }
                 }
             }
         })

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -269,6 +269,7 @@ class MainActivity : BaseActivity() {
                     searchViewModel.setQuery(null)
                     navController.navigate(R.id.searchFragment)
                 }
+                item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS or MenuItem.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW)
                 return true
             }
 

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -106,29 +106,16 @@ class MainActivity : BaseActivity() {
 
         binding.bottomNav.setOnApplyWindowInsetsListener(null)
 
-        // Prevent adding duplicate entries into backstack on multiple
-        // click on bottom navigation item
-        binding.bottomNav.setOnItemReselectedListener { }
+        // Prevent duplicate entries into backstack, if selected item and current
+        // visible fragment is different, then navigate to selected item.
+        binding.bottomNav.setOnItemReselectedListener {
+            if (it.itemId != navController.currentDestination?.id) {
+                navigateToBottomSelectedItem(it)
+            }
+        }
 
         binding.bottomNav.setOnItemSelectedListener {
-            // clear backstack if it's the start fragment
-            if (startFragmentId == it.itemId) navController.backQueue.clear()
-
-            if (it.itemId == R.id.subscriptionsFragment) {
-                binding.bottomNav.removeBadge(R.id.subscriptionsFragment)
-            }
-
-            // navigate to the selected fragment, if the fragment already
-            // exists in backstack then pop up to that entry
-            if (!navController.popBackStack(it.itemId, false)) {
-                navController.navigate(it.itemId)
-            }
-
-            // Remove focus from search view when navigating to bottom view.
-            // Call only after navigate to destination, so it can be used in
-            // onMenuItemActionCollapse for backstack management
-            removeSearchFocus()
-
+            navigateToBottomSelectedItem(it)
             false
         }
 
@@ -494,6 +481,26 @@ class MainActivity : BaseActivity() {
             window.decorView.systemUiVisibility =
                 (View.SYSTEM_UI_FLAG_VISIBLE or View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
         }
+    }
+
+    private fun navigateToBottomSelectedItem(item: MenuItem) {
+        // clear backstack if it's the start fragment
+        if (startFragmentId == item.itemId) navController.backQueue.clear()
+
+        if (item.itemId == R.id.subscriptionsFragment) {
+            binding.bottomNav.removeBadge(R.id.subscriptionsFragment)
+        }
+
+        // navigate to the selected fragment, if the fragment already
+        // exists in backstack then pop up to that entry
+        if (!navController.popBackStack(item.itemId, false)) {
+            navController.navigate(item.itemId)
+        }
+
+        // Remove focus from search view when navigating to bottom view.
+        // Call only after navigate to destination, so it can be used in
+        // onMenuItemActionCollapse for backstack management
+        removeSearchFocus()
     }
 
     override fun onUserLeaveHint() {

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -105,6 +105,10 @@ class MainActivity : BaseActivity() {
 
         binding.bottomNav.setOnApplyWindowInsetsListener(null)
 
+        // Prevent adding duplicate entries into backstack on multiple
+        // click on bottom navigation item
+        binding.bottomNav.setOnItemReselectedListener { }
+
         binding.bottomNav.setOnItemSelectedListener {
             // clear backstack if it's the start fragment
             if (startFragmentId == it.itemId) navController.backQueue.clear()
@@ -115,8 +119,11 @@ class MainActivity : BaseActivity() {
 
             removeSearchFocus()
 
-            // navigate to the selected fragment
-            navController.navigate(it.itemId)
+            // navigate to the selected fragment, if the fragment already
+            // exists in backstack then pop up to that entry
+            if (!navController.popBackStack(it.itemId, false)) {
+                navController.navigate(it.itemId)
+            }
             false
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.libretube.R
 import com.github.libretube.api.RetrofitInstance
@@ -16,7 +15,6 @@ import com.github.libretube.db.DatabaseHelper
 import com.github.libretube.db.obj.SearchHistoryItem
 import com.github.libretube.extensions.TAG
 import com.github.libretube.extensions.hideKeyboard
-import com.github.libretube.ui.activities.MainActivity
 import com.github.libretube.ui.adapters.SearchAdapter
 import com.github.libretube.ui.base.BaseFragment
 import com.github.libretube.util.PreferenceHelper
@@ -142,15 +140,5 @@ class SearchResultFragment : BaseFragment() {
                 )
             )
         }
-    }
-
-    override fun onStop() {
-        if (findNavController().currentDestination?.id != R.id.searchFragment) {
-            // remove the search focus
-            (activity as MainActivity)
-                .binding.toolbar.menu
-                .findItem(R.id.action_search).collapseActionView()
-        }
-        super.onStop()
     }
 }


### PR DESCRIPTION
Prevent duplicate entries in the navigation stack on reselection of the bottom item. Check if the reselected item and currently visible fragment is same, if not navigate to the bottom selected item.

Fix search history appearing at unwanted locations. Remove the search focus after the query is submitted. Fix the search option overflow when searchView is expanded.

Closes #1599, fixes #1948, fixes #1834