### PR TITLE
Fix relative time formatting on Android versions below 7.0.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
@@ -123,7 +123,7 @@ class VideosAdapter(
                 R.string.trending_views,
                 video.uploaderName,
                 video.views.formatShort(),
-                video.uploaded?.let { TextUtils.formatRelativeDate(it) }
+                video.uploaded?.let { TextUtils.formatRelativeDate(root.context, it) }
             )
             video.duration?.let { thumbnailDuration.setFormattedDuration(it, video.isShort) }
             channelImage.setOnClickListener {
@@ -154,7 +154,9 @@ class VideosAdapter(
             videoInfo.text = root.context.getString(
                 R.string.normal_views,
                 video.views.formatShort(),
-                video.uploaded?.let { TextUtils.SEPARATOR + TextUtils.formatRelativeDate(it) }
+                video.uploaded?.let {
+                    TextUtils.SEPARATOR + TextUtils.formatRelativeDate(root.context, it)
+                }
             )
 
             thumbnailDuration.text = video.duration?.let { DateUtils.formatElapsedTime(it) }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,4 +456,17 @@
     <string name="background_channel_description">Shows a notification with buttons to control the audio player.</string>
     <string name="push_channel_name">Notification Worker</string>
     <string name="push_channel_description">Shows a notification when new streams are available.</string>
+    <!-- Relative time formatting strings (remove when setting the minSdk to 24) -->
+    <plurals name="years_ago">
+        <item quantity="one">1 year ago</item>
+        <item quantity="other">%d years ago</item>
+    </plurals>
+    <plurals name="months_ago">
+        <item quantity="one">1 month ago</item>
+        <item quantity="other">%d months ago</item>
+    </plurals>
+    <plurals name="weeks_ago">
+        <item quantity="one">1 week ago</item>
+        <item quantity="other">%d weeks ago</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Add quantity strings to display relative time strings similar to Android 7.0 and later.