### PR TITLE
Format upload date in downloads view.

### DIFF
--- a/app/src/main/java/com/github/libretube/db/obj/Download.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/Download.kt
@@ -2,6 +2,7 @@ package com.github.libretube.db.obj
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlinx.datetime.LocalDate
 
 @Entity(tableName = "download")
 data class Download(
@@ -10,6 +11,6 @@ data class Download(
     val title: String = "",
     val description: String = "",
     val uploader: String = "",
-    val uploadDate: String? = null,
+    val uploadDate: LocalDate? = null,
     val thumbnailPath: String? = null
 )

--- a/app/src/main/java/com/github/libretube/services/DownloadService.kt
+++ b/app/src/main/java/com/github/libretube/services/DownloadService.kt
@@ -103,7 +103,7 @@ class DownloadService : LifecycleService() {
                     streams.title,
                     streams.description,
                     streams.uploader,
-                    streams.uploadDate.toString(),
+                    streams.uploadDate,
                     thumbnailTargetFile.absolutePath
                 )
                 Database.downloadDao().insertDownload(download)

--- a/app/src/main/java/com/github/libretube/ui/adapters/DownloadsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/DownloadsAdapter.kt
@@ -16,6 +16,7 @@ import com.github.libretube.extensions.formatAsFileSize
 import com.github.libretube.helpers.ImageHelper
 import com.github.libretube.ui.activities.OfflinePlayerActivity
 import com.github.libretube.ui.viewholders.DownloadsViewHolder
+import com.github.libretube.util.TextUtils
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.io.File
 import kotlinx.coroutines.Dispatchers
@@ -42,7 +43,7 @@ class DownloadsAdapter(
         holder.binding.apply {
             title.text = download.title
             uploaderName.text = download.uploader
-            videoInfo.text = download.uploadDate
+            videoInfo.text = download.uploadDate?.let { TextUtils.localizeDate(it) }
 
             val downloadSize = items.sumOf { it.downloadSize }
             val currentSize = items.sumOf { File(it.path).length() }


### PR DESCRIPTION
Format the upload date displayed in the Downloads view using the same style as in the player and watch history views.