### PR TITLE
Removed : Social Media from Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,20 @@
   <img src="https://libre-tube.github.io/images/gh-banner.png" width="auto" height="auto" alt="LibreTube">
 
 [![GPL-v3](https://libre-tube.github.io/assets/widgets/license-widget.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
+<div align="center">
+<p> Connect us on </p>
+
 [![Matrix](https://libre-tube.github.io/assets/widgets/mat-widget.svg)](https://matrix.to/#/#LibreTube:matrix.org)
 [![Mastodon](https://libre-tube.github.io/assets/widgets/mast-widget.svg)](https://fosstodon.org/@libretube)
 [![Telegram](https://libre-tube.github.io/assets/widgets/tg-widget.svg)](https://t.me/libretube)
-[![Reddit](https://libre-tube.github.io/assets/widgets/rd-widget.svg)](https://www.reddit.com/r/Libretube/)
-[![Discord](https://libre-tube.github.io/assets/widgets/discord-widget.svg)](https://discord.gg/Qc34xCj2GV)
 
-</div><div align="center" style="width:100%; display:flex; justify-content:space-between;">
+</div>
+
+> **Note** <br>
+> We don't accept feature or bug requests on these platforms. Kindly submit requests only on GitHub.
+
+<div align="center" style="width:100%; display:flex; justify-content:space-between;">
+<p> Download from </p>
 
 [<img src="https://libre-tube.github.io/assets/badges/fdrload.png" alt="Get it on F-Droid" width="30%">](https://f-droid.org/en/packages/com.github.libretube/)
 [<img src="https://libre-tube.github.io/assets/badges/izzyload.png" alt="Get it on IzzyOnDroid" width="30%">](https://apt.izzysoft.de/fdroid/index/apk/com.github.libretube)<br/>


### PR DESCRIPTION
As per Bnyro's notification, We would like to inform you that the LibreTube community on Reddit and Discord will be removed on May 1st, as it is no longer maintained by any of the LibreTube maintainers. These media platforms will no longer be affiliated with LibreTube.

Thank you.