### PR TITLE
Improvement to links in description and comment texts.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
@@ -79,10 +79,6 @@ class CommentsAdapter(
             commentText.text = comment.commentText?.replace("</a>", "</a> ")
                 ?.parseAsHtml(tagHandler = HtmlParser(LinkHandler(handleLink ?: {})))
 
-            commentText.setOnClickListener {
-                navigateToReplies(comment)
-            }
-
             ImageHelper.loadImage(comment.thumbnail, commentorImage)
             likesTextView.text = comment.likeCount.formatShort()
 
@@ -119,6 +115,9 @@ class CommentsAdapter(
 
             if (!isRepliesAdapter && comment.repliesPage != null) {
                 root.setOnClickListener {
+                    navigateToReplies(comment)
+                }
+                commentText.setOnClickListener {
                     navigateToReplies(comment)
                 }
             }

--- a/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
@@ -1,8 +1,6 @@
 package com.github.libretube.ui.adapters
 
 import android.annotation.SuppressLint
-import android.os.Handler
-import android.os.Looper
 import android.text.method.LinkMovementMethod
 import android.view.*
 import android.view.ViewGroup.MarginLayoutParams
@@ -78,7 +76,7 @@ class CommentsAdapter(
             commentInfos.text = comment.author + TextUtils.SEPARATOR + comment.commentedTime
 
             commentText.movementMethod = LinkMovementMethod.getInstance()
-            commentText.text = comment.commentText
+            commentText.text = comment.commentText?.replace("</a>", "</a> ")
                 ?.parseAsHtml(tagHandler = HtmlParser(LinkHandler(handleLink ?: {})))
 
             commentText.setOnClickListener {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -110,10 +110,6 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.exoplayer2.util.MimeTypes
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import java.io.IOException
-import java.util.*
-import java.util.concurrent.Executors
-import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -122,6 +118,10 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import retrofit2.HttpException
+import java.io.IOException
+import java.util.*
+import java.util.concurrent.Executors
+import kotlin.math.abs
 
 class PlayerFragment : Fragment(), OnlinePlayerOptions {
     private var _binding: FragmentPlayerBinding? = null
@@ -1087,7 +1087,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         // detect whether the description is html formatted
         if (description.contains("<") && description.contains(">")) {
             descTextView.movementMethod = LinkMovementMethod.getInstance()
-            descTextView.text = description
+            descTextView.text = description.replace("</a>", "</a> ")
                 .parseAsHtml(tagHandler = HtmlParser(LinkHandler(this::handleLink)))
         } else {
             // Links can be present as plain text


### PR DESCRIPTION
Closes #3659
Closes #3638 (This fix may work only for html formatted links)

Your PR #3658 creates another problem - Replies fragment will only open when clicked twice on the comment. This PR does not address this issue.