### PR TITLE
Ignore touches to the top of the player

### DIFF
--- a/app/src/main/java/com/github/libretube/util/PlayerGestureController.kt
+++ b/app/src/main/java/com/github/libretube/util/PlayerGestureController.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.util
 
 import android.annotation.SuppressLint
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.os.Handler
 import android.os.Looper
@@ -22,6 +23,7 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
     // size changes.
     private val width get() = Resources.getSystem().displayMetrics.widthPixels
     private val height get() = Resources.getSystem().displayMetrics.heightPixels
+    private val orientation get() = Resources.getSystem().configuration.orientation
     private val elapsedTime get() = SystemClock.elapsedRealtime()
 
     private val playerViewModel: PlayerViewModel by activity.viewModels()
@@ -55,8 +57,8 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
             listener.onSwipeEnd()
         }
 
-        // ignore touches to the top of the player
-        if (event.y < height * 0.1) return false
+        // ignore touches to the top of the player when in landscape mode
+        if (event.y < height * 0.1 && orientation == Configuration.ORIENTATION_LANDSCAPE) return false
 
         // Event can be already consumed by some view which may lead to NPE.
         try {

--- a/app/src/main/java/com/github/libretube/util/PlayerGestureController.kt
+++ b/app/src/main/java/com/github/libretube/util/PlayerGestureController.kt
@@ -55,6 +55,9 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
             listener.onSwipeEnd()
         }
 
+        // ignore touches to the top of the player
+        if (event.y < height * 0.1) return false
+
         // Event can be already consumed by some view which may lead to NPE.
         try {
             scaleGestureDetector.onTouchEvent(event)


### PR DESCRIPTION
Allows pulling down the status bar when watching a video in landscape mode