### PR TITLE
Remove week relative strings.

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -471,14 +471,6 @@
         <item quantity="many">%d منذ أشهر</item>
         <item quantity="other">%d منذ أشهر</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="zero">%d منذ أسبوع</item>
-        <item quantity="one">%d منذ أسبوع</item>
-        <item quantity="two">%d منذ أسبوعين</item>
-        <item quantity="few">%d منذ أسابيع</item>
-        <item quantity="many">%d منذ أسابيع</item>
-        <item quantity="other">%d منذ أسابيع</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">استخدم LBRY HLS للبث إذا كان متاحا.</string>
     <string name="subscriberAndVideoCounts">مشتركون %1$s • فيديوهات %2$d</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -459,10 +459,6 @@
         <item quantity="one">%d ay əvvəl</item>
         <item quantity="other">%d ay əvvəl</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d həftə əvvəl</item>
-        <item quantity="other">%d həftə əvvəl</item>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="one">%d il əvvəl</item>
         <item quantity="other">%d il əvvəl</item>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -427,12 +427,6 @@
     <string name="codecs">Кодэкі</string>
     <string name="mark_as_watched">Пазначыць як прагледжанае</string>
     <string name="custom_playback_speed">Карыстальніцкая хуткасць</string>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d тыдзень таму</item>
-        <item quantity="few">%d тыдні таму</item>
-        <item quantity="many">%d тыдняў таму</item>
-        <item quantity="other">%d тыдняў таму</item>
-    </plurals>
     <string name="alternative_pip_controls">Альтэрнатыўныя элементы кіравання PiP</string>
     <string name="alternative_pip_controls_summary">Паказваць толькі аўдыя і прапускаць элементы кіравання ў PiP замест перамоткі наперад і назад</string>
     <string name="custom_playback_speed_summary">Выкарыстоўвайце іншую хуткасць прайгравання, чым для звычайнага прайгравальніка.</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -111,10 +111,6 @@
     <string name="related_streams_summary">پیشاندانی ناوەڕۆکە هاوشێوەکان لەکاتی سەیرکردندا.</string>
     <string name="player_summary">فرمانە بنەڕەتییەکان</string>
     <string name="instance_frontend_url">ناونیشانی ڕاستەوخۆ</string>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d هەفتە لەمەوپێش</item>
-        <item quantity="other">%d هەفتە لەمەوپێش</item>
-    </plurals>
     <string name="customInstance_summary">زیادکردن…</string>
     <string name="show_chapters">پیشاندانی بەشەکان</string>
     <string name="hide_chapters">شاردنەوەی بەشەکان</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -465,11 +465,6 @@
         <item quantity="few">Před %d měsíci</item>
         <item quantity="other">Před %d měsíci</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">Před týdnem</item>
-        <item quantity="few">Před %d týdny</item>
-        <item quantity="other">Před %d týdny</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">Pro streamování použít LBRY HLS, pokud je k dispozici.</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d videí</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -463,10 +463,6 @@
         <item quantity="one">Vor %d Jahr</item>
         <item quantity="other">Vor %d Jahren</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">Vor %d Woche</item>
-        <item quantity="other">Vor %d Wochen</item>
-    </plurals>
     <string name="lbry_hls_summary">Falls verfügbar, LBRY HLS für das Streaming verwenden.</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d Videos</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -465,11 +465,6 @@
         <item quantity="many">Hace %d meses</item>
         <item quantity="other">Hace %d meses</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">Hace %d semana</item>
-        <item quantity="many">Hace %d semanas</item>
-        <item quantity="other">Hace %d semanas</item>
-    </plurals>
     <string name="lbry_hls_summary">Utilice LBRY HLS para el streaming si está disponible.</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="subscriberAndVideoCounts">%1$s suscriptores • %2$d vídeos</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -327,10 +327,6 @@
     <string name="appearance_summary">تنظیم کاره به سلیقه‌تان.</string>
     <string name="no_replies">این نظر پاسخی ندارد.</string>
     <string name="privacy_alert">هشدار محرمانگی</string>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d هفته پیش</item>
