### PR TITLE
Fix watch history deletion

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/WatchHistoryAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/WatchHistoryAdapter.kt
@@ -21,8 +21,9 @@ class WatchHistoryAdapter(
     RecyclerView.Adapter<WatchHistoryViewHolder>() {
 
     fun removeFromWatchHistory(position: Int) {
+        val history = watchHistory[position]
         query {
-            DatabaseHolder.Database.watchHistoryDao().delete(watchHistory[position])
+            DatabaseHolder.Database.watchHistoryDao().delete(history)
         }
         watchHistory.removeAt(position)
         notifyItemRemoved(position)

--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -89,7 +89,7 @@ class WatchHistoryFragment : BaseFragment() {
         // observe changes
         watchHistoryAdapter.registerAdapterDataObserver(object :
                 RecyclerView.AdapterDataObserver() {
-                override fun onChanged() {
+                override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
                     if (watchHistoryAdapter.itemCount == 0) {
                         binding.watchHistoryRecView.visibility = View.GONE
                         binding.historyEmpty.visibility = View.VISIBLE


### PR DESCRIPTION
Fix threading issue, video was removed before the database query can use it for deletion which lead to remove wrong video.

Fix empty history view was not showing after removing all videos.

Closes #2127 