### PR TITLE
Disable picture-in-picture on Android Go devices.

### DIFF
--- a/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
+++ b/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
@@ -1,9 +1,16 @@
 package com.github.libretube.compat
 
 import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 
 object PictureInPictureCompat {
+    fun isPictureInPictureAvailable(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+    }
+
     fun isInPictureInPictureMode(activity: Activity): Boolean {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && activity.isInPictureInPictureMode
     }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -344,13 +344,12 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         binding.playerMotionLayout.progress = 1.toFloat()
         binding.playerMotionLayout.transitionToStart()
 
+        val activity = requireActivity()
         if (PlayerHelper.pipEnabled) {
-            PictureInPictureCompat.setPictureInPictureParams(requireActivity(), pipParams)
+            PictureInPictureCompat.setPictureInPictureParams(activity, pipParams)
         }
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            binding.relPlayerPip.visibility = View.GONE
-        }
+        binding.relPlayerPip.isVisible = PictureInPictureCompat
+            .isPictureInPictureAvailable(activity)
     }
 
     // actions that don't depend on video information

--- a/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
@@ -2,8 +2,6 @@ package com.github.libretube.ui.preferences
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Toast
@@ -11,6 +9,7 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import com.github.libretube.R
+import com.github.libretube.compat.PictureInPictureCompat
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.helpers.LocaleHelper
 import com.github.libretube.helpers.PreferenceHelper
@@ -64,7 +63,8 @@ class PlayerSettings : BasePreferenceFragment() {
             PreferenceKeys.PICTURE_IN_PICTURE
         )!!
         val pauseOnQuit = findPreference<SwitchPreferenceCompat>(PreferenceKeys.PAUSE_ON_QUIT)
-        pictureInPicture.isVisible = SDK_INT >= Build.VERSION_CODES.O
+        pictureInPicture.isVisible = PictureInPictureCompat
+            .isPictureInPictureAvailable(requireContext())
         pauseOnQuit?.isVisible = !pictureInPicture.isVisible || !pictureInPicture.isChecked
 
         pictureInPicture.setOnPreferenceChangeListener { _, newValue ->


### PR DESCRIPTION
Disable picture-in-picture controls on Android Go devices, as the functionality is unavailable on those devices.