-        <item quantity="other">%d هفته پیش</item>
-    </plurals>
     <string name="codecs">رمزینه‌ها</string>
     <string name="resume">از سر گیری</string>
     <string name="pause">مکث</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -465,8 +465,4 @@
         <item quantity="one">%d kuukausi sitten</item>
         <item quantity="other">%d kuukautta sitten</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d viikko sitten</item>
-        <item quantity="other">%d viikkoa sitten</item>
-    </plurals>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -469,11 +469,6 @@
         <item quantity="many">il y a %d mois</item>
         <item quantity="other">il y a %d mois</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">il y a %d semaine</item>
-        <item quantity="many">il y a %d semaines</item>
-        <item quantity="other">il y a %d semaines</item>
-    </plurals>
     <string name="disable_proxy">Désactiver le proxy Piped</string>
     <string name="disable_proxy_summary">Chargez des vidéos et des images directement depuis les serveurs de YouTube. N\'activez cette option que si vous utilisez un VPN ! Notez que cela peut ne pas fonctionner avec le contenu de Youtube music.</string>
     <string name="auto_fullscreen_shorts">Plein écran automatique sur les vidéos courtes</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -463,10 +463,6 @@
         <item quantity="one">%d महीना पहले</item>
         <item quantity="other">%d महीने पहले</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d सप्ताह पहले</item>
-        <item quantity="other">%d हफ्तों पहले</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">उपलब्ध होने पर स्ट्रीमिंग के लिए LBRY HLS का प्रयोग करें।</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d वीडियोज</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -470,10 +470,6 @@
         <item quantity="one">%d hónapja</item>
         <item quantity="other">%d hónapja</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d hete</item>
-        <item quantity="other">%d hete</item>
-    </plurals>
     <string name="new_group">Új</string>
     <string name="group_name">Csoportnév</string>
     <string name="edit_group">Csoport szerkesztése</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -458,9 +458,6 @@
     <plurals name="months_ago">
         <item quantity="other">%d bulan yang lalu</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="other">%d minggu yang lalu</item>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="other">%d tahun yang lalu</item>
     </plurals>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -460,11 +460,6 @@
         <item quantity="many">%d mesi fa</item>
         <item quantity="other">%d mesi fa</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d settimana fa</item>
-        <item quantity="many">%d settimane fa</item>
-        <item quantity="other">%d settimane fa</item>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="one">%d anno fa</item>
         <item quantity="many">%d anni fa</item>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -461,12 +461,6 @@
         <item quantity="many">לפני %d חודשים</item>
         <item quantity="other"/>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">לפני שבוע</item>
-        <item quantity="two">לפני שבועיים</item>
-        <item quantity="many">לפני %d שבועות</item>
-        <item quantity="other"/>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="one">לפני שנה</item>
         <item quantity="two">לפני שנתיים</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -449,9 +449,6 @@
     <plurals name="months_ago">
         <item quantity="other">%d か月前</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="other">%d 週間前</item>
-    </plurals>
     <string name="concurrent_downloads_limit_reached">同時ダウンロード数の上限に達しました。</string>
     <string name="no_subtitle">サブタイトルなし</string>
     <string name="download_paused">ダウンロードを一時停止しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -463,9 +463,6 @@
     <plurals name="months_ago">
         <item quantity="other">%d개월 전</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="other">%d주 전</item>
-    </plurals>
     <string name="resume">재개하다</string>
     <string name="forward">빨리 감기</string>
     <string name="disable_proxy">Piped 프록시 비활성화</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -445,11 +445,6 @@
         <item quantity="one">pirms %d gada</item>
         <item quantity="other">pirms %d gadiem</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="zero">pirms %d nedēļām</item>
-        <item quantity="one">pirms %d nedēļas</item>
-        <item quantity="other">pirms %d nedēļām</item>
-    </plurals>
     <string name="concurrent_downloads_limit_reached">Sasniegts vienlaikus atļauto lejuipelāžu skaits.</string>
     <string name="resume">Atsākt</string>
     <string name="concurrent_downloads">Vienlaikus atļautās lejupielādes</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -201,10 +201,6 @@
     <string name="exportsuccess">കയറ്റുമതി ചെയ്തു.</string>
     <string name="help">സഹായം</string>
     <string name="faq">പതിവുചോദ്യങ്ങൾ</string>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d ആഴ്ച മുമ്പ്</item>
