### PR TITLE
feat(settings): move proxy settings to instance page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,6 +399,7 @@
     <string name="playing_next">Playing next in %1$s</string>
     <string name="lbry_hls">LBRY HLS</string>
     <string name="lbry_hls_summary">Use LBRY HLS for streaming if available.</string>
+    <string name="proxy">Proxy</string>
     <string name="disable_proxy">Disable Piped proxy</string>
     <string name="disable_proxy_summary">Load videos and images directly from YouTube\'s servers. Only enable the option if you use a VPN anyways!</string>
     <string name="auto_fullscreen_shorts">Auto fullscreen on short videos</string>

--- a/app/src/main/res/xml/audio_video_settings.xml
+++ b/app/src/main/res/xml/audio_video_settings.xml
@@ -95,22 +95,6 @@
             app:title="@string/codecs"
             app:useSimpleSummaryProvider="true" />
 
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:icon="@drawable/ic_server"
-            android:summary="@string/disable_proxy_summary"
-            android:title="@string/disable_proxy"
-            app:key="disable_video_image_proxy" />
-
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:dependency="disable_video_image_proxy"
-            android:icon="@drawable/ic_music"
-            android:summary="@string/fallback_piped_proxy_desc"
-            android:title="@string/fallback_piped_proxy"
-            app:defaultValue="true"
-            app:key="fallback_piped_proxy" />
-
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/app/src/main/res/xml/instance_settings.xml
+++ b/app/src/main/res/xml/instance_settings.xml
@@ -64,4 +64,24 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="@string/proxy">
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:icon="@drawable/ic_server"
+            android:summary="@string/disable_proxy_summary"
+            android:title="@string/disable_proxy"
+            app:key="disable_video_image_proxy" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:dependency="disable_video_image_proxy"
+            android:icon="@drawable/ic_music"
+            android:summary="@string/fallback_piped_proxy_desc"
+            android:title="@string/fallback_piped_proxy"
+            app:defaultValue="true"
+            app:key="fallback_piped_proxy" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Moves the option to disable the piped proxy to the instance settings page. The proxy preferences align better with the instance settings, given they refer more to video loading than to audio and video configurations. A newcomer might equate proxy settings to "Avoid using a piped instance."

![Instance settings with proxy settings](https://github.com/libre-tube/LibreTube/assets/63370021/33310796-2abe-41b7-99c8-93cbb94a4c89)