### PR TITLE
Use DASH in the audio only/background player

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1329,15 +1329,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                 val uri = streams.dash?.let { ProxyHelper.unwrapIfEnabled(it) }?.toUri().takeIf {
                     streams.livestream || streams.videoStreams.isEmpty()
                 } ?: let {
-                    val manifest = DashHelper.createManifest(
-                        streams,
-                        DisplayHelper.supportsHdr(requireContext()),
-                    )
-
-                    // encode to base64
-                    val encoded = Base64.encodeToString(manifest.toByteArray(), Base64.DEFAULT)
-
-                    "data:application/dash+xml;charset=utf-8;base64,$encoded".toUri()
+                    PlayerHelper.createDashSource(streams, requireContext())
                 }
 
                 this.setMediaSource(uri, MimeTypes.APPLICATION_MPD)

--- a/app/src/main/res/xml/audio_video_settings.xml
+++ b/app/src/main/res/xml/audio_video_settings.xml
@@ -13,6 +13,7 @@
             app:title="@string/defres"
             app:useSimpleSummaryProvider="true" />
 
+        <!--
         <ListPreference
             android:icon="@drawable/ic_headphones"
             app:defaultValue="best"
@@ -21,6 +22,7 @@
             app:key="player_audio_quality"
             app:title="@string/playerAudioQuality"
             app:useSimpleSummaryProvider="true" />
+        -->
 
     </PreferenceCategory>
 
@@ -35,6 +37,7 @@
             app:title="@string/defres"
             app:useSimpleSummaryProvider="true" />
 
+        <!--
         <ListPreference
             android:icon="@drawable/ic_headphones"
             app:defaultValue="best"
@@ -43,6 +46,7 @@
             app:key="player_audio_quality_mobile"
             app:title="@string/playerAudioQuality"
             app:useSimpleSummaryProvider="true" />
+        -->
 
     </PreferenceCategory>
 


### PR DESCRIPTION
This significantly improves the loading times when playing audio in the background.
Note that this change requires us to disable the audio quality preference for now, it can be re-enabled later (when we added some logic to select audio tracks in the audio player mode) theoretically.