-        <item quantity="other">%d ആഴ്ചകൾ മുമ്പ്</item>
-    </plurals>
     <plurals name="months_ago">
         <item quantity="one">%d മാസം മുമ്പ്</item>
         <item quantity="other">%d മാസങ്ങൾ മുമ്പ്</item>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -465,10 +465,6 @@
         <item quantity="one">%d महिन्यापूर्वी</item>
         <item quantity="other">%d महिन्यांपूर्वी</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d आठवड्यापूर्वी</item>
-        <item quantity="other">%d आठवड्यांपूर्वी</item>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="one">%d वर्षापूर्वी</item>
         <item quantity="other">%d वर्षांपूर्वी</item>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -461,10 +461,6 @@
         <item quantity="one">%d måned siden</item>
         <item quantity="other">%d måneder siden</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d uke siden</item>
-        <item quantity="other">%d uker siden</item>
-    </plurals>
     <string name="autoplay_countdown_summary">Vis 5 sekunders nedtelling før autospilling av neste video.</string>
     <string name="playing_next">Spiller neste om %1$s</string>
     <string name="lbry_hls_summary">Hent videostrøm i LBRY HLS-format hvis tilgjengelig.</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -463,10 +463,6 @@
         <item quantity="one">%d ମାସ ପୂର୍ବେ</item>
         <item quantity="other">%d ମାସ ପୂର୍ବରୁ</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d ସପ୍ତାହ ପୂର୍ବେ</item>
-        <item quantity="other">%d ସପ୍ତାହ ପୂର୍ବରୁ</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">ଉପଲବ୍ଧ ଥିଲେ ଷ୍ଟ୍ରିମିଂ ପାଇଁ LBRY HLS ବ୍ୟବହାର କରନ୍ତୁ ।</string>
     <string name="subscriberAndVideoCounts">%1$s ଗ୍ରାହକ • %2$d ଭିଡିଓ</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -463,10 +463,6 @@
         <item quantity="one">%d ਮਹੀਨਾ ਪਹਿਲਾਂ</item>
         <item quantity="other">%d ਮਹੀਨੇ ਪਹਿਲਾਂ</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d ਹਫ਼ਤਾ ਪਹਿਲਾਂ</item>
-        <item quantity="other">%d ਹਫ਼ਤੇ ਪਹਿਲਾਂ</item>
-    </plurals>
     <string name="lbry_hls">ਲਿਬਰੀ HLS</string>
     <string name="lbry_hls_summary">ਉਪਲਬਧ ਹੋਵੇ ਤਾਂ ਸਟ੍ਰੀਮਿੰਗ ਲਈ ਲੀਬਰ HLS ਵਰਤੋ।</string>
     <string name="subscriberAndVideoCounts">%1$s ਸਬਸਕ੍ਰਾਈਬਰ• %2$d ਵੀਡੀਓ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -467,12 +467,6 @@
         <item quantity="many">%d miesięcy temu</item>
         <item quantity="other">%d miesięcy temu</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d tydzień temu</item>
-        <item quantity="few">%d tygodnie temu</item>
-        <item quantity="many">%d tygodni temu</item>
-        <item quantity="other">%d tygodni temu</item>
-    </plurals>
     <string name="lbry_hls_summary">Użyj LBRY HLS do transmisji strumieniowej, jeśli jest dostępna.</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d filmów</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -460,11 +460,6 @@
         <item quantity="many">%d anos atrás</item>
         <item quantity="other">%d anos atrás</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d semana atrás</item>
-        <item quantity="many">%d semanas atrás</item>
-        <item quantity="other">%d semanas atrás</item>
-    </plurals>
     <plurals name="months_ago">
         <item quantity="one">%d mês atrás</item>
         <item quantity="many">%d meses atrás</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -460,11 +460,6 @@
         <item quantity="many">%d meses atrás</item>
         <item quantity="other">%d meses atrás</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d semana atrás</item>
