### PR TITLE
fix: hide add to queue option for playlists when queue empty

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaylistOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaylistOptionsBottomSheet.kt
@@ -32,9 +32,10 @@ class PlaylistOptionsBottomSheet(
     override fun onCreate(savedInstanceState: Bundle?) {
         // options for the dialog
         val optionsList = mutableListOf(
-            getString(R.string.playOnBackground),
-            getString(R.string.add_to_queue)
+            getString(R.string.playOnBackground)
         )
+
+        if (PlayingQueue.isNotEmpty()) optionsList.add(getString(R.string.add_to_queue))
 
         val isBookmarked = runBlocking(Dispatchers.IO) {
             DatabaseHolder.Database.playlistBookmarkDao().includes(playlistId)


### PR DESCRIPTION
closes #4429