### PR TITLE
Replace MathUtils.clamp with Kotlin coerceIn

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/AudioHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/AudioHelper.kt
@@ -3,7 +3,6 @@ package com.github.libretube.helpers
 import android.content.Context
 import android.media.AudioManager
 import androidx.core.content.getSystemService
-import androidx.core.math.MathUtils
 import androidx.media.AudioManagerCompat
 import com.github.libretube.extensions.normalize
 
@@ -16,7 +15,7 @@ class AudioHelper(context: Context) {
     var volume: Int
         get() = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC) - minimumVolumeIndex
         set(value) {
-            val vol = MathUtils.clamp(value, minimumVolumeIndex, maximumVolumeIndex)
+            val vol = value.coerceIn(minimumVolumeIndex, maximumVolumeIndex)
             audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, vol, 0)
         }
 

--- a/app/src/main/java/com/github/libretube/ui/listeners/SeekbarPreviewListener.kt
+++ b/app/src/main/java/com/github/libretube/ui/listeners/SeekbarPreviewListener.kt
@@ -4,7 +4,6 @@ import android.text.format.DateUtils
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.graphics.drawable.toBitmap
-import androidx.core.math.MathUtils
 import androidx.core.view.updateLayoutParams
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.TimeBar
@@ -98,7 +97,7 @@ class SeekbarPreviewListener(
                 playerBinding.seekbarPreview.width / 2
             // normalize the offset to keep a minimum distance at left and right
             val maxPadding = parentWidth - MIN_PADDING - playerBinding.seekbarPreview.width
-            marginStart = MathUtils.clamp(offset.toInt(), MIN_PADDING, maxPadding)
+            marginStart = offset.toInt().coerceIn(MIN_PADDING, maxPadding)
         }
     }
 


### PR DESCRIPTION
Just so you can see it's the same:

MathUtils.clamp function:
```
public static int clamp(int value, int min, int max) {
    if (value < min) {
        return min;
    } else if (value > max) {
        return max;
    }
    return value;
}
```

Kotlin's coerceIn extension function:
```
public fun Int.coerceIn(minimumValue: Int, maximumValue: Int): Int {
    if (minimumValue > maximumValue) throw IllegalArgumentException("Cannot coerce value to an empty range: maximum $maximumValue is less than minimum $minimumValue.")
    if (this < minimumValue) return minimumValue
    if (this > maximumValue) return maximumValue
    return this
}
```