### PR TITLE
refactor(UI): increase scrubber size

### DIFF
--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -335,8 +335,8 @@
                 app:bar_height="2dp"
                 app:played_color="?attr/colorSecondary"
                 app:scrubber_color="?attr/colorSecondary"
-                app:scrubber_dragged_size="16dp"
-                app:scrubber_enabled_size="12dp" />
+                app:scrubber_dragged_size="24dp"
+                app:scrubber_enabled_size="18dp" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Currently the seek button is frustratingly small and even with smaller hands one has to tap the screen a few times before being able to actually use it. This increases the button size by 1.5 factor.