### PR TITLE
Improve notification grouping for new streams.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -384,7 +384,7 @@ class MainActivity : BaseActivity() {
         intent?.getStringExtra(IntentData.channelId)?.let {
             navController.navigate(
                 R.id.channelFragment,
-                bundleOf(IntentData.channelName to it)
+                bundleOf(IntentData.channelId to it)
             )
         }
         intent?.getStringExtra(IntentData.channelName)?.let {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -485,4 +485,8 @@
         <item quantity="one">%d week ago</item>
         <item quantity="other">%d weeks ago</item>
     </plurals>
+    <plurals name="channel_new_streams">
+        <item quantity="one">%d new stream</item>
+        <item quantity="other">%d new streams</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
* Group new stream notifications together by originating channel, and display a summary notification on Android versions below 7.0.
* Fix the channel navigation.

**Screenshots**

Android 5.0

![Screenshot_20230411_210747](https://user-images.githubusercontent.com/31027858/231216199-7d9d93b0-a5ed-473d-8bcd-46406ff03e5d.png)
![Screenshot_20230411_210754](https://user-images.githubusercontent.com/31027858/231216189-21f436d5-e3df-4521-bd8f-af53ac50b6dc.png)

Android 12

![Screenshot_20230411-203531_Trebuchet](https://user-images.githubusercontent.com/31027858/231216403-bd9f2578-3398-4fb6-962e-e89f28d4a920.png)
