### PR TITLE
feat(channelGroups): disable confirm button if creation is not possible

### DIFF
--- a/app/src/main/java/com/github/libretube/db/dao/SubscriptionGroupsDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/SubscriptionGroupsDao.kt
@@ -11,6 +11,9 @@ interface SubscriptionGroupsDao {
     @Query("SELECT * FROM subscriptionGroups")
     suspend fun getAll(): List<SubscriptionGroup>
 
+    @Query("SELECT EXISTS(SELECT * FROM subscriptionGroups WHERE name = :name)")
+    suspend fun exists(name: String): Boolean
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun createGroup(subscriptionGroup: SubscriptionGroup)
 

--- a/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
@@ -9,6 +9,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.api.SubscriptionHelper
 import com.github.libretube.api.obj.Subscription
 import com.github.libretube.databinding.DialogEditChannelGroupBinding
@@ -38,6 +39,10 @@ class EditChannelGroupSheet(
         binding.channelsRV.layoutManager = LinearLayoutManager(context)
         fetchSubscriptions()
 
+        binding.groupName.addTextChangedListener {
+            updateConfirmStatus()
+        }
+
         binding.searchInput.addTextChangedListener {
             showChannels(channels, it?.toString())
         }
@@ -46,6 +51,7 @@ class EditChannelGroupSheet(
             dismiss()
         }
 
+        updateConfirmStatus()
         binding.confirm.setOnClickListener {
             group.name = binding.groupName.text.toString()
             if (group.name.isBlank()) return@setOnClickListener
@@ -78,8 +84,23 @@ class EditChannelGroupSheet(
             group
         ) {
             group = it
+            updateConfirmStatus()
         }
         binding.subscriptionsContainer.isVisible = true
         binding.progress.isVisible = false
+    }
+
+    private fun updateConfirmStatus() {
+        with(binding) {
+            val isGroupNameBlank = groupName.text?.isBlank() == true
+
+            groupName.error = if (isGroupNameBlank) {
+                requireContext().getString(R.string.group_name_error)
+            } else {
+                null
+            }
+
+            confirm.isEnabled = !isGroupNameBlank && group.channels.isNotEmpty()
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,7 @@
     <string name="channel_groups">Channel groups</string>
     <string name="new_group">New</string>
     <string name="group_name">Group name</string>
+    <string name="group_name_error">Please enter a name</string>
     <string name="edit_group">Edit group</string>
     <string name="play_automatically">Play automatically</string>
     <string name="play_automatically_summary">Start playing video automatically when selecting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,7 +406,8 @@
     <string name="channel_groups">Channel groups</string>
     <string name="new_group">New</string>
     <string name="group_name">Group name</string>
-    <string name="group_name_error">Please enter a name</string>
+    <string name="group_name_error_empty">Please enter a name</string>
+    <string name="group_name_error_exists">Please choose a name that is unique</string>
     <string name="edit_group">Edit group</string>
     <string name="play_automatically">Play automatically</string>
     <string name="play_automatically_summary">Start playing video automatically when selecting</string>


### PR DESCRIPTION
Disables the confirm button when creating or modifying a channel group if the group cannot be created. This can either be the case if the group name is empty, or (newly added) no channels are selected.

![Disabled confirm button with error text](https://github.com/libre-tube/LibreTube/assets/63370021/3a371c16-cac5-4fc7-b8ac-2e107c568164)
![Enabled confirm button](https://github.com/libre-tube/LibreTube/assets/63370021/a740e82e-a59b-41d6-9def-d515bedbdf82)

addresses #3558