### PR TITLE
Enable auto rotate by default in TV

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -54,7 +54,12 @@ class MainActivity : BaseActivity() {
     lateinit var navController: NavController
     private var startFragmentId = R.id.homeFragment
 
-    val autoRotationEnabled = PreferenceHelper.getBoolean(PreferenceKeys.AUTO_ROTATION, false)
+    val autoRotationEnabled: Boolean by lazy {
+        PreferenceHelper.getBoolean(
+            PreferenceKeys.AUTO_ROTATION,
+            resources.getBoolean(R.bool.config_default_auto_rotation_pref)
+        )
+    }
 
     lateinit var searchView: SearchView
     private lateinit var searchItem: MenuItem

--- a/app/src/main/res/values-television/config.xml
+++ b/app/src/main/res/values-television/config.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="config_default_auto_rotation_pref">true</bool>
+</resources>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -1,0 +1,3 @@
+<resources>
+    <bool name="config_default_auto_rotation_pref">false</bool>
+</resources>

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -31,7 +31,7 @@
             app:key="audio_only_mode" />
 
         <SwitchPreferenceCompat
-            android:defaultValue="false"
+            android:defaultValue="@bool/config_default_auto_rotation_pref"
             android:icon="@drawable/ic_screen_rotation"
             app:key="auto_rotation"
             app:title="@string/auto_rotation" />


### PR DESCRIPTION
Set auto-rotation ON by default in TV

Tested on below two emulators:
Android TV, API 30 -- auto rotation enabled by default and opened in landscape mode
Pixel 2 API 32 with GMS -- auto rotation disabled by default and opened in portrait mode