### PR TITLE
Fix notification freezing issue

### DIFF
--- a/app/src/main/java/com/github/libretube/services/BackgroundMode.kt
+++ b/app/src/main/java/com/github/libretube/services/BackgroundMode.kt
@@ -354,6 +354,14 @@ class BackgroundMode : Service() {
     }
 
     /**
+     * Stop the service when app is removed from the task manager.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        onDestroy()
+    }
+
+    /**
      * destroy the [BackgroundMode] foreground service
      */
     override fun onDestroy() {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -194,9 +194,6 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         super.onViewCreated(view, savedInstanceState)
         context?.hideKeyboard(view)
 
-        // Stop [BackgroundMode] service if it is running.
-        BackgroundHelper.stopBackgroundPlay(requireContext())
-
         // clear the playing queue
         PlayingQueue.resetToDefaults()
 
@@ -317,8 +314,6 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         }
 
         binding.playImageView.setOnClickListener {
-            // Stop [BackgroundMode] service if it is running.
-            BackgroundHelper.stopBackgroundPlay(requireContext())
             if (!exoPlayer.isPlaying) {
                 // start or go on playing
                 binding.playImageView.setImageResource(R.drawable.ic_pause)
@@ -819,6 +814,11 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         // Listener for play and pause icon change
         exoPlayer.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
+                if (isPlaying) {
+                    // Stop [BackgroundMode] service if it is running.
+                    BackgroundHelper.stopBackgroundPlay(requireContext())
+                }
+
                 if (isPlaying && PlayerHelper.sponsorBlockEnabled) {
                     Handler(Looper.getMainLooper()).postDelayed(
                         this@PlayerFragment::checkForSegments,

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1,7 +1,6 @@
 package com.github.libretube.ui.fragments
 
 import android.annotation.SuppressLint
-import android.app.ActivityManager
 import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.pm.ActivityInfo
@@ -195,6 +194,9 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         super.onViewCreated(view, savedInstanceState)
         context?.hideKeyboard(view)
 
+        // Stop [BackgroundMode] service if it is running.
+        BackgroundHelper.stopBackgroundPlay(requireContext())
+
         // clear the playing queue
         PlayingQueue.resetToDefaults()
 
@@ -315,6 +317,8 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         }
 
         binding.playImageView.setOnClickListener {
+            // Stop [BackgroundMode] service if it is running.
+            BackgroundHelper.stopBackgroundPlay(requireContext())
             if (!exoPlayer.isPlaying) {
                 // start or go on playing
                 binding.playImageView.setImageResource(R.drawable.ic_pause)
@@ -1398,20 +1402,9 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             return false
         }
 
-        val backgroundModeRunning = isServiceRunning(requireContext(), BackgroundMode::class.java)
+        val backgroundModeRunning = BackgroundHelper.isServiceRunning(requireContext(), BackgroundMode::class.java)
 
         return exoPlayer.isPlaying && !backgroundModeRunning
-    }
-
-    private fun isServiceRunning(context: Context, serviceClass: Class<*>): Boolean {
-        val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        @Suppress("DEPRECATION")
-        for (service in manager.getRunningServices(Int.MAX_VALUE)) {
-            if (serviceClass.name == service.service.className) {
-                return true
-            }
-        }
-        return false
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -303,6 +303,7 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             mainActivity.supportFragmentManager.beginTransaction()
                 .remove(this)
                 .commit()
+            BackgroundHelper.stopBackgroundPlay(requireContext())
         }
         playerBinding.closeImageButton.setOnClickListener {
             viewModel.isFullscreen.value = false
@@ -311,6 +312,7 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             mainActivity.supportFragmentManager.beginTransaction()
                 .remove(this)
                 .commit()
+            BackgroundHelper.stopBackgroundPlay(requireContext())
         }
 
         binding.playImageView.setOnClickListener {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1411,6 +1411,10 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         super.onConfigurationChanged(newConfig)
 
         if (!PlayerHelper.autoRotationEnabled) return
+
+        // If in PiP mode, orientation is given as landscape.
+        if (SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) return
+
         when (newConfig.orientation) {
             // go to fullscreen mode
             Configuration.ORIENTATION_LANDSCAPE -> setFullscreen()

--- a/app/src/main/java/com/github/libretube/util/BackgroundHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/BackgroundHelper.kt
@@ -1,5 +1,6 @@
 package com.github.libretube.util
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -10,6 +11,11 @@ import com.github.libretube.services.BackgroundMode
  * Helper for starting a new Instance of the [BackgroundMode]
  */
 object BackgroundHelper {
+
+    /**
+     * Start the foreground service [BackgroundMode] to play in background. [position]
+     * is seek to position specified in milliseconds in the current [videoId].
+     */
     fun playOnBackground(
         context: Context,
         videoId: String,
@@ -28,5 +34,30 @@ object BackgroundHelper {
         } else {
             context.startService(intent)
         }
+    }
+
+    /**
+     * Stop the [BackgroundMode] service if it is running.
+     */
+    fun stopBackgroundPlay(context: Context) {
+        if (!isServiceRunning(context, BackgroundMode::class.java)) return
+
+        // Intent to stop background mode service
+        val intent = Intent(context, BackgroundMode::class.java)
+        context.stopService(intent)
+    }
+
+    /**
+     * Check if the given service as [serviceClass] is currently running.
+     */
+    fun isServiceRunning(context: Context, serviceClass: Class<*>): Boolean {
+        val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        @Suppress("DEPRECATION")
+        for (service in manager.getRunningServices(Int.MAX_VALUE)) {
+            if (serviceClass.name == service.service.className) {
+                return true
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
The foreground service was still running when using the audio mode and then switching back to video (by pressing play button, play another video, or close app). 
So check when the video `isPlaying` and If `BackgroundMode` service is running first stop it and start video play.

However, i am not able to check what happens when OS kills this foreground service. But, since the notification is cleared in `onDestroy` of `BackgroundMode` service it should work fine. Please give it try.

One more little fix, when `activity` is in PiP then it gives orientation as landscape always, which leads to `setFullscreen` and `BrightnessHelper` thinks it's full-screen :)

(Hope) Closes #1601, closes #1722