### PR TITLE
Use only the date in relative time formatting.

### DIFF
--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -64,8 +64,10 @@ object TextUtils {
     }
 
     fun formatRelativeDate(context: Context, unixTime: Long): CharSequence {
+        // TODO: Use LocalDate.ofInstant() when it is available in SDK 34.
         val date = LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTime), ZoneId.systemDefault())
-        val now = LocalDateTime.now()
+            .toLocalDate()
+        val now = java.time.LocalDate.now()
         val weeks = date.until(now, ChronoUnit.WEEKS)
 
         return if (weeks > 0) {


### PR DESCRIPTION
Ignore the time value of the provided timestamp when calculating the time difference.