-        <item quantity="many">%d semanas atrás</item>
-        <item quantity="other">%d semanas atrás</item>
-    </plurals>
     <plurals name="years_ago">
         <item quantity="one">%d ano atrás</item>
         <item quantity="many">%d anos atrás</item>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -448,11 +448,6 @@
         <item quantity="few">acum %d luni</item>
         <item quantity="other">acum %d de luni</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">acum %d săptămână</item>
-        <item quantity="few">acum %d săptămâni</item>
-        <item quantity="other">acum %d de săptămâni</item>
-    </plurals>
     <string name="color_violet">Violet polivalent</string>
     <string name="auto">Automat</string>
     <string name="playback_pitch">Înălțime</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -467,12 +467,6 @@
         <item quantity="many">%d лет назад</item>
         <item quantity="other">%d лет назад</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d неделю назад</item>
-        <item quantity="few">%d недели назад</item>
-        <item quantity="many">%d недель назад</item>
-        <item quantity="other">%d недель назад</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">Использовать LBRY HLS для трансляции, если доступно.</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d видео</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -462,10 +462,6 @@
         <item quantity="one">මාස %dකට පෙර</item>
         <item quantity="other">මාස %dකට පෙර</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">සති %d කට පෙර</item>
-        <item quantity="other">සති %d කට පෙර</item>
-    </plurals>
     <string name="autoplay_countdown">ස්වයංක්‍රීය වාදනය ගණන් කිරීම</string>
     <string name="playing_next">මීළඟ වීඩියෝව %1$s හි වාදනය වේ</string>
     <string name="stats_for_nerds">නර්ඩ්ස් සඳහා සංඛ්‍යාලේඛන</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -458,11 +458,6 @@
         <item quantity="few">Пре %d година</item>
         <item quantity="other">Пре %d година</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">Пре %d недељу</item>
-        <item quantity="few">Пре %d недеље</item>
-        <item quantity="other">Пре %d недеље</item>
-    </plurals>
     <plurals name="months_ago">
         <item quantity="one">Пре %d месец</item>
         <item quantity="few">Пре %d месеци</item>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -463,10 +463,6 @@
         <item quantity="one">%d ay önce</item>
         <item quantity="other">%d ay önce</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d hafta önce</item>
-        <item quantity="other">%d hafta önce</item>
-    </plurals>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d video</string>
     <string name="subscriberAndVideoCounts">%1$s abone • %2$d video</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -467,12 +467,6 @@
         <item quantity="many">%d місяців тому</item>
         <item quantity="other">%d місяців тому</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d тиждень тому</item>
-        <item quantity="few">%d тижні тому</item>
-        <item quantity="many">%d тижнів тому</item>
-        <item quantity="other">%d тижнів тому</item>
-    </plurals>
     <string name="lbry_hls_summary">Використовувати LBRY HLS для стримінгу, якщо це можливо.</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d відео</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -461,9 +461,6 @@
     <plurals name="months_ago">
         <item quantity="other">%d 个月前</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="other">%d 周前</item>
-    </plurals>
     <string name="lbry_hls_summary">若可用则使用 LBRY HLS 进行流式传输。</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d 个视频</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -458,9 +458,6 @@
     <plurals name="months_ago">
         <item quantity="other">%d 個月前</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="other">%d 週前</item>
-    </plurals>
     <string name="subscriberAndVideoCounts">%1$s 訂閱者 • %2$d 個視頻</string>
     <string name="uploaderAndVideoCount">%1$s • %2$d 個視頻</string>
     <string name="lbry_hls_summary">如果可用，請使用 LBRY HLS 進行流式傳輸。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,10 +483,6 @@
         <item quantity="one">%d month ago</item>
         <item quantity="other">%d months ago</item>
     </plurals>
-    <plurals name="weeks_ago">
-        <item quantity="one">%d week ago</item>
-        <item quantity="other">%d weeks ago</item>
-    </plurals>
     <plurals name="channel_new_streams">
         <item quantity="one">%d new stream</item>
         <item quantity="other">%d new streams</item>


### PR DESCRIPTION
Remove the week relative time formatting strings, as Android natively supports formatting relative weeks.