### PR TITLE
Fix two taps required to interact with player when in fullscreen mode

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
@@ -20,25 +20,24 @@ object WindowHelper {
 
         WindowCompat.setDecorFitsSystemWindows(window, !isFullscreen)
 
-        val controller = WindowCompat.getInsetsController(window, window.decorView)
-        val flags = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars()
         if (isFullscreen) {
-            controller.hide(flags)
+            activity.hideSystemBars()
         } else {
-            controller.show(flags)
+            activity.showSystemBars()
         }
+    }
+}
 
-        controller.systemBarsBehavior = if (isFullscreen) {
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        } else {
-            WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
-        }
+fun Activity.hideSystemBars() {
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        hide(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
+    }
+}
 
-        val layoutFlag = WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-        if (isFullscreen) {
-            window.setFlags(layoutFlag, layoutFlag)
-        } else {
-            window.clearFlags(layoutFlag)
-        }
+fun Activity.showSystemBars() {
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        show(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
@@ -6,6 +6,8 @@ import android.view.WindowManager
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.github.libretube.ui.extensions.hideSystemBars
+import com.github.libretube.ui.extensions.showSystemBars
 
 object WindowHelper {
     fun toggleFullscreen(activity: Activity, isFullscreen: Boolean) {
@@ -25,19 +27,5 @@ object WindowHelper {
         } else {
             activity.showSystemBars()
         }
-    }
-}
-
-fun Activity.hideSystemBars() {
-    WindowCompat.getInsetsController(window, window.decorView).apply {
-        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        hide(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
-    }
-}
-
-fun Activity.showSystemBars() {
-    WindowCompat.getInsetsController(window, window.decorView).apply {
-        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        show(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.view.WindowManager
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import com.github.libretube.ui.extensions.hideSystemBars
 import com.github.libretube.ui.extensions.showSystemBars
 
@@ -23,9 +22,9 @@ object WindowHelper {
         WindowCompat.setDecorFitsSystemWindows(window, !isFullscreen)
 
         if (isFullscreen) {
-            activity.hideSystemBars()
+            activity.hideSystemBars(WindowInsetsCompat.Type.systemBars())
         } else {
-            activity.showSystemBars()
+            activity.showSystemBars(WindowInsetsCompat.Type.systemBars())
         }
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/WindowHelper.kt
@@ -5,8 +5,7 @@ import android.os.Build
 import android.view.WindowManager
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
-import com.github.libretube.ui.extensions.hideSystemBars
-import com.github.libretube.ui.extensions.showSystemBars
+import com.github.libretube.ui.extensions.toggleSystemBars
 
 object WindowHelper {
     fun toggleFullscreen(activity: Activity, isFullscreen: Boolean) {
@@ -21,10 +20,12 @@ object WindowHelper {
 
         WindowCompat.setDecorFitsSystemWindows(window, !isFullscreen)
 
-        if (isFullscreen) {
-            activity.hideSystemBars(WindowInsetsCompat.Type.systemBars())
-        } else {
-            activity.showSystemBars(WindowInsetsCompat.Type.systemBars())
-        }
+        // Show the system bars when it is not fullscreen and hide them when it is fullscreen
+        // System bars means status bar and the navigation bar
+        // See: https://developer.android.com/training/system-ui/immersive#kotlin
+        activity.toggleSystemBars(
+            types = WindowInsetsCompat.Type.systemBars(),
+            showBars = !isFullscreen
+        )
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
@@ -1,0 +1,20 @@
+package com.github.libretube.ui.extensions
+
+import android.app.Activity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+fun Activity.hideSystemBars() {
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        hide(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
+    }
+}
+
+fun Activity.showSystemBars() {
+    WindowCompat.getInsetsController(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        show(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
@@ -5,16 +5,13 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat.Type.InsetsType
 import androidx.core.view.WindowInsetsControllerCompat
 
-fun Activity.hideSystemBars(@InsetsType types: Int) {
+fun Activity.toggleSystemBars(@InsetsType types: Int, showBars: Boolean) {
     WindowCompat.getInsetsController(window, window.decorView).apply {
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        hide(types)
-    }
-}
-
-fun Activity.showSystemBars(@InsetsType types: Int) {
-    WindowCompat.getInsetsController(window, window.decorView).apply {
-        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        show(types)
+        if (showBars) {
+            show(types)
+        } else {
+            hide(types)
+        }
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/Activity.kt
@@ -2,19 +2,19 @@ package com.github.libretube.ui.extensions
 
 import android.app.Activity
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.InsetsType
 import androidx.core.view.WindowInsetsControllerCompat
 
-fun Activity.hideSystemBars() {
+fun Activity.hideSystemBars(@InsetsType types: Int) {
     WindowCompat.getInsetsController(window, window.decorView).apply {
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        hide(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
+        hide(types)
     }
 }
 
-fun Activity.showSystemBars() {
+fun Activity.showSystemBars(@InsetsType types: Int) {
     WindowCompat.getInsetsController(window, window.decorView).apply {
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        show(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.navigationBars())
+        show(types)
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -210,8 +210,12 @@ internal class CustomExoPlayerView(
                 playerViewModel?.isFullscreen?.value?.let { isFullscreen ->
                     if (!isFullscreen) return@let
                     when (visibility) {
-                        View.VISIBLE -> activity.showSystemBars(WindowInsetsCompat.Type.statusBars())
-                        View.GONE -> activity.hideSystemBars(WindowInsetsCompat.Type.statusBars())
+                        View.VISIBLE -> {
+                            activity.showSystemBars(WindowInsetsCompat.Type.statusBars())
+                        }
+                        View.GONE -> {
+                            activity.hideSystemBars(WindowInsetsCompat.Type.statusBars())
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -32,10 +32,10 @@ import com.github.libretube.helpers.AudioHelper
 import com.github.libretube.helpers.BrightnessHelper
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.WindowHelper
-import com.github.libretube.helpers.hideSystemBars
-import com.github.libretube.helpers.showSystemBars
 import com.github.libretube.obj.BottomSheetItem
 import com.github.libretube.ui.base.BaseActivity
+import com.github.libretube.ui.extensions.hideSystemBars
+import com.github.libretube.ui.extensions.showSystemBars
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
 import com.github.libretube.ui.interfaces.PlayerGestureOptions
 import com.github.libretube.ui.interfaces.PlayerOptions

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.os.postDelayed
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.marginStart
 import androidx.core.view.updateLayoutParams
@@ -207,15 +208,10 @@ internal class CustomExoPlayerView(
         setControllerVisibilityListener(
             ControllerVisibilityListener { visibility ->
                 playerViewModel?.isFullscreen?.value?.let { isFullscreen ->
-                    if (isFullscreen) {
-                        when (visibility) {
-                            View.VISIBLE -> {
-                                activity.showSystemBars()
-                            }
-                            View.GONE -> {
-                                activity.hideSystemBars()
-                            }
-                        }
+                    if (!isFullscreen) return@let
+                    when (visibility) {
+                        View.VISIBLE -> activity.showSystemBars(WindowInsetsCompat.Type.statusBars())
+                        View.GONE -> activity.hideSystemBars(WindowInsetsCompat.Type.statusBars())
                     }
                 }
             }

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -35,8 +35,7 @@ import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.WindowHelper
 import com.github.libretube.obj.BottomSheetItem
 import com.github.libretube.ui.base.BaseActivity
-import com.github.libretube.ui.extensions.hideSystemBars
-import com.github.libretube.ui.extensions.showSystemBars
+import com.github.libretube.ui.extensions.toggleSystemBars
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
 import com.github.libretube.ui.interfaces.PlayerGestureOptions
 import com.github.libretube.ui.interfaces.PlayerOptions
@@ -209,14 +208,11 @@ internal class CustomExoPlayerView(
             ControllerVisibilityListener { visibility ->
                 playerViewModel?.isFullscreen?.value?.let { isFullscreen ->
                     if (!isFullscreen) return@let
-                    when (visibility) {
-                        View.VISIBLE -> {
-                            activity.showSystemBars(WindowInsetsCompat.Type.statusBars())
-                        }
-                        View.GONE -> {
-                            activity.hideSystemBars(WindowInsetsCompat.Type.statusBars())
-                        }
-                    }
+                    // Show status bar only not navigation bar if the player controls are visible and hide it otherwise
+                    activity.toggleSystemBars(
+                        types = WindowInsetsCompat.Type.statusBars(),
+                        showBars = visibility == View.VISIBLE
+                    )
                 }
             }
         )

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -32,6 +32,8 @@ import com.github.libretube.helpers.AudioHelper
 import com.github.libretube.helpers.BrightnessHelper
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.WindowHelper
+import com.github.libretube.helpers.hideSystemBars
+import com.github.libretube.helpers.showSystemBars
 import com.github.libretube.obj.BottomSheetItem
 import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
@@ -201,6 +203,23 @@ internal class CustomExoPlayerView(
 
             override fun onScrubStop(timeBar: TimeBar, position: Long, canceled: Boolean) {}
         })
+
+        setControllerVisibilityListener(
+            ControllerVisibilityListener { visibility ->
+                playerViewModel?.isFullscreen?.value?.let { isFullscreen ->
+                    if (isFullscreen) {
+                        when (visibility) {
+                            View.VISIBLE -> {
+                                activity.showSystemBars()
+                            }
+                            View.GONE -> {
+                                activity.hideSystemBars()
+                            }
+                        }
+                    }
+                }
+            }
+        )
 
         playerViewModel?.isFullscreen?.observe(viewLifecycleOwner!!) { isFullscreen ->
             WindowHelper.toggleFullscreen(activity, isFullscreen)


### PR DESCRIPTION
previously we had to tap twice to show controllers. On first tap the status bar will be shown and on the next tap player controller will be shown. This pr fixes this by showing controller on single tap