### PR TITLE
Use CompactDecimalFormat to format counts.

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/FormatShort.kt
+++ b/app/src/main/java/com/github/libretube/extensions/FormatShort.kt
@@ -1,14 +1,22 @@
 package com.github.libretube.extensions
 
+import android.icu.text.CompactDecimalFormat
+import android.os.Build
+import java.util.*
 import kotlin.math.pow
 
 fun Long?.formatShort(): String {
-    this ?: return (0).toString()
-    val units = arrayOf("", "K", "M", "B", "T")
-
-    for (i in units.size downTo 1) {
-        val step = 1000.0.pow(i.toDouble())
-        if (this > step) return String.format("%3.0f%s", this / step, units[i]).trim()
+    val value = this ?: 0
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        CompactDecimalFormat
+            .getInstance(Locale.getDefault(), CompactDecimalFormat.CompactStyle.SHORT)
+            .format(value)
+    } else {
+        val units = arrayOf("", "K", "M", "B", "T")
+        for (i in units.size downTo 1) {
+            val step = 1000.0.pow(i.toDouble())
+            if (value > step) return String.format("%3.0f%s", value / step, units[i]).trim()
+        }
+        value.toString()
     }
-    return this.toString()
 }


### PR DESCRIPTION
Use [`CompactDecimalFormat`](https://developer.android.com/reference/android/icu/text/CompactDecimalFormat) to format counts on Android 7.0 and later.

**Screenshots**

Before

![Screenshot_20230325_190050_LibreTube](https://user-images.githubusercontent.com/31027858/227720319-8c96857f-439d-4893-84c6-079b71e0b19c.jpg)

After

![Screenshot_20230325_190101_LibreTube Debug](https://user-images.githubusercontent.com/31027858/227720330-968c31a3-9757-4e07-8875-c745198306f8.jpg)
