### PR TITLE
Hide alternative PiP controls setting if PiP is not enabled.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
@@ -59,16 +59,22 @@ class PlayerSettings : BasePreferenceFragment() {
             true
         }
 
-        val pictureInPicture = findPreference<SwitchPreferenceCompat>(
-            PreferenceKeys.PICTURE_IN_PICTURE
-        )!!
+        val pictureInPicture =
+            findPreference<SwitchPreferenceCompat>(PreferenceKeys.PICTURE_IN_PICTURE)!!
+        pictureInPicture.isVisible =
+            PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
+
         val pauseOnQuit = findPreference<SwitchPreferenceCompat>(PreferenceKeys.PAUSE_ON_QUIT)
-        pictureInPicture.isVisible = PictureInPictureCompat
-            .isPictureInPictureAvailable(requireContext())
-        pauseOnQuit?.isVisible = !pictureInPicture.isVisible || !pictureInPicture.isChecked
+        val alternativePipControls =
+            findPreference<SwitchPreferenceCompat>(PreferenceKeys.ALTERNATIVE_PIP_CONTROLS)
+        val isPipEnabled = pictureInPicture.isVisible && pictureInPicture.isChecked
+        pauseOnQuit?.isVisible = !isPipEnabled
+        alternativePipControls?.isVisible = isPipEnabled
 
         pictureInPicture.setOnPreferenceChangeListener { _, newValue ->
-            pauseOnQuit?.isVisible = !(newValue as Boolean)
+            val isChecked = newValue as Boolean
+            pauseOnQuit?.isVisible = !isChecked
+            alternativePipControls?.isVisible = isChecked
             true
         }
 


### PR DESCRIPTION
Hide the alternative picture-in-picture controls setting if PiP is not available/enabled.

https://user-images.githubusercontent.com/31027858/228851355-67db22bb-7bfb-4fe2-bea7-4c32ff86a8c9.mp4