### PR TITLE
Fix: MainActivity crash after icon change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,19 +80,30 @@
             android:screenOrientation="user"
             android:supportsPictureInPicture="true"
             android:windowSoftInputMode="adjustPan">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-            </intent-filter>
-
             <!-- allow being recognized as a music player -->
             <intent-filter>
                 <action android:name="android.intent.action.MUSIC_PLAYER" />
                 <category android:name="android.intent.category.CATEGORY_APP_MUSIC" />
             </intent-filter>
         </activity>
+
+        <activity-alias
+            android:name=".Default"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
+            android:enabled="true"
+            android:exported="true"
+            android:icon="@mipmap/ic_launcher"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsPictureInPicture="true"
+            android:targetActivity=".ui.activities.MainActivity"
+            android:windowSoftInputMode="adjustPan" >
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+
+            <category android:name="android.intent.category.LAUNCHER" />
+            <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+        </intent-filter>
+        </activity-alias>
 
         <activity-alias
             android:name=".IconGradient"

--- a/app/src/main/java/com/github/libretube/ui/adapters/IconsSheetAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/IconsSheetAdapter.kt
@@ -41,7 +41,7 @@ class IconsSheetAdapter : RecyclerView.Adapter<IconsSheetViewHolder>() {
             val activityAlias: String,
         ) {
             object Default :
-                AppIcon(R.string.defaultIcon, R.mipmap.ic_launcher, "ui.activities.MainActivity")
+                AppIcon(R.string.defaultIcon, R.mipmap.ic_launcher, "Default")
 
             object DefaultLight :
                 AppIcon(R.string.defaultIconLight, R.mipmap.ic_launcher_light, "DefaultLight")


### PR DESCRIPTION
Fix ActivityNotFoundException for the main activity by creating a default activity alias and keeping `.MainActivity` enabled.

closes #3092 
closes #3703 
closes #3960 

However for #3960 I don’t think it’s possible to restore the default icon, but in `WelcomeActivity` we can restore it on the first launch.