### PR TITLE
Removed : Social Media from Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 <div align="center">
   <img src="https://libre-tube.github.io/images/gh-banner.png" width="auto" height="auto" alt="LibreTube">
-
+  
 [![GPL-v3](https://libre-tube.github.io/assets/widgets/license-widget.svg)](https://www.gnu.org/licenses/gpl-3.0.en.html)
+</div><div align="center" style="width:100%; display:flex; justify-content:space-between;">
+
 [![Matrix](https://libre-tube.github.io/assets/widgets/mat-widget.svg)](https://matrix.to/#/#LibreTube:matrix.org)
 [![Mastodon](https://libre-tube.github.io/assets/widgets/mast-widget.svg)](https://fosstodon.org/@libretube)
 [![Telegram](https://libre-tube.github.io/assets/widgets/tg-widget.svg)](https://t.me/libretube)
-[![Reddit](https://libre-tube.github.io/assets/widgets/rd-widget.svg)](https://www.reddit.com/r/Libretube/)
-[![Discord](https://libre-tube.github.io/assets/widgets/discord-widget.svg)](https://discord.gg/Qc34xCj2GV)
+
+</div>
+
+> **Note** <br>
+> We don't accept feature or bug requests on these platforms. Kindly submit requests only on GitHub.
 
 </div><div align="center" style="width:100%; display:flex; justify-content:space-between;">
 


### PR DESCRIPTION
As per Bnyro's notification, We would like to inform you that the LibreTube community on Reddit and Discord will be removed on May 1st, as it is no longer maintained by any of the LibreTube maintainers. These media platforms will no longer be affiliated with LibreTube.

Thank you.