### PR TITLE
Update Activity and Fragment dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,9 +81,11 @@ dependencies {
     //debugImplementation libs.square.leakcanary
 
     /* Android Core */
+    implementation libs.androidx.activity
     implementation libs.androidx.appcompat
     implementation libs.androidx.core
     implementation libs.androidx.constraintlayout
+    implementation libs.androidx.fragment
     implementation libs.androidx.legacySupport
     implementation libs.androidx.navigation.fragment
     implementation libs.androidx.navigation.ui

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,11 +21,15 @@ kotlinxSerialization = "1.5.1"
 kotlinxDatetime = "0.4.0"
 kotlinxRetrofit = "1.0.0"
 media3 = "1.1.0"
+activity = "1.7.2"
+fragment = "1.6.0"
 
 [libraries]
+androidx-activity = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-core = { group = "androidx.core", name = "core", version.ref = "core" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigation" }
 androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigation" }


### PR DESCRIPTION
Update the AndroidX Activity and Fragment dependencies to their latest versions ([Activity changelog](https://developer.android.com/jetpack/androidx/releases/activity#1.7.0), [Fragment changelog](https://developer.android.com/jetpack/androidx/releases/fragment#1.6.0))