### PR TITLE
Disable search closing when user press back while playing video

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -354,7 +354,9 @@ class MainActivity : BaseActivity() {
                     this@MainActivity.onBackPressedDispatcher.onBackPressed()
                 }
 
-                return true
+                // Suppress collapsing of search view here.
+                // It will close when search fragment will close, so its safe to return false here
+                return false
             }
         })
         return super.onCreateOptionsMenu(menu)


### PR DESCRIPTION
Issue #1965:
* Search for something
* Play the video
* Clicking back btn would close the search also

Fix:
Disable auto close of search in onMenuItemActionCollapse method call. Search will close when search fragment is removed.

Known Issues:
Search will still close when player fragment is closed.