### PR TITLE
Miniplayer is not showing properly in release build

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -106,3 +106,7 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# Fix for miniplayer placing issue in release build
+-keep class androidx.constraintlayout.motion.widget.** { *; }
+-keepclassmembers class androidx.constraintlayout.motion.widget.** { *; }


### PR DESCRIPTION
Upon analysis found below error
java.lang.NoSuchMethodException:
  androidx.constraintlayout.motion.widget.KeyAttributes.\<init\> []
Added proguard rules, not able to reproduce the issue with this change.

Fixes #3861