### PR TITLE
Fix sharing short videos to the app

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -700,7 +700,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                     (videoStream?.height ?: 0) > (videoStream?.width ?: 0)
                 ) {
                     withContext(Dispatchers.Main) {
-                        setFullscreen()
+                        if (binding.playerMotionLayout.progress == 0f) setFullscreen()
                     }
                 }
             }


### PR DESCRIPTION
There has been an issue when sharing a shorts video while having `Automatic fullscreen on short videos` turned on.