### PR TITLE
Remove unnecessary TextViewCompat calls.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/extensions/SetDrawables.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetDrawables.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.extensions
 
-import android.graphics.drawable.Drawable
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.widget.TextViewCompat
 
 fun TextView.setDrawables(
     start: Int? = null,
@@ -11,19 +9,10 @@ fun TextView.setDrawables(
     end: Int? = null,
     bottom: Int? = null
 ) {
-    setDrawables(
+    setCompoundDrawablesRelativeWithIntrinsicBounds(
         start?.let { AppCompatResources.getDrawable(context, it) },
         top?.let { AppCompatResources.getDrawable(context, it) },
         end?.let { AppCompatResources.getDrawable(context, it) },
         bottom?.let { AppCompatResources.getDrawable(context, it) }
     )
-}
-
-fun TextView.setDrawables(
-    start: Drawable? = null,
-    top: Drawable? = null,
-    end: Drawable? = null,
-    bottom: Drawable? = null
-) {
-    TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(this, start, top, end, bottom)
 }

--- a/app/src/main/java/com/github/libretube/ui/views/DrawableTextView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DrawableTextView.kt
@@ -6,7 +6,6 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.Gravity
 import androidx.appcompat.widget.AppCompatTextView
-import androidx.core.widget.TextViewCompat
 import com.github.libretube.R
 
 /**
@@ -72,34 +71,5 @@ class DrawableTextView(
             if (it > 0) setBounds(0, 0, it, it)
         }
         return this
-    }
-
-    fun setDrawables(
-        start: Drawable? = null,
-        top: Drawable? = null,
-        end: Drawable? = null,
-        bottom: Drawable? = null
-    ) {
-        TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
-            this,
-            start,
-            top,
-            end,
-            bottom
-        )
-    }
-
-    fun setDrawablesDimension(
-        start: Float = drawableStartDimen,
-        top: Float = drawableTopDimen,
-        end: Float = drawableEndDimen,
-        bottom: Float = drawableBottomDimen
-    ) {
-        drawableStartDimen = start
-        drawableTopDimen = top
-        drawableEndDimen = end
-        drawableBottomDimen = bottom
-
-        invalidate()
     }
 }


### PR DESCRIPTION
`setCompoundDrawablesRelativeWithIntrinsicBounds` is available since API level 17 (Android 4.2).