### PR TITLE
feat: show controls on STATE_ENDED

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/Instances.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Instances.kt
@@ -16,5 +16,5 @@ data class Instances(
     @SerialName("cache") val chache: Boolean = false,
     @SerialName("s3_enabled") val s3Enabled: Boolean = false,
     @SerialName("image_proxy_url") val imageProxyUrl: String = "",
-    @SerialName("registration_disabled") val registrationDisabled: Boolean = false,
+    @SerialName("registration_disabled") val registrationDisabled: Boolean = false
 )

--- a/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
@@ -31,8 +31,10 @@ class InstancesAdapter(
         holder.binding.apply {
             var instanceText = "${instance.name}   ${instance.locations}"
             if (instance.cdn) instanceText += "   (\uD83C\uDF10 CDN)"
-            if (instance.registrationDisabled) instanceText +=
-                "   (${root.context.getString(R.string.registration_disabled)})"
+            if (instance.registrationDisabled) {
+                instanceText +=
+                    "   (${root.context.getString(R.string.registration_disabled)})"
+            }
             radioButton.text = instanceText
             radioButton.setOnCheckedChangeListener(null)
             radioButton.isChecked = selectedInstanceIndex == position

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -934,16 +934,16 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                 }
 
                 // check if video has ended, next video is available and autoplay is enabled.
-                if (
-                    playbackState == Player.STATE_ENDED &&
-                    !isTransitioning &&
-                    PlayerHelper.autoPlayEnabled
-                ) {
-                    isTransitioning = true
-                    if (PlayerHelper.autoPlayCountdown) {
-                        showAutoPlayCountdown()
+                if (playbackState == Player.STATE_ENDED) {
+                    if (!isTransitioning && PlayerHelper.autoPlayEnabled) {
+                        isTransitioning = true
+                        if (PlayerHelper.autoPlayCountdown) {
+                            showAutoPlayCountdown()
+                        } else {
+                            playNextVideo()
+                        }
                     } else {
-                        playNextVideo()
+                        binding.player.showController()
                     }
                 }
 


### PR DESCRIPTION
Shows the controls once the video ends to indicate to the user that the video has ended.
This addresses an issue I've faced multiple times, mistaking a video's black screen ending for a playback error/buffering.

The controls appear only when autoplay for the next video is off.