### PR TITLE
Simplify LocaleHelper methods.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
@@ -73,7 +73,7 @@ class PlayerSettings : BasePreferenceFragment() {
     }
 
     private fun setupSubtitlePref(preference: ListPreference) {
-        val locales = LocaleHelper.getAvailableLocales().sortedBy { it.name }
+        val locales = LocaleHelper.getAvailableLocales()
         val localeNames = locales.map { it.name }
             .toMutableList()
         localeNames.add(0, requireContext().getString(R.string.none))

--- a/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
@@ -17,7 +17,7 @@ object LocaleHelper {
         val languageName = PreferenceHelper.getString(PreferenceKeys.LANGUAGE, "sys")
         val locale = when {
             languageName == "sys" -> Locale.getDefault()
-            languageName.contains("-") == true -> {
+            languageName.contains("-") -> {
                 val languageParts = languageName.split("-")
                 Locale(
                     languageParts[0],
@@ -41,9 +41,9 @@ object LocaleHelper {
     private fun updateResourcesLegacy(context: Context, locale: Locale) {
         Locale.setDefault(locale)
         val resources: Resources = context.resources
-        val configuration: Configuration = resources.getConfiguration()
+        val configuration = resources.configuration
         configuration.locale = locale
-        resources.updateConfiguration(configuration, resources.getDisplayMetrics())
+        resources.updateConfiguration(configuration, resources.displayMetrics)
     }
 
     private fun getDetectedCountry(context: Context): String {

--- a/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
@@ -67,37 +67,16 @@ object LocaleHelper {
     }
 
     fun getAvailableCountries(): List<Country> {
-        val isoCountries = Locale.getISOCountries()
-        val countries = mutableListOf<Country>()
-        isoCountries.forEach { countryCode ->
-            val locale = Locale("", countryCode)
-            val countryName = locale.displayCountry
-            countries.add(
-                Country(
-                    countryName,
-                    countryCode
-                )
-            )
-        }
-        countries.sortBy { it.name }
-        return countries
+        return Locale.getISOCountries()
+            .map { Country(Locale("", it).displayCountry, it) }
+            .sortedBy { it.name }
     }
 
     fun getAvailableLocales(): List<Country> {
-        val availableLocales: Array<Locale> = Locale.getAvailableLocales()
-        val locales = mutableListOf<Country>()
-
-        availableLocales.forEach { locale ->
-            if (locales.filter { it.code == locale.language }.isEmpty()) {
-                locales.add(
-                    Country(
-                        locale.displayLanguage,
-                        locale.language
-                    )
-                )
-            }
-        }
-        return locales
+        return Locale.getAvailableLocales()
+            .distinctBy { it.language }
+            .map { Country(it.displayLanguage, it.language) }
+            .sortedBy { it.name }
     }
 
     fun getTrendingRegion(context: Context): String {

--- a/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
+++ b/app/src/main/java/com/github/libretube/util/LocaleHelper.kt
@@ -2,7 +2,6 @@ package com.github.libretube.util
 
 import android.content.Context
 import android.content.res.Configuration
-import android.content.res.Resources
 import android.os.Build
 import android.telephony.TelephonyManager
 import androidx.core.content.getSystemService
@@ -40,30 +39,30 @@ object LocaleHelper {
     @Suppress("DEPRECATION")
     private fun updateResourcesLegacy(context: Context, locale: Locale) {
         Locale.setDefault(locale)
-        val resources: Resources = context.resources
+        val resources = context.resources
         val configuration = resources.configuration
         configuration.locale = locale
         resources.updateConfiguration(configuration, resources.displayMetrics)
     }
 
     private fun getDetectedCountry(context: Context): String {
-        return detectSIMCountry(context).ifEmpty {
-            detectNetworkCountry(context).ifEmpty {
-                detectLocaleCountry(context).ifEmpty { "UK" }
-            }
-        }
+        return detectSIMCountry(context)
+            ?: detectNetworkCountry(context)
+            ?: detectLocaleCountry(context)
+            ?: "UK"
     }
 
-    private fun detectSIMCountry(context: Context): String {
-        return context.getSystemService<TelephonyManager>()?.simCountryIso.orEmpty()
+    private fun detectSIMCountry(context: Context): String? {
+        return context.getSystemService<TelephonyManager>()?.simCountryIso?.ifEmpty { null }
     }
 
-    private fun detectNetworkCountry(context: Context): String {
-        return context.getSystemService<TelephonyManager>()?.networkCountryIso.orEmpty()
+    private fun detectNetworkCountry(context: Context): String? {
+        return context.getSystemService<TelephonyManager>()?.networkCountryIso?.ifEmpty { null }
     }
 
-    private fun detectLocaleCountry(context: Context): String {
+    private fun detectLocaleCountry(context: Context): String? {
         return ConfigurationCompat.getLocales(context.resources.configuration)[0]!!.country
+            .ifEmpty { null }
     }
 
     fun getAvailableCountries(): List<Country> {


### PR DESCRIPTION
Simplify the `LocaleHelper` methods using Kotlin's extensions and property syntax.