### PR TITLE
fix: duplicate comments

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -81,7 +81,6 @@ class CommentsMainFragment : Fragment() {
             binding.commentsRV.scrollToPosition(viewModel.currentCommentsPosition)
         }
 
-
         // listen for new comments to be loaded
         viewModel.commentsPage.observe(viewLifecycleOwner) {
             if (it == null) return@observe

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -81,6 +81,7 @@ class CommentsMainFragment : Fragment() {
             binding.commentsRV.scrollToPosition(viewModel.currentCommentsPosition)
         }
 
+
         // listen for new comments to be loaded
         viewModel.commentsPage.observe(viewLifecycleOwner) {
             if (it == null) return@observe
@@ -98,6 +99,11 @@ class CommentsMainFragment : Fragment() {
                 binding.errorTV.isVisible = true
                 return@observe
             }
+
+            // sometimes the received comments have the same size as the existing ones
+            // which causes comments.subList to throw InvalidArgumentException
+            if (commentsAdapter.itemCount > it.comments.size) return@observe
+
             commentsAdapter.updateItems(
                 // only add the new comments to the recycler view
                 it.comments.subList(commentsAdapter.itemCount, it.comments.size)

--- a/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
@@ -56,9 +56,16 @@ class CommentsViewModel : ViewModel() {
                 Log.e(TAG(), e.toString())
                 return@launch
             }
+
             val updatedPage = commentsPage.value?.apply {
-                comments += response.comments.filterNonEmptyComments()
+                val combinedComments = this.comments + response.comments.filterNonEmptyComments()
+
+                // filtering out the comments that have the same id (duplicated)
+                this.comments = combinedComments.groupBy { it.commentId }
+                    .filter { it.value.size == 1 }
+                    .flatMap { it.value }
             }
+
             nextPage = response.nextpage
             commentsPage.postValue(updatedPage)
             isLoading = false

--- a/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
@@ -58,12 +58,9 @@ class CommentsViewModel : ViewModel() {
             }
 
             val updatedPage = commentsPage.value?.apply {
-                val combinedComments = this.comments + response.comments.filterNonEmptyComments()
-
-                // filtering out the comments that have the same id (duplicated)
-                this.comments = combinedComments.groupBy { it.commentId }
-                    .filter { it.value.size == 1 }
-                    .flatMap { it.value }
+                comments += response.comments
+                    .filterNonEmptyComments()
+                    .filter { comment -> comments.none { it.commentId == comment.commentId } }
             }
 
             nextPage = response.nextpage


### PR DESCRIPTION
Fix #4291

Sometimes, the Piped API's response contains comments that were already given in previous pages, so I have added a filter to remove them.

This might not be the best way to do it, but this is my first time working with Kotlin/Android because I found this bug annoying and wanted to do whatever it takes to fix it, so if there is a better way, please do it.

:)