### PR TITLE
feat(channelGroups): allow re-ordering of groups

### DIFF
--- a/app/schemas/com.github.libretube.db.AppDatabase/14.json
+++ b/app/schemas/com.github.libretube.db.AppDatabase/14.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 13,
-    "identityHash": "a07f3a23fa32cba2d80830e903c145c4",
+    "version": 14,
+    "identityHash": "4b4658954c6632e2aa1ebd25a9d7c731",
     "entities": [
       {
         "tableName": "watchHistoryItem",
@@ -474,7 +474,7 @@
       },
       {
         "tableName": "subscriptionGroups",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `channels` TEXT NOT NULL, `index` INTEGER, PRIMARY KEY(`name`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `channels` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`name`))",
         "fields": [
           {
             "fieldPath": "name",
@@ -492,7 +492,7 @@
             "fieldPath": "index",
             "columnName": "index",
             "affinity": "INTEGER",
-            "notNull": false
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -508,7 +508,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a07f3a23fa32cba2d80830e903c145c4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4b4658954c6632e2aa1ebd25a9d7c731')"
     ]
   }
 }

--- a/app/src/main/java/com/github/libretube/api/obj/Instances.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Instances.kt
@@ -16,5 +16,5 @@ data class Instances(
     @SerialName("cache") val chache: Boolean = false,
     @SerialName("s3_enabled") val s3Enabled: Boolean = false,
     @SerialName("image_proxy_url") val imageProxyUrl: String = "",
-    @SerialName("registration_disabled") val registrationDisabled: Boolean = false,
+    @SerialName("registration_disabled") val registrationDisabled: Boolean = false
 )

--- a/app/src/main/java/com/github/libretube/db/AppDatabase.kt
+++ b/app/src/main/java/com/github/libretube/db/AppDatabase.kt
@@ -39,7 +39,7 @@ import com.github.libretube.db.obj.WatchPosition
         DownloadItem::class,
         SubscriptionGroup::class
     ],
-    version = 13,
+    version = 14,
     autoMigrations = [
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),

--- a/app/src/main/java/com/github/libretube/db/DatabaseHolder.kt
+++ b/app/src/main/java/com/github/libretube/db/DatabaseHolder.kt
@@ -23,9 +23,17 @@ object DatabaseHolder {
         }
     }
 
