### PR TITLE
refactor: Use LocalDate.ofInstant()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId 'com.github.libretube'

--- a/app/src/main/java/com/github/libretube/ui/listeners/AudioPlayerThumbnailListener.kt
+++ b/app/src/main/java/com/github/libretube/ui/listeners/AudioPlayerThumbnailListener.kt
@@ -47,12 +47,12 @@ class AudioPlayerThumbnailListener(context: Context, private val listener: Audio
         }
 
         override fun onScroll(
-            e1: MotionEvent,
+            e1: MotionEvent?,
             e2: MotionEvent,
             distanceX: Float,
             distanceY: Float
         ): Boolean {
-            val insideThreshHold = abs(e2.y - e1.y) <= MOVEMENT_THRESHOLD
+            val insideThreshHold = abs(e2.y - e1!!.y) <= MOVEMENT_THRESHOLD
 
             // If the movement is inside threshold or scroll is horizontal then return false
             if (!isMoving && (insideThreshHold || abs(distanceX) > abs(distanceY))) {

--- a/app/src/main/java/com/github/libretube/ui/listeners/PlayerGestureController.kt
+++ b/app/src/main/java/com/github/libretube/ui/listeners/PlayerGestureController.kt
@@ -135,14 +135,14 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
         }
 
         override fun onScroll(
-            e1: MotionEvent,
+            e1: MotionEvent?,
             e2: MotionEvent,
             distanceX: Float,
             distanceY: Float
         ): Boolean {
             if (!isEnabled || scaleGestureDetector.isInProgress) return false
 
-            val insideThreshHold = abs(e2.y - e1.y) <= MOVEMENT_THRESHOLD
+            val insideThreshHold = abs(e2.y - e1!!.y) <= MOVEMENT_THRESHOLD
             val insideBorder =
                 (e1.x < BORDER_THRESHOLD || e1.y < BORDER_THRESHOLD || e1.x > width - BORDER_THRESHOLD || e1.y > height - BORDER_THRESHOLD)
 

--- a/app/src/main/java/com/github/libretube/ui/views/SingleViewTouchableMotionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/SingleViewTouchableMotionLayout.kt
@@ -58,7 +58,7 @@ class SingleViewTouchableMotionLayout(context: Context, attributeSet: AttributeS
         }
 
         override fun onScroll(
-            e1: MotionEvent,
+            e1: MotionEvent?,
             e2: MotionEvent,
             distanceX: Float,
             distanceY: Float

--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -64,9 +64,7 @@ object TextUtils {
     }
 
     fun formatRelativeDate(context: Context, unixTime: Long): CharSequence {
-        // TODO: Use LocalDate.ofInstant() when it is available in SDK 34.
-        val date = LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTime), ZoneId.systemDefault())
-            .toLocalDate()
+        val date = LocalDate.ofInstant(Instant.ofEpochMilli(unixTime), ZoneId.systemDefault())
         val now = LocalDate.now()
         val months = date.until(now, ChronoUnit.MONTHS)
 


### PR DESCRIPTION
* Bump compile SDK to 34 (sources are now available for download).
* Use [`LocalDate.ofInstant()`](https://developer.android.com/reference/java/time/LocalDate#ofInstant(java.time.Instant,%20java.time.ZoneId)).