### PR TITLE
In-built browser intent chooser

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -339,11 +339,6 @@
             android:exported="false" />
 
         <service
-            android:name=".services.UpdateService"
-            android:enabled="true"
-            android:exported="false" />
-
-        <service
             android:name=".services.BackgroundMode"
             android:enabled="true"
             android:exported="false" />
@@ -354,4 +349,10 @@
             android:exported="false" />
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="*" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/java/com/github/libretube/helpers/IntentHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/IntentHelper.kt
@@ -2,18 +2,41 @@ package com.github.libretube.helpers
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.net.toUri
+import androidx.fragment.app.FragmentManager
 import com.github.libretube.R
 import com.github.libretube.extensions.toastFromMainThread
+import com.github.libretube.ui.sheets.IntentChooserSheet
 
 object IntentHelper {
-    fun openLinkFromHref(context: Context, link: String) {
-        val uri = Uri.parse(link)
-        val launchIntent = Intent(Intent.ACTION_VIEW).setData(uri)
-        try {
-            context.startActivity(launchIntent)
-        } catch (e: Exception) {
-            context.toastFromMainThread(R.string.unknown_error)
+    fun openLinkFromHref(context: Context, fragmentManager: FragmentManager, link: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setData(link.toUri())
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+        @Suppress("DEPRECATION")
+        val resolveInfoList = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager
+                .queryIntentActivities(
+                    intent,
+                    PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_ALL.toLong())
+                )
+        } else {
+            context.packageManager
+                .queryIntentActivities(intent, PackageManager.MATCH_ALL)
+        }
+
+        if (resolveInfoList.isEmpty()) {
+            try {
+                context.startActivity(intent)
+            } catch (e: Exception) {
+                context.toastFromMainThread(R.string.error)
+            }
+        } else {
+            IntentChooserSheet(resolveInfoList, link)
+                .show(fragmentManager)
         }
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/activities/AboutActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/AboutActivity.kt
@@ -59,7 +59,7 @@ class AboutActivity : BaseActivity() {
 
     private fun setupCard(card: MaterialCardView, link: String) {
         card.setOnClickListener {
-            IntentHelper.openLinkFromHref(this, link)
+            IntentHelper.openLinkFromHref(this, supportFragmentManager, link)
         }
         card.setOnLongClickListener {
             onLongClick(link)
@@ -77,7 +77,7 @@ class AboutActivity : BaseActivity() {
             Snackbar.LENGTH_LONG
         )
             .setAction(R.string.open_copied) {
-                IntentHelper.openLinkFromHref(this, href)
+                IntentHelper.openLinkFromHref(this, supportFragmentManager, href)
             }
             .setAnimationMode(Snackbar.ANIMATION_MODE_FADE)
             .show()

--- a/app/src/main/java/com/github/libretube/ui/activities/HelpActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/HelpActivity.kt
@@ -35,7 +35,7 @@ class HelpActivity : BaseActivity() {
 
     private fun setupCard(card: MaterialCardView, link: String) {
         card.setOnClickListener {
-            IntentHelper.openLinkFromHref(this, link)
+            IntentHelper.openLinkFromHref(this, supportFragmentManager, link)
         }
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/adapters/IntentChooserAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/IntentChooserAdapter.kt
@@ -1,0 +1,44 @@
+package com.github.libretube.ui.adapters
+
+import android.content.Intent
+import android.content.pm.ResolveInfo
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.net.toUri
+import androidx.recyclerview.widget.RecyclerView
+import com.github.libretube.databinding.IntentChooserItemBinding
+import com.github.libretube.ui.viewholders.IntentChooserViewHolder
+
+/**
+ * An adapter for opening an intent chooser inside the app, example-wise for urls
+ * @param packages A list of resolved packages found by a package query
+ */
+class IntentChooserAdapter(
+    private val packages: List<ResolveInfo>,
+    private val queryUrl: String
+) : RecyclerView.Adapter<IntentChooserViewHolder>() {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IntentChooserViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        val binding = IntentChooserItemBinding.inflate(layoutInflater, parent, false)
+        return IntentChooserViewHolder(binding)
+    }
+
+    override fun getItemCount() = packages.size
+
+    override fun onBindViewHolder(holder: IntentChooserViewHolder, position: Int) {
+        val currentPackage = packages[position]
+        holder.binding.apply {
+            val drawable = currentPackage.loadIcon(root.context.packageManager)
+            appIconIV.setImageDrawable(drawable)
+            val appLabel = currentPackage.loadLabel(root.context.packageManager)
+            appNameTV.text = appLabel
+            root.setOnClickListener {
+                runCatching {
+                    val intent = Intent(Intent.ACTION_VIEW, queryUrl.toUri())
+                        .setPackage(currentPackage.activityInfo.packageName)
+                    root.context.startActivity(intent)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -90,7 +90,6 @@ import com.github.libretube.ui.models.PlayerViewModel
 import com.github.libretube.ui.sheets.BaseBottomSheet
 import com.github.libretube.ui.sheets.CommentsSheet
 import com.github.libretube.ui.sheets.PlayingQueueSheet
-import com.github.libretube.util.DataSaverMode
 import com.github.libretube.util.HtmlParser
 import com.github.libretube.util.LinkHandler
 import com.github.libretube.util.NowPlayingNotification
@@ -184,7 +183,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
     private val handler = Handler(Looper.getMainLooper())
     private val mainActivity get() = activity as MainActivity
-    private val windowInsetsControllerCompat get() =  WindowCompat
+    private val windowInsetsControllerCompat get() = WindowCompat
         .getInsetsController(mainActivity.window, mainActivity.window.decorView)
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
@@ -1,0 +1,31 @@
+package com.github.libretube.ui.sheets
+
+import android.content.pm.ResolveInfo
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.GridLayoutManager
+import com.github.libretube.databinding.BottomSheetBinding
+import com.github.libretube.ui.adapters.IntentChooserAdapter
+
+class IntentChooserSheet(
+    private val packages: List<ResolveInfo>,
+    private val url: String
+) : BaseBottomSheet() {
+    private lateinit var binding: BottomSheetBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = BottomSheetBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
+        binding.optionsRecycler.adapter = IntentChooserAdapter(packages, url)
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
@@ -29,7 +29,7 @@ class IntentChooserSheet(
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IntentChooserAdapter(packages, url)
     }
-    
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
@@ -13,19 +13,25 @@ class IntentChooserSheet(
     private val packages: List<ResolveInfo>,
     private val url: String
 ) : BaseBottomSheet() {
-    private lateinit var binding: BottomSheetBinding
+    private var _binding: BottomSheetBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = BottomSheetBinding.inflate(inflater)
+        _binding = BottomSheetBinding.inflate(inflater)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IntentChooserAdapter(packages, url)
+    }
+    
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/VideoOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/VideoOptionsBottomSheet.kt
@@ -18,9 +18,7 @@ import com.github.libretube.ui.dialogs.DownloadDialog
 import com.github.libretube.ui.dialogs.ShareDialog
 import com.github.libretube.ui.fragments.SubscriptionsFragment
 import com.github.libretube.util.PlayingQueue
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**

--- a/app/src/main/java/com/github/libretube/ui/viewholders/IntentChooserViewHolder.kt
+++ b/app/src/main/java/com/github/libretube/ui/viewholders/IntentChooserViewHolder.kt
@@ -3,10 +3,6 @@ package com.github.libretube.ui.viewholders
 import androidx.recyclerview.widget.RecyclerView
 import com.github.libretube.databinding.IntentChooserItemBinding
 
-/**
- * A simple view holder for the [IntentChooserAdapter]
- * @param binding The view binding of the adapter item
- */
 class IntentChooserViewHolder(
     val binding: IntentChooserItemBinding
 ) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/com/github/libretube/ui/viewholders/IntentChooserViewHolder.kt
+++ b/app/src/main/java/com/github/libretube/ui/viewholders/IntentChooserViewHolder.kt
@@ -1,0 +1,12 @@
+package com.github.libretube.ui.viewholders
+
+import androidx.recyclerview.widget.RecyclerView
+import com.github.libretube.databinding.IntentChooserItemBinding
+
+/**
+ * A simple view holder for the [IntentChooserAdapter]
+ * @param binding The view binding of the adapter item
+ */
+class IntentChooserViewHolder(
+    val binding: IntentChooserItemBinding
+) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/res/layout/intent_chooser_item.xml
+++ b/app/src/main/res/layout/intent_chooser_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="10dp"
+    android:background="@drawable/rounded_ripple"
+    android:orientation="vertical"
+    android:paddingVertical="10dp">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/appIconIV"
+        android:layout_width="75dp"
+        android:layout_height="75dp"
+        android:layout_gravity="center"
+        android:padding="10dp"
+        app:shapeAppearance="@style/CircleImageView"
+        tools:src="@mipmap/ic_launcher_round" />
+
+    <TextView
+        android:id="@+id/appNameTV"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="11sp" />
+
+</LinearLayout>


### PR DESCRIPTION
Newer Android versions do always open links inside the default browser of the phone instead of letting the user choose which browser to use. Using `Intent#createChooser` behaves the same way. In order to allow users to choose which browser they actually want to use, the app queries for available packages. Silent contribution from @AudricV, because they're working hard to support the development in the background :)