### PR TITLE
Avoid possible PIP-related exception on API levels below 33.

### DIFF
--- a/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
+++ b/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 
 object PictureInPictureCompat {
     fun isPictureInPictureAvailable(context: Context): Boolean {
@@ -18,7 +17,6 @@ object PictureInPictureCompat {
 
     fun setPictureInPictureParams(activity: Activity, params: PictureInPictureParamsCompat) {
         if (isPictureInPictureAvailable(activity)) {
-            if (params.toPictureInPictureParams().actions.isEmpty()) throw IllegalArgumentException()
             activity.setPictureInPictureParams(params.toPictureInPictureParams())
         }
     }


### PR DESCRIPTION
The [`PictureInPictureParams#getActions`](https://developer.android.com/reference/android/app/PictureInPictureParams#getActions()) method is only available on API 33 and later, so an error would be thrown on earlier Android versions.