### PR TITLE
Fix minimized player and repeat button

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -315,6 +315,12 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             BackgroundHelper.stopBackgroundPlay(requireContext())
         }
 
+        playerBinding.repeatBTN.setOnClickListener {
+            // Restart video if finished
+            exoPlayer.seekTo(0)
+            exoPlayer.play()
+        }
+
         binding.playImageView.setOnClickListener {
             if (!exoPlayer.isPlaying) {
                 // start or go on playing
@@ -819,14 +825,6 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                 if (isPlaying) {
                     // Stop [BackgroundMode] service if it is running.
                     BackgroundHelper.stopBackgroundPlay(requireContext())
-                    // video is playing
-                    binding.playImageView.setImageResource(R.drawable.ic_pause)
-                } else if (exoPlayer.playbackState == Player.STATE_ENDED) {
-                    // video has finished
-                    binding.playImageView.setImageResource(R.drawable.ic_restart)
-                } else {
-                    // player in any other state
-                    binding.playImageView.setImageResource(R.drawable.ic_play)
                 }
 
                 if (isPlaying && PlayerHelper.sponsorBlockEnabled) {
@@ -834,6 +832,18 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                         this@PlayerFragment::checkForSegments,
                         100
                     )
+                }
+            }
+
+            override fun onEvents(player: Player, events: Player.Events) {
+                super.onEvents(player, events)
+                if (events.containsAny(
+                        Player.EVENT_PLAYBACK_STATE_CHANGED,
+                        Player.EVENT_IS_PLAYING_CHANGED,
+                        Player.EVENT_PLAY_WHEN_READY_CHANGED
+                    )
+                ) {
+                    updatePlayPauseButton()
                 }
             }
 
