### PR TITLE
Fix brightness inconsistency

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -84,6 +84,7 @@ object PreferenceKeys {
     const val USE_HLS_OVER_DASH = "use_hls"
     const val QUEUE_AUTO_INSERT_RELATED = "queue_insert_related_videos"
     const val PLAYER_SWIPE_CONTROLS = "player_swipe_controls"
+    const val PLAYER_SCREEN_BRIGHTNESS = "player_screen_brightness"
     const val SHOW_OPEN_WITH = "show_open_with"
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -9,7 +9,6 @@ import android.os.Looper
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
-import android.view.WindowManager
 import com.github.libretube.R
 import com.github.libretube.databinding.DoubleTapOverlayBinding
 import com.github.libretube.databinding.ExoStyledPlayerControlViewBinding
@@ -320,15 +319,12 @@ internal class CustomExoPlayerView(
     }
 
     private fun initializeGestureProgress() {
-        val brightnessBar = gestureViewBinding.brightnessProgressBar
-        val volumeBar = gestureViewBinding.volumeProgressBar
-
-        brightnessBar.progress = if (brightnessHelper.brightness == WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE) {
-            25.normalize(0, 100, 0, volumeBar.max)
-        } else {
-            brightnessHelper.getBrightnessWithScale(brightnessBar.max.toFloat()).toInt()
+        gestureViewBinding.brightnessProgressBar.let { bar ->
+            bar.progress = brightnessHelper.getBrightnessWithScale(bar.max.toFloat(), saved = true).toInt()
         }
-        volumeBar.progress = audioHelper.getVolumeWithScale(volumeBar.max)
+        gestureViewBinding.volumeProgressBar.let { bar ->
+            bar.progress = audioHelper.getVolumeWithScale(bar.max)
+        }
     }
 
     private fun updateBrightness(distance: Float) {
@@ -444,6 +440,13 @@ internal class CustomExoPlayerView(
             val params = it.layoutParams as MarginLayoutParams
             params.bottomMargin = offset.toInt()
             it.layoutParams = params
+        }
+
+        if (PlayerHelper.swipeGestureEnabled) {
+            when (newConfig?.orientation) {
+                Configuration.ORIENTATION_LANDSCAPE -> brightnessHelper.restoreSavedBrightness()
+                else -> brightnessHelper.resetToSystemBrightness(true)
+            }
         }
     }
 

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -445,7 +445,7 @@ internal class CustomExoPlayerView(
         if (PlayerHelper.swipeGestureEnabled) {
             when (newConfig?.orientation) {
                 Configuration.ORIENTATION_LANDSCAPE -> brightnessHelper.restoreSavedBrightness()
-                else -> brightnessHelper.resetToSystemBrightness(true)
+                else -> brightnessHelper.resetToSystemBrightness(false)
             }
         }
     }

--- a/app/src/main/java/com/github/libretube/util/BrightnessHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/BrightnessHelper.kt
@@ -2,6 +2,7 @@ package com.github.libretube.util
 
 import android.app.Activity
 import android.view.WindowManager
+import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.normalize
 
 class BrightnessHelper(activity: Activity) {
@@ -13,26 +14,60 @@ class BrightnessHelper(activity: Activity) {
     /**
      * Wrapper for the current screen brightness
      */
-    var brightness: Float
+    private var brightness: Float
         get() = window.attributes.screenBrightness
-        private set(value) {
+        set(value) {
             val lp = window.attributes
             lp.screenBrightness = value
             window.attributes = lp
         }
 
     /**
-     * Restore screen brightness to device system brightness.
+     * Wrapper for the brightness persisted in the shared preferences.
      */
-    fun resetToSystemBrightness() {
+    private var savedBrightness: Float
+        get() = PreferenceHelper.getFloat(PreferenceKeys.PLAYER_SCREEN_BRIGHTNESS, brightness)
+        set(value) = PreferenceHelper.putFloat(PreferenceKeys.PLAYER_SCREEN_BRIGHTNESS, value)
+
+    /**
+     * Restore screen brightness to device system brightness.
+     * [saveOldValue] determines whether the old value should be persisted or not.
+     */
+    fun resetToSystemBrightness(saveOldValue: Boolean = false) {
+        savedBrightness = if (saveOldValue) {
+            brightness
+        } else {
+            WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+        }
+
         brightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
     }
 
-    fun setBrightnessWithScale(value: Float, maxValue: Float, minValue: Float = 0.0f) {
-        brightness = value.normalize(minValue, maxValue, minBrightness, maxBrightness)
+    /**
+     * Set current screen brightness to saved brightness value.
+     */
+    fun restoreSavedBrightness() {
+        brightness = savedBrightness
     }
 
-    fun getBrightnessWithScale(maxValue: Float, minValue: Float = 0.0f): Float {
-        return brightness.normalize(minBrightness, maxBrightness, minValue, maxValue)
+    /**
+     * Set current brightness value with scaling to given range.
+     * [shouldSave] determines whether the value should be persisted.
+     */
+    fun setBrightnessWithScale(value: Float, maxValue: Float, minValue: Float = 0.0f, shouldSave: Boolean = false) {
+        brightness = value.normalize(minValue, maxValue, minBrightness, maxBrightness)
+        if (shouldSave) savedBrightness = brightness
+    }
+
+    /**
+     * Get scaled brightness with given range. if [saved] is
+     * ture value will be retrived from shared preferences.
+     */
+    fun getBrightnessWithScale(maxValue: Float, minValue: Float = 0.0f, saved: Boolean = false): Float {
+        return if (saved) {
+            savedBrightness.normalize(minBrightness, maxBrightness, minValue, maxValue)
+        } else {
+            brightness.normalize(minBrightness, maxBrightness, minValue, maxValue)
+        }
     }
 }

--- a/app/src/main/java/com/github/libretube/util/BrightnessHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/BrightnessHelper.kt
@@ -1,11 +1,12 @@
 package com.github.libretube.util
 
 import android.app.Activity
+import android.os.Build
 import android.view.WindowManager
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.normalize
 
-class BrightnessHelper(activity: Activity) {
+class BrightnessHelper(private val activity: Activity) {
 
     private val window = activity.window
     private val minBrightness = 0.0f
@@ -31,15 +32,13 @@ class BrightnessHelper(activity: Activity) {
 
     /**
      * Restore screen brightness to device system brightness.
-     * [saveOldValue] determines whether the old value should be persisted or not.
+     * if [forced] is false then value will be stored only if it's not
+     * [WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE] value.
      */
-    fun resetToSystemBrightness(saveOldValue: Boolean = false) {
-        savedBrightness = if (saveOldValue) {
-            brightness
-        } else {
-            WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+    fun resetToSystemBrightness(forced: Boolean = true) {
+        if (forced || brightness != WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE) {
+            savedBrightness = brightness
         }
-
         brightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
     }
 
@@ -47,6 +46,9 @@ class BrightnessHelper(activity: Activity) {
      * Set current screen brightness to saved brightness value.
      */
     fun restoreSavedBrightness() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity.isInPictureInPictureMode) {
+            return
+        }
         brightness = savedBrightness
     }
 

--- a/app/src/main/java/com/github/libretube/util/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/PreferenceHelper.kt
@@ -41,6 +41,10 @@ object PreferenceHelper {
         editor.putInt(key, value).commit()
     }
 
+    fun putFloat(key: String, value: Float) {
+        editor.putFloat(key, value).commit()
+    }
+
     fun getString(key: String?, defValue: String): String {
         return settings.getString(key, defValue) ?: defValue
     }
@@ -51,6 +55,10 @@ object PreferenceHelper {
 
     fun getInt(key: String?, defValue: Int): Int {
         return settings.getInt(key, defValue)
+    }
+
+    fun getFloat(key: String?, defValue: Float): Float {
+        return settings.getFloat(key, defValue)
     }
 
     fun clearPreferences() {


### PR DESCRIPTION
Brightness changes affect only when the player is in full-screen (landscape) mode. when orientation is changed to portrait, save brightness to shared preferences. It can be restored for later use.

Closes #2046 