+    private val MIGRATION_13_14 = object : Migration(13, 14) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                "ALTER TABLE 'subscriptionGroups' ADD COLUMN 'index' INTEGER NOT NULL DEFAULT 0"
+            )
+        }
+    }
+
     val Database by lazy {
         Room.databaseBuilder(LibreTubeApp.instance, AppDatabase::class.java, DATABASE_NAME)
-            .addMigrations(MIGRATION_11_12, MIGRATION_12_13)
+            .addMigrations(MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/app/src/main/java/com/github/libretube/db/dao/SubscriptionGroupsDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/SubscriptionGroupsDao.kt
@@ -4,11 +4,12 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.github.libretube.db.obj.SubscriptionGroup
 
 @Dao()
 interface SubscriptionGroupsDao {
-    @Query("SELECT * FROM subscriptionGroups")
+    @Query("SELECT * FROM subscriptionGroups ORDER BY `index` ASC")
     suspend fun getAll(): List<SubscriptionGroup>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -16,6 +17,9 @@ interface SubscriptionGroupsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(subscriptionGroups: List<SubscriptionGroup>)
+
+    @Update
+    suspend fun updateAll(subscriptionGroups: List<SubscriptionGroup>)
 
     @Query("DELETE FROM subscriptionGroups WHERE name = :name")
     suspend fun deleteGroup(name: String)

--- a/app/src/main/java/com/github/libretube/db/obj/SubscriptionGroup.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/SubscriptionGroup.kt
@@ -8,5 +8,6 @@ import kotlinx.serialization.Serializable
 @Entity(tableName = "subscriptionGroups")
 data class SubscriptionGroup(
     @PrimaryKey var name: String,
-    var channels: List<String>
+    var channels: List<String>,
+    var index: Int
 )

--- a/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
@@ -31,8 +31,10 @@ class InstancesAdapter(
         holder.binding.apply {
             var instanceText = "${instance.name}   ${instance.locations}"
             if (instance.cdn) instanceText += "   (\uD83C\uDF10 CDN)"
-            if (instance.registrationDisabled) instanceText +=
-                "   (${root.context.getString(R.string.registration_disabled)})"
+            if (instance.registrationDisabled) {
+                instanceText +=
+                    "   (${root.context.getString(R.string.registration_disabled)})"
+            }
             radioButton.text = instanceText
             radioButton.setOnCheckedChangeListener(null)
             radioButton.isChecked = selectedInstanceIndex == position

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -187,6 +187,7 @@ class SubscriptionsFragment : Fragment() {
         binding.channelGroups.removeAllViews()
 
         binding.channelGroups.addView(binding.chipAll)
+        channelGroups = channelGroups.sortedBy { subscriptionGroup -> subscriptionGroup.index }
         channelGroups.forEach { group ->
             val chip = layoutInflater.inflate(R.layout.filter_chip, null) as Chip
             chip.apply {

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -187,7 +187,7 @@ class SubscriptionsFragment : Fragment() {
         binding.channelGroups.removeAllViews()
 
         binding.channelGroups.addView(binding.chipAll)
-        channelGroups = channelGroups.sortedBy { subscriptionGroup -> subscriptionGroup.index }
+        channelGroups = channelGroups.sortedBy { it.index }
         channelGroups.forEach { group ->
             val chip = layoutInflater.inflate(R.layout.filter_chip, null) as Chip
             chip.apply {

--- a/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
@@ -64,7 +64,7 @@ class ChannelGroupsSheet(
                 groups.move(from, to)
                 adapter.notifyItemMoved(from, to)
 
-                groups.mapIndexed { index, subscriptionGroup -> subscriptionGroup.index = index }
+                groups.forEachIndexed { index, subscriptionGroup -> subscriptionGroup.index = index }
                 runBlocking(Dispatchers.IO) {
                     DatabaseHolder.Database.subscriptionGroupsDao().updateAll(groups)
                 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
@@ -64,7 +64,7 @@ class ChannelGroupsSheet(
                 groups.move(from, to)
                 adapter.notifyItemMoved(from, to)
 
-                groups.forEachIndexed { index, subscriptionGroup -> subscriptionGroup.index = index }
+                groups.forEachIndexed { index, group -> group.index = index }
                 runBlocking(Dispatchers.IO) {
                     DatabaseHolder.Database.subscriptionGroupsDao().updateAll(groups)
                 }

--- a/app/src/main/res/layout/subscription_group_row.xml
+++ b/app/src/main/res/layout/subscription_group_row.xml
@@ -6,6 +6,13 @@
     android:paddingHorizontal="5dp"
     android:paddingVertical="10dp">
 
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginHorizontal="10dp"
+        android:src="@drawable/ic_drag" />
+
     <TextView
         android:id="@+id/group_name"
         android:layout_width="0dp"
@@ -31,12 +38,5 @@
         android:layout_marginHorizontal="10dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:src="@drawable/ic_delete" />
-
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginHorizontal="10dp"
-        android:src="@drawable/ic_drag" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/subscription_group_row.xml
+++ b/app/src/main/res/layout/subscription_group_row.xml
@@ -32,4 +32,11 @@
         android:background="?attr/selectableItemBackgroundBorderless"
         android:src="@drawable/ic_delete" />
 
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginHorizontal="10dp"
+        android:src="@drawable/ic_drag" />
+
 </LinearLayout>


### PR DESCRIPTION
Addresses https://github.com/libre-tube/LibreTube/issues/3558 by allowing channel groups to be rearranged using DnD.

https://github.com/libre-tube/LibreTube/assets/63370021/18d7fbe8-08ff-4feb-a13b-6f18ffeebf1a

This will currently update all groups in the database, this may cause problems with larger sets of groups, in which case it may be worth checking which groups need updating.
Due to the other issues listed in https://github.com/libre-tube/LibreTube/issues/3558 with the Ui, I did not add drag handles.