### PR TITLE
fix(import): prevent crash when importing

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ImportHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImportHelper.kt
@@ -23,6 +23,7 @@ import kotlin.streams.toList
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
+import java.util.stream.Collectors
 
 object ImportHelper {
     /**
@@ -79,7 +80,7 @@ object ImportHelper {
                     it.bufferedReader().use { reader ->
                         reader.lines().map { line -> line.substringBefore(",") }
                             .filter { channelId -> channelId.length == 24 }
-                            .toList()
+                            .collect(Collectors.toList())
                     }
                 }.orEmpty()
             }


### PR DESCRIPTION
Closes https://github.com/libre-tube/LibreTube/issues/4453.
Because `.toList` is not available on Java < 16, importing a CSV file fail. Using `.collect(Collectors.toList())` fixes the error and allows the user to correctly import the data.