### PR TITLE
Fix plain text links and NPE when opening link from external source

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -16,6 +16,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.text.format.DateUtils
+import android.text.util.Linkify
 import android.util.Base64
 import android.util.Log
 import android.view.LayoutInflater
@@ -945,6 +946,8 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         if (description.contains("<") && description.contains(">")) {
             binding.playerDescription.setFormattedHtml(description)
         } else {
+            // Links can be present as plain text
+            binding.playerDescription.autoLinkMask = Linkify.WEB_URLS
             binding.playerDescription.text = description
         }
 

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -442,7 +442,7 @@ internal class CustomExoPlayerView(
             it.layoutParams = params
         }
 
-        if (PlayerHelper.swipeGestureEnabled) {
+        if (PlayerHelper.swipeGestureEnabled && this::brightnessHelper.isInitialized) {
             when (newConfig?.orientation) {
                 Configuration.ORIENTATION_LANDSCAPE -> brightnessHelper.restoreSavedBrightness()
                 else -> brightnessHelper.resetToSystemBrightness(false)


### PR DESCRIPTION
Some links are in plain text so that need to be considered.

When opening link from an external source (e.g. browser) `brightnessHelper` is not initialized which causes NPE