### PR TITLE
Fix to adopt dynamic aspect ration in PiP mode

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/extensions/SetAspectRatio.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetAspectRatio.kt
@@ -1,0 +1,22 @@
+package com.github.libretube.ui.extensions
+
+import android.app.PictureInPictureParams
+import android.os.Build
+import android.util.Rational
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun PictureInPictureParams.Builder.setAspectRatio(
+    width: Int,
+    height: Int
+): PictureInPictureParams.Builder {
+    val ratio = (width.toFloat() / height).let {
+        when {
+            it.isNaN() -> Rational(4, 3)
+            it <= 0.418410 -> Rational(41841, 100000)
+            it >= 2.390000 -> Rational(239, 100)
+            else -> Rational(width, height)
+        }
+    }
+    return setAspectRatio(ratio)
+}

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -71,6 +71,7 @@ import com.github.libretube.ui.base.BaseFragment
 import com.github.libretube.ui.dialogs.AddToPlaylistDialog
 import com.github.libretube.ui.dialogs.DownloadDialog
 import com.github.libretube.ui.dialogs.ShareDialog
+import com.github.libretube.ui.extensions.setAspectRatio
 import com.github.libretube.ui.extensions.setFormattedHtml
 import com.github.libretube.ui.extensions.setInvisible
 import com.github.libretube.ui.extensions.setupSubscriptionButton
@@ -1361,6 +1362,7 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                 setAutoEnterEnabled(true)
             }
         }
+        .setAspectRatio(exoPlayer.videoSize.width, exoPlayer.videoSize.height)
         .build()
 
     private fun shouldStartPiP(): Boolean {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -278,7 +278,7 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             binding.playerMotionLayout.transitionToStart()
         }
 
-        if (usePiP()) (activity as MainActivity).setPictureInPictureParams(getPipParams())
+        if (usePiP()) activity?.setPictureInPictureParams(getPipParams())
 
         if (SDK_INT < Build.VERSION_CODES.O) {
             binding.relPlayerPip.visibility = View.GONE
@@ -824,6 +824,8 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                         // media actually playing
                         transitioning = false
                         binding.playImageView.setImageResource(R.drawable.ic_pause)
+                        // update the PiP params to use the correct aspect ratio
+                        if (usePiP()) activity?.setPictureInPictureParams(getPipParams())
                     }
                     Player.STATE_ENDED -> {
                         // video has finished
@@ -1361,8 +1363,10 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             if (SDK_INT >= Build.VERSION_CODES.S) {
                 setAutoEnterEnabled(true)
             }
+            if (exoPlayer.isPlaying) {
+                setAspectRatio(exoPlayer.videoSize.width, exoPlayer.videoSize.height)
+            }
         }
-        .setAspectRatio(exoPlayer.videoSize.width, exoPlayer.videoSize.height)
         .build()
 
     private fun shouldStartPiP(): Boolean {


### PR DESCRIPTION
We can pass aspect ration for pip mode.
However, it will not change ration while already in pip mode.
e.g. When playing short -> go to PiP mode -> next video with different ration -> pip size will be same as during short video.
Closes #2092, closes #1644