### PR TITLE
feat(player): allow pausing when loading

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -159,7 +159,7 @@ open class CustomExoPlayerView(
                     player?.seekTo(0)
                 }
 
-                player?.isPlaying == false -> player?.play()
+                player?.isPlaying == false && player?.isLoading == false -> player?.play()
                 else -> player?.pause()
             }
         }


### PR DESCRIPTION
Allows to pause the player, while the video is buffering. This can be helpful if the video is constantly buffering, to load a longer timeframe. It is also helpful when simply wanting to pause the video while it is buffering.

To test:
1. Start watching a video
2. Turn off the network
3. Wait until the video starts to buffer
4. Pause the video and turn the network back on
5. Notice how the video does not start playing again once it finished loading