### PR TITLE
Fix activity goes in PiP mode on link opening

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -340,6 +340,15 @@ class MainActivity : BaseActivity() {
     }
 
     private fun loadIntentData() {
+        // If activity is running in PiP mode, then start it in front.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            isInPictureInPictureMode
+        ) {
+            moveTaskToBack(true)
+            intent?.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            startActivity(intent)
+        }
+
         intent?.getStringExtra(IntentData.channelId)?.let {
             navController.navigate(
                 R.id.channelFragment,

--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -25,6 +25,7 @@ import com.github.libretube.ui.base.BaseFragment
 import com.github.libretube.ui.extensions.withMaxSize
 import com.github.libretube.util.LocaleHelper
 import com.github.libretube.util.PreferenceHelper
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -141,6 +142,9 @@ class HomeFragment : BaseFragment() {
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 action.invoke()
+                // Can be caused due to activity launch in front view from PiP mode.
+            } catch (e: CancellationException) {
+                Log.e("fetching home tab", e.toString())
             } catch (e: Exception) {
                 e.localizedMessage?.let { context?.toastFromMainThread(it) }
                 Log.e("fetching home tab", e.toString())


### PR DESCRIPTION
If the activity is running in PiP, then start the activity in front.
When the video is in `play` state sometimes it causes `kotlinx.coroutines.JobCancellationException` in `HomeFragment` but I think it's expected behavior since Job is closed forcefully.
Anyways, it's not affecting any behavior (other than making Toast which is handled now) so we can ignore it.