### PR TITLE
Correct Kurdish (Central) native language name

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -32,6 +32,7 @@
         <item>Euskara</item>
         <item>বাংলা</item>
         <item>Català</item>
+        <item>کوردی</item>
         <item>简体中文</item>
         <item>繁體中文</item>
         <item>čeština</item>
@@ -62,7 +63,6 @@
         <item>Română</item>
         <item>Русский</item>
         <item>Slovenčina</item>
-        <item>سۆرانی</item>
         <item>Español</item>
         <item>ภาษาไทย</item>
         <item>Türkçe</item>
@@ -77,6 +77,7 @@
         <item>eu</item>
         <item>bn</item>
         <item>ca</item>
+        <item>ckb</item>
         <item>zh-Hans</item>
         <item>zh-Hant</item>
         <item>cs</item>
@@ -107,7 +108,6 @@
         <item>ro</item>
         <item>ru</item>
         <item>sk</item>
-        <item>ckb</item>
         <item>es</item>
         <item>th</item>
         <item>tr</item>


### PR DESCRIPTION
Correct Kurdish (Central) native language name and moved to below of Catalan language by language code ckb