### PR TITLE
Fix uploaded date accuracy

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
@@ -128,7 +128,7 @@ class VideosAdapter(
             videoInfo.text =
                 video.views.formatShort() + " " +
                 root.context.getString(R.string.views_placeholder) +
-                TextUtils.SEPARATOR + video.uploaded?.let { DateUtils.getRelativeTimeSpanString(it) }
+                TextUtils.SEPARATOR + video.uploadedDate
 
             thumbnailDuration.text =
                 video.duration?.let { DateUtils.formatElapsedTime(it) }


### PR DESCRIPTION
`video.uploaded` gives same value for some upload time range, I guess using `video.uploadedDate` which provides a response like `3 months ago` is better as discussed in issue. I didn't find any reason for using that `video.uploaded` and then parsing it,

Closes #1818