### PR TITLE
Release view bindings in search fragments.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchFragment.kt
@@ -20,7 +20,9 @@ import com.github.libretube.ui.base.BaseFragment
 import com.github.libretube.ui.models.SearchViewModel
 
 class SearchFragment : BaseFragment() {
-    private lateinit var binding: FragmentSearchBinding
+    private var _binding: FragmentSearchBinding? = null
+    private val binding get() = _binding!!
+
     private val viewModel: SearchViewModel by activityViewModels()
 
     private var query: String? = null
@@ -35,7 +37,7 @@ class SearchFragment : BaseFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSearchBinding.inflate(layoutInflater, container, false)
+        _binding = FragmentSearchBinding.inflate(layoutInflater, container, false)
         return binding.root
     }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.withContext
 import retrofit2.HttpException
 
 class SearchResultFragment : BaseFragment() {
-    private lateinit var binding: FragmentSearchResultBinding
+    private var _binding: FragmentSearchResultBinding? = null
+    private val binding get() = _binding!!
 
     private var nextPage: String? = null
     private var query: String = ""
@@ -43,7 +44,7 @@ class SearchResultFragment : BaseFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentSearchResultBinding.inflate(layoutInflater, container, false)
+        _binding = FragmentSearchResultBinding.inflate(layoutInflater, container, false)
         return binding.root
     }
 
@@ -75,12 +76,18 @@ class SearchResultFragment : BaseFragment() {
 
         fetchSearch()
 
-        binding.searchRecycler.viewTreeObserver
-            .addOnScrollChangedListener {
-                if (!binding.searchRecycler.canScrollVertically(1)) {
-                    if (nextPage != null) fetchNextSearchItems()
-                }
+        binding.searchRecycler.viewTreeObserver.addOnScrollChangedListener {
+            if (_binding?.searchRecycler?.canScrollVertically(1) == false &&
+                nextPage != null
+            ) {
+                fetchNextSearchItems()
             }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun fetchSearch() {


### PR DESCRIPTION
Release the view bindings in the search fragments when the view is destroyed to avoid memory leaks.