### PR TITLE
Change Language Strings

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -74,7 +74,7 @@
         <item>Euskara</item>
         <item>বাংলা</item>
         <item>Català</item>
-        <item>汉语</item>
+        <item>简体中文</item>
         <item>古文</item>
         <item>Czech</item>
         <item>Dansk</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -76,7 +76,7 @@
         <item>Català</item>
         <item>简体中文</item>
         <item>繁體中文</item>
-        <item>Czech</item>
+        <item>čeština</item>
         <item>Dansk</item>
         <item>English</item>
         <item>Wikang Filipino</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -88,7 +88,7 @@
         <item>עברית</item>
         <item>हिन्दी</item>
         <item>Magyar</item>
-        <item>Indonesian</item>
+        <item>Bahasa Indonesia</item>
         <item>Italiano</item>
         <item>日本語</item>
         <item>조선말</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -75,7 +75,7 @@
         <item>বাংলা</item>
         <item>Català</item>
         <item>简体中文</item>
-        <item>古文</item>
+        <item>繁體中文</item>
         <item>Czech</item>
         <item>Dansk</item>
         <item>English</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -104,7 +104,7 @@
         <item>Română</item>
         <item>Русский</item>
         <item>Slovenčina</item>
-        <item>Sorani</item>
+        <item>سۆرانی</item>
         <item>Español</item>
         <item>ภาษาไทย</item>
         <item>Türkçe</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -70,7 +70,7 @@
     <string-array name="languages">
         <item>@string/systemLanguage</item>
         <item>العربية</item>
-        <item>آذربایجان دیلی</item>
+        <item>Azərbaycan dili</item>
         <item>Euskara</item>
         <item>বাংলা</item>
         <item>Català</item>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -69,47 +69,47 @@
 
     <string-array name="languages">
         <item>@string/systemLanguage</item>
-        <item>Arabic</item>
-        <item>Azerbaijani</item>
-        <item>Basque</item>
-        <item>Bengali</item>
-        <item>Catalan</item>
-        <item>Chinese (simplified)</item>
-        <item>Chinese (traditional)</item>
+        <item>العربية</item>
+        <item>آذربایجان دیلی</item>
+        <item>Euskara</item>
+        <item>বাংলা</item>
+        <item>Català</item>
+        <item>汉语</item>
+        <item>古文</item>
         <item>Czech</item>
-        <item>Danish</item>
+        <item>Dansk</item>
         <item>English</item>
-        <item>Filipino</item>
-        <item>Finnish</item>
-        <item>French</item>
-        <item>German</item>
-        <item>Greek</item>
-        <item>Gujarati</item>
-        <item>Hebrew</item>
-        <item>Hindi</item>
-        <item>Hungarian</item>
+        <item>Wikang Filipino</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>ગુજરાતી</item>
+        <item>עברית</item>
+        <item>हिन्दी</item>
+        <item>Magyar</item>
         <item>Indonesian</item>
-        <item>Italian</item>
-        <item>Japanese</item>
-        <item>Korean</item>
-        <item>Latvian</item>
-        <item>Malayalam</item>
-        <item>Marathi</item>
-        <item>Norwegian</item>
-        <item>Persian</item>
-        <item>Odia</item>
-        <item>Polish</item>
-        <item>Portuguese</item>
-        <item>Portuguese (Brazil)</item>
-        <item>Romanian</item>
-        <item>Russian</item>
-        <item>Slovak</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>조선말</item>
+        <item>latviešu</item>
+        <item>മലയാളം</item>
+        <item>मराठी</item>
+        <item>Norsk</item>
+        <item>فارسی</item>
+        <item>ଓଡ଼ିଆ</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Português (BR)</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Slovenčina</item>
         <item>Sorani</item>
-        <item>Spanish</item>
-        <item>Thai</item>
-        <item>Turkish</item>
-        <item>Turkmen</item>
-        <item>Ukrainian</item>
+        <item>Español</item>
+        <item>ภาษาไทย</item>
+        <item>Türkçe</item>
+        <item>Türkmençe</item>
+        <item>Українська</item>
     </string-array>
 
     <string-array name="languagesValue">


### PR DESCRIPTION
This PR changes the list of languages to use their spelling instead of having them all in English.

This list was used:

https://en.wikipedia.org/wiki/List_of_language_names

Someone should double-check it to make sure there are no mistakes.