### PR TITLE
Show/Hide exact view count with description toggle

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -463,10 +463,20 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
             // hide the description and chapters
             binding.playerDescriptionArrow.animate().rotation(0F).setDuration(250).start()
             binding.descLinLayout.visibility = View.GONE
+
+            // show formated short view count
+            val viewInfo = context?.getString(R.string.views, streams.views.formatShort()) +
+                if (!isLive) TextUtils.SEPARATOR + streams.uploadDate else ""
+            binding.playerViewsInfo.text = viewInfo
         } else {
             // show the description and chapters
             binding.playerDescriptionArrow.animate().rotation(180F).setDuration(250).start()
             binding.descLinLayout.visibility = View.VISIBLE
+
+            // show exact view count
+            val viewInfo = context?.getString(R.string.views, String.format("%,d", streams.views)) +
+                if (!isLive) TextUtils.SEPARATOR + streams.uploadDate else ""
+            binding.playerViewsInfo.text = viewInfo
         }
         if (this::chapters.isInitialized && chapters.isNotEmpty()) {
             val chapterIndex = getCurrentChapterIndex()

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -459,25 +459,24 @@ class PlayerFragment : BaseFragment(), OnlinePlayerOptions {
     }
 
     private fun toggleDescription() {
+        var viewInfo = if (!isLive) TextUtils.SEPARATOR + streams.uploadDate else ""
         if (binding.descLinLayout.isVisible) {
             // hide the description and chapters
             binding.playerDescriptionArrow.animate().rotation(0F).setDuration(250).start()
             binding.descLinLayout.visibility = View.GONE
 
             // show formated short view count
-            val viewInfo = context?.getString(R.string.views, streams.views.formatShort()) +
-                if (!isLive) TextUtils.SEPARATOR + streams.uploadDate else ""
-            binding.playerViewsInfo.text = viewInfo
+            viewInfo = getString(R.string.views, streams.views.formatShort()) + viewInfo
         } else {
             // show the description and chapters
             binding.playerDescriptionArrow.animate().rotation(180F).setDuration(250).start()
             binding.descLinLayout.visibility = View.VISIBLE
 
             // show exact view count
-            val viewInfo = context?.getString(R.string.views, String.format("%,d", streams.views)) +
-                if (!isLive) TextUtils.SEPARATOR + streams.uploadDate else ""
-            binding.playerViewsInfo.text = viewInfo
+            viewInfo = getString(R.string.views, String.format("%,d", streams.views)) + viewInfo
         }
+        binding.playerViewsInfo.text = viewInfo
+
         if (this::chapters.isInitialized && chapters.isNotEmpty()) {
             val chapterIndex = getCurrentChapterIndex()
             // scroll to the current chapter in the chapterRecView in the description


### PR DESCRIPTION
Show the exact view count when the description is open. Otherwise, show formated short count.

Closes #2138 