### PR TITLE
Fix search bar collapse while search in progress

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -280,6 +280,22 @@ class MainActivity : BaseActivity() {
         return super.onPrepareOptionsMenu(menu)
     }
 
+    private fun isSearchInProgress(): Boolean {
+        if (!::navController.isInitialized) return false
+        val id = navController.currentDestination?.id ?: return false
+        return id in listOf(R.id.searchFragment, R.id.searchResultFragment)
+    }
+
+    override fun invalidateMenu() {
+        // Don't invalidate menu when in search in progress
+        // this is a workaround as there is bug in android code
+        // details of bug: https://issuetracker.google.com/issues/244336571
+        if (isSearchInProgress()) {
+            return
+        }
+        super.invalidateMenu()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.action_bar, menu)
@@ -354,9 +370,8 @@ class MainActivity : BaseActivity() {
                     this@MainActivity.onBackPressedDispatcher.onBackPressed()
                 }
 
-                // Suppress collapsing of search view here.
-                // It will close when search fragment will close, so its safe to return false here
-                return false
+                // Suppress collapsing of search when search in progress.
+                return !isSearchInProgress()
             }
         })
         return super.onCreateOptionsMenu(menu)


### PR DESCRIPTION
This is an AOSP bug where destroy of fragment calls invalideMenu of Activity even though the fragment does not participate in menu updates.

https://issuetracker.google.com/issues/244336571

Hence added an workaroud to not invalidate menu when search is in progress.

Closes #1965 