### PR TITLE
Fix Shuffle Button Error

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -166,6 +166,7 @@ class PlaylistFragment : Fragment() {
                 binding.bookmark.setIconResource(R.drawable.ic_shuffle)
                 binding.bookmark.text = getString(R.string.shuffle)
                 binding.bookmark.setOnClickListener {
+                    if (playlistFeed.isEmpty()) return@setOnClickListener
                     val queue = playlistFeed.shuffled()
                     PlayingQueue.resetToDefaults()
                     PlayingQueue.add(*queue.toTypedArray())


### PR DESCRIPTION
Added a check for empty playlists.
that prevents error while shuffling private playlists (closes #3248)