### PR TITLE
Fix link opening issues

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/extensions/SetFormattedHtml.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetFormattedHtml.kt
@@ -1,0 +1,10 @@
+package com.github.libretube.ui.extensions
+
+import android.text.util.Linkify
+import android.widget.TextView
+import androidx.core.text.HtmlCompat
+
+fun TextView.setFormattedHtml(text: String) {
+    Linkify.addLinks(this, Linkify.WEB_URLS)
+    this.text = HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_LEGACY)
+}

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -15,7 +15,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
-import android.text.Html
 import android.text.format.DateUtils
 import android.util.Base64
 import android.util.Log
@@ -73,6 +72,7 @@ import com.github.libretube.ui.base.BaseFragment
 import com.github.libretube.ui.dialogs.AddToPlaylistDialog
 import com.github.libretube.ui.dialogs.DownloadDialog
 import com.github.libretube.ui.dialogs.ShareDialog
+import com.github.libretube.ui.extensions.setFormattedHtml
 import com.github.libretube.ui.extensions.setInvisible
 import com.github.libretube.ui.extensions.setupSubscriptionButton
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
@@ -940,19 +940,13 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         initializeRelatedVideos(response.relatedStreams)
         // set video description
         val description = response.description!!
-        binding.playerDescription.text =
-            // detect whether the description is html formatted
-            if (description.contains("<") && description.contains(">")) {
-                if (SDK_INT >= Build.VERSION_CODES.N) {
-                    Html.fromHtml(description, Html.FROM_HTML_MODE_COMPACT)
-                        .trim()
-                } else {
-                    @Suppress("DEPRECATION")
-                    Html.fromHtml(description).trim()
-                }
-            } else {
-                description
-            }
+
+        // detect whether the description is html formatted
+        if (description.contains("<") && description.contains(">")) {
+            binding.playerDescription.setFormattedHtml(description)
+        } else {
+            binding.playerDescription.text = description
+        }
 
         binding.playerChannel.setOnClickListener {
             val activity = view?.context as MainActivity

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -53,7 +53,7 @@ class PlaylistFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         arguments?.let {
             playlistId = it.getString(IntentData.playlistId)
-            playlistType = it.serializable(IntentData.playlistType)!!
+            playlistType = it.serializable(IntentData.playlistType) ?: PlaylistType.PUBLIC
         }
     }
 

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -125,7 +125,6 @@
                     android:id="@+id/player_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:autoLink="web"
                     android:padding="8dp"
                     android:textIsSelectable="true"
                     android:textSize="14sp" />


### PR DESCRIPTION
Fix opening playlist causing `NPE`.
Fix links are not actual hyperlinks. Which causes issues when opening ellipsed links.

There is still one issue, when clicking link it goes into PiP mode. What I have understood is,
When we click on link it trigers `MainActivity#onUserLeaveHint()` which then calls `PlayerFragment#onUserLeaveHint` which leads activity to go into PiP mode.
This problem won't occur when the player is paused because `PlayerFragment#shouldStartPiP()` check for it.

Possible solution could be,
- Pause player when the link is clicked. (Tried setting click listner but seems like Intent is send before the given event)
- Make PiP to fullscreen when the new Intent is received. (I don't think there is any straightforward way to do this)

Closes #1975 