@@ -960,6 +970,25 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
 
         playerBinding.skipNext.setOnClickListener {
             playNextVideo()
+        }
+    }
+
+    private fun updatePlayPauseButton() {
+        if (exoPlayer.isPlaying) {
+            // video is playing
+            binding.playImageView.setImageResource(R.drawable.ic_pause)
+            playerBinding.exoPlayPause.visibility = View.VISIBLE
+            playerBinding.repeatBTN.visibility = View.GONE
+        } else if (exoPlayer.playbackState == Player.STATE_ENDED) {
+            // video has finished
+            binding.playImageView.setImageResource(R.drawable.ic_restart)
+            playerBinding.exoPlayPause.visibility = View.GONE
+            playerBinding.repeatBTN.visibility = View.VISIBLE
+        } else {
+            // player in any other state
+            binding.playImageView.setImageResource(R.drawable.ic_play)
+            playerBinding.exoPlayPause.visibility = View.VISIBLE
+            playerBinding.repeatBTN.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -819,6 +819,14 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                 if (isPlaying) {
                     // Stop [BackgroundMode] service if it is running.
                     BackgroundHelper.stopBackgroundPlay(requireContext())
+                    // video is playing
+                    binding.playImageView.setImageResource(R.drawable.ic_pause)
+                } else if (exoPlayer.playbackState == Player.STATE_ENDED) {
+                    // video has finished
+                    binding.playImageView.setImageResource(R.drawable.ic_restart)
+                } else {
+                    // player in any other state
+                    binding.playImageView.setImageResource(R.drawable.ic_play)
                 }
 
                 if (isPlaying && PlayerHelper.sponsorBlockEnabled) {
@@ -847,22 +855,11 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                     playNextVideo()
                 }
 
-                when (playbackState) {
-                    Player.STATE_READY -> {
-                        // media actually playing
-                        transitioning = false
-                        binding.playImageView.setImageResource(R.drawable.ic_pause)
-                        // update the PiP params to use the correct aspect ratio
-                        if (usePiP()) activity?.setPictureInPictureParams(getPipParams())
-                    }
-                    Player.STATE_ENDED -> {
-                        // video has finished
-                        binding.playImageView.setImageResource(R.drawable.ic_restart)
-                    }
-                    else -> {
-                        // player in any other state
-                        binding.playImageView.setImageResource(R.drawable.ic_play)
-                    }
+                if (playbackState == Player.STATE_READY) {
+                    // media actually playing
+                    transitioning = false
+                    // update the PiP params to use the correct aspect ratio
+                    if (usePiP()) activity?.setPictureInPictureParams(getPipParams())
                 }
 
                 // save the watch position when paused

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -315,16 +315,9 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             BackgroundHelper.stopBackgroundPlay(requireContext())
         }
 
-        playerBinding.repeatBTN.setOnClickListener {
-            // Restart video if finished
-            exoPlayer.seekTo(0)
-            exoPlayer.play()
-        }
-
-        binding.playImageView.setOnClickListener {
+        val playPauseClickListner = View.OnClickListener {
             if (!exoPlayer.isPlaying) {
                 // start or go on playing
-                binding.playImageView.setImageResource(R.drawable.ic_pause)
                 if (exoPlayer.playbackState == Player.STATE_ENDED) {
                     // restart video if finished
                     exoPlayer.seekTo(0)
@@ -332,10 +325,11 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
                 exoPlayer.play()
             } else {
                 // pause the video
-                binding.playImageView.setImageResource(R.drawable.ic_play)
                 exoPlayer.pause()
             }
         }
+        playerBinding.playPauseBTN.setOnClickListener(playPauseClickListner)
+        binding.playImageView.setOnClickListener(playPauseClickListner)
 
         // video description and chapters toggle
         binding.playerTitleLayout.setOnClickListener {
@@ -977,18 +971,15 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
         if (exoPlayer.isPlaying) {
             // video is playing
             binding.playImageView.setImageResource(R.drawable.ic_pause)
-            playerBinding.exoPlayPause.visibility = View.VISIBLE
-            playerBinding.repeatBTN.visibility = View.GONE
+            playerBinding.playPauseBTN.setImageResource(R.drawable.ic_pause)
         } else if (exoPlayer.playbackState == Player.STATE_ENDED) {
             // video has finished
             binding.playImageView.setImageResource(R.drawable.ic_restart)
-            playerBinding.exoPlayPause.visibility = View.GONE
-            playerBinding.repeatBTN.visibility = View.VISIBLE
+            playerBinding.playPauseBTN.setImageResource(R.drawable.ic_restart)
         } else {
             // player in any other state
             binding.playImageView.setImageResource(R.drawable.ic_play)
-            playerBinding.exoPlayPause.visibility = View.VISIBLE
-            playerBinding.repeatBTN.visibility = View.GONE
+            playerBinding.playPauseBTN.setImageResource(R.drawable.ic_play)
         }
     }
 

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -272,7 +272,7 @@ internal class CustomExoPlayerView(
         binding.exoBottomBar.visibility = visibility
         binding.closeImageButton.visibility = visibility
         binding.exoTitle.visibility = visibility
-        binding.exoPlayPause.visibility = visibility
+        binding.playPauseBTN.visibility = visibility
 
         // disable tap and swipe gesture if the player is locked
         playerGestureController.isEnabled = isLocked

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -283,6 +283,14 @@
             android:background="?android:selectableItemBackgroundBorderless"
             app:tint="@android:color/white" />
 
+        <ImageButton
+            android:id="@+id/repeatBTN"
+            style="@style/ExoStyledControls.Button.Center.PlayPause"
+            android:layout_marginHorizontal="10dp"
+            android:background="?android:selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_restart"
+            app:tint="@android:color/white" />
+
         <FrameLayout
             android:id="@+id/forwardBTN"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -277,18 +277,10 @@
         </FrameLayout>
 
         <ImageButton
-            android:id="@id/exo_play_pause"
+            android:id="@+id/playPauseBTN"
             style="@style/ExoStyledControls.Button.Center.PlayPause"
             android:layout_marginHorizontal="10dp"
             android:background="?android:selectableItemBackgroundBorderless"
-            app:tint="@android:color/white" />
-
-        <ImageButton
-            android:id="@+id/repeatBTN"
-            style="@style/ExoStyledControls.Button.Center.PlayPause"
-            android:layout_marginHorizontal="10dp"
-            android:background="?android:selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_restart"
             app:tint="@android:color/white" />
 
         <FrameLayout

--- a/app/src/main/res/values/drawables.xml
+++ b/app/src/main/res/values/drawables.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!-- Replaces the drawables of the default exoplayer controls (see https://github.com/google/ExoPlayer/blob/release-v2/library/ui/src/main/res/values/drawables.xml) -->
 <resources>
 
-    <drawable name="exo_styled_controls_play">@drawable/ic_play</drawable>
-    <drawable name="exo_styled_controls_pause">@drawable/ic_pause</drawable>
     <drawable name="exo_notification_small_icon">@drawable/ic_launcher_lockscreen</drawable>
 
 </resources>


### PR DESCRIPTION
Synchronize mini-player buttons with playback state.

Use new image button for player repeat, because changing image resources of `exo_play_pause` will not work since It is frequently updated by [StyledPlayerControlView](https://github.com/google/ExoPlayer/blob/release-v2/library/ui/src/main/java/com/google/android/exoplayer2/ui/StyledPlayerControlView.java#L959).

Closes #2073 