### PR TITLE
Display stream notification thumbnails.

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -107,6 +107,7 @@ object PreferenceKeys {
      * Notifications
      */
     const val NOTIFICATION_ENABLED = "notification_toggle"
+    const val SHOW_STREAM_THUMBNAILS = "show_stream_thumbnails"
     const val CHECKING_FREQUENCY = "checking_frequency"
     const val REQUIRED_NETWORK = "required_network"
     const val IGNORED_NOTIFICATION_CHANNELS = "ignored_notification_channels"

--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -11,6 +11,7 @@ import coil.disk.DiskCache
 import coil.load
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import com.github.libretube.api.CronetHelper
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.toAndroidUri
@@ -71,6 +72,14 @@ object ImageHelper {
             .build()
 
         imageLoader.enqueue(request)
+    }
+
+    suspend fun getImage(context: Context, url: String?): ImageResult {
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .build()
+
+        return imageLoader.execute(request)
     }
 
     fun getDownloadedImage(context: Context, path: Path): Bitmap? {

--- a/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
+++ b/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
@@ -26,7 +26,6 @@ import com.github.libretube.helpers.ImageHelper
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.ui.activities.MainActivity
 import com.github.libretube.ui.views.TimePickerPreference
-import com.github.libretube.util.DataSaverMode
 import java.time.LocalTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -156,8 +155,8 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
                 // The intent that will fire when the user taps the notification
                 .setContentIntent(pendingIntent)
 
-            // Load stream thumbnails if data saving mode is disabled.
-            if (!DataSaverMode.isEnabled(applicationContext)) {
+            // Load stream thumbnails if the relevant toggle is enabled.
+            if (PreferenceHelper.getBoolean(PreferenceKeys.SHOW_STREAM_THUMBNAILS, false)) {
                 val thumbnail = withContext(Dispatchers.IO) {
                     ImageHelper.getImage(applicationContext, it.thumbnail).drawable?.toBitmap()
                 }

--- a/app/src/main/res/drawable/ic_image.xml
+++ b/app/src/main/res/drawable/ic_image.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,6 +268,8 @@
     <string name="notifications">Notifications</string>
     <string name="notify_new_streams">Notifications for new streams</string>
     <string name="notify_new_streams_summary">Notifications about fresh content from creators you follow.</string>
+    <string name="show_stream_thumbnails">Show stream thumbnails</string>
+    <string name="show_stream_thumbnails_summary">Show the thumbnails of new streams. Enabling this will consume additional data.</string>
     <string name="checking_frequency">Checking every …</string>
     <string name="new_streams_count">%1$s new streams available</string>
     <string name="new_streams_by">New streams by %1$s…</string>

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -11,6 +11,13 @@
             app:key="notification_toggle"
             app:title="@string/notify_new_streams" />
 
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_image"
+            app:defaultValue="false"
+            app:key="show_stream_thumbnails"
+            app:title="@string/show_stream_thumbnails"
+            app:summary="@string/show_stream_thumbnails_summary" />
+
         <ListPreference
             android:icon="@drawable/ic_time"
             app:defaultValue="60"


### PR DESCRIPTION
Display the thumbnails of new streams in their notifications.

**Screenshots**

Android 5.0
![Screenshot on Android 5](https://user-images.githubusercontent.com/31027858/231652383-8b7a0fb1-26b4-4d28-a66e-350437a21d13.png)

Android 8.1
![Screenshot_20230413-082019_LibreTube Debug](https://user-images.githubusercontent.com/31027858/231652405-320e4069-39e5-4bc9-bd46-6efa25a02d58.jpg)
![Screenshot_20230413-082124_LibreTube Debug](https://user-images.githubusercontent.com/31027858/231652339-0530809f-db57-4f0e-a523-4697e37989d3.jpg)

Settings page
![Screenshot_20230413-172032_LibreTube Debug](https://user-images.githubusercontent.com/31027858/231750001-5dc9fa4c-f698-4316-9ffd-7ccae4a26554.png)
