### PR TITLE
Fix: hide the nothing here indicator when refreshing home page

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -84,6 +84,7 @@ class HomeFragment : Fragment() {
     private fun fetchHomeFeed() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
+                binding.nothingHere.isGone = true
                 val defaultItems = resources.getStringArray(R.array.homeTabItemsValues)
                 val visibleItems = PreferenceHelper
                     .getStringSet(PreferenceKeys.HOME_TAB_CONTENT, defaultItems.toSet())


### PR DESCRIPTION
closes #4123