### PR TITLE
feat: Show channel icons for stream notifications

### DIFF
--- a/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
+++ b/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
@@ -205,6 +205,7 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .setGroup(group)
+            .setCategory(Notification.CATEGORY_SOCIAL)
     }
 
     companion object {


### PR DESCRIPTION
* Download and display channel icons for the stream summary notifications. This only occurs if thumbnails are enabled.
* Use the [social category](https://developer.android.com/reference/android/app/Notification#CATEGORY_SOCIAL) for stream notifications.

**Screenshots**
![Screenshot_20230811_065654](https://github.com/libre-tube/LibreTube/assets/31027858/30e472cb-ec20-437c-8af2-d7cf49990a42)
