### PR TITLE
feat: add sponsorblock option to skip only once

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -12,7 +12,8 @@ data class Segment(
     val segment: List<Double> = listOf(),
     val userID: String? = null,
     val videoDuration: Double? = null,
-    val votes: Int? = null
+    val votes: Int? = null,
+    var skipped: Boolean? = false
 ) {
     val segmentStartAndEnd = segment[0] to segment[1]
 }

--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -13,7 +13,7 @@ data class Segment(
     val userID: String? = null,
     val videoDuration: Double? = null,
     val votes: Int? = null,
-    var skipped: Boolean? = false
+    var skipped: Boolean = false
 ) {
     val segmentStartAndEnd = segment[0] to segment[1]
 }

--- a/app/src/main/java/com/github/libretube/enums/SbSkipOptions.kt
+++ b/app/src/main/java/com/github/libretube/enums/SbSkipOptions.kt
@@ -4,5 +4,6 @@ enum class SbSkipOptions {
     OFF,
     VISIBLE,
     MANUAL,
-    AUTOMATIC
+    AUTOMATIC,
+    AUTOMATIC_ONCE
 }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -493,9 +493,12 @@ object PlayerHelper {
             if ((duration - currentPosition).absoluteValue < 500) continue
 
             if (currentPosition in segmentStart until segmentEnd) {
-                if (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC
-                    || (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE
-                            && segment.skipped == false)) {
+                if (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC ||
+                    (
+                        sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE &&
+                            segment.skipped == false
+                        )
+                ) {
                     if (sponsorBlockNotifications) {
                         runCatching {
                             Toast.makeText(context, R.string.segment_skipped, Toast.LENGTH_SHORT)

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -484,7 +484,7 @@ object PlayerHelper {
         context: Context,
         segments: List<Segment>,
         sponsorBlockConfig: MutableMap<String, SbSkipOptions>
-    ): Long? {
+    ): Segment? {
         for (segment in segments.filter { it.category != SPONSOR_HIGHLIGHT_CATEGORY }) {
             val (start, end) = segment.segmentStartAndEnd
             val (segmentStart, segmentEnd) = (start * 1000f).toLong() to (end * 1000f).toLong()
@@ -493,7 +493,9 @@ object PlayerHelper {
             if ((duration - currentPosition).absoluteValue < 500) continue
 
             if (currentPosition in segmentStart until segmentEnd) {
-                if (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC) {
+                if (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC
+                    || (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE
+                            && segment.skipped == false)) {
                     if (sponsorBlockNotifications) {
                         runCatching {
                             Toast.makeText(context, R.string.segment_skipped, Toast.LENGTH_SHORT)
@@ -501,8 +503,9 @@ object PlayerHelper {
                         }
                     }
                     seekTo(segmentEnd)
+                    segment.skipped = true
                 } else if (sponsorBlockConfig[segment.category] == SbSkipOptions.MANUAL) {
-                    return segmentEnd
+                    return segment
                 }
             }
         }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -507,7 +507,12 @@ object PlayerHelper {
                     }
                     seekTo(segmentEnd)
                     segment.skipped = true
-                } else if (sponsorBlockConfig[segment.category] == SbSkipOptions.MANUAL) {
+                } else if (sponsorBlockConfig[segment.category] == SbSkipOptions.MANUAL ||
+                    (
+                        sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE &&
+                            segment.skipped == true
+                        )
+                ) {
                     return segment
                 }
             }

--- a/app/src/main/java/com/github/libretube/services/DownloadService.kt
+++ b/app/src/main/java/com/github/libretube/services/DownloadService.kt
@@ -40,6 +40,18 @@ import com.github.libretube.receivers.NotificationReceiver.Companion.ACTION_DOWN
 import com.github.libretube.receivers.NotificationReceiver.Companion.ACTION_DOWNLOAD_RESUME
 import com.github.libretube.receivers.NotificationReceiver.Companion.ACTION_DOWNLOAD_STOP
 import com.github.libretube.ui.activities.MainActivity
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.Executors
+import kotlin.io.path.absolute
+import kotlin.io.path.createFile
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.fileSize
+import kotlin.math.min
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -54,18 +66,6 @@ import kotlinx.coroutines.withContext
 import okio.buffer
 import okio.sink
 import okio.source
-import java.io.File
-import java.net.HttpURLConnection
-import java.net.SocketTimeoutException
-import java.net.URL
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
-import java.util.concurrent.Executors
-import kotlin.io.path.absolute
-import kotlin.io.path.createFile
-import kotlin.io.path.deleteIfExists
-import kotlin.io.path.fileSize
-import kotlin.math.min
 
 /**
  * Download service with custom implementation of downloading using [HttpURLConnection].
@@ -205,7 +205,7 @@ class DownloadService : LifecycleService() {
                             notificationBuilder
                                 .setContentText(
                                     totalRead.formatAsFileSize() + " / " +
-                                            item.downloadSize.formatAsFileSize()
+                                        item.downloadSize.formatAsFileSize()
                                 )
                                 .setProgress(
                                     item.downloadSize.toInt(),

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -676,11 +676,12 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         if (!sponsorBlockEnabled || segments.isEmpty()) return
 
         exoPlayer.checkForSegments(requireContext(), segments, sponsorBlockConfig)
-            ?.let { segmentEnd ->
+            ?.let { segment->
                 if (viewModel.isMiniPlayerVisible.value == true) return@let
                 binding.sbSkipBtn.isVisible = true
                 binding.sbSkipBtn.setOnClickListener {
-                    exoPlayer.seekTo(segmentEnd)
+                    exoPlayer.seekTo((segment.segmentStartAndEnd.second * 1000f).toLong())
+                    segment.skipped = true
                 }
                 return
             }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -676,7 +676,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         if (!sponsorBlockEnabled || segments.isEmpty()) return
 
         exoPlayer.checkForSegments(requireContext(), segments, sponsorBlockConfig)
-            ?.let { segment->
+            ?.let { segment ->
                 if (viewModel.isMiniPlayerVisible.value == true) return@let
                 binding.sbSkipBtn.isVisible = true
                 binding.sbSkipBtn.setOnClickListener {

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -446,6 +446,7 @@
         <item>@string/visible</item>
         <item>@string/manual</item>
         <item>@string/automatic</item>
+        <item>@string/automatic_once</item>
     </string-array>
 
     <string-array name="sb_skip_options_values">
@@ -453,6 +454,7 @@
         <item>visible</item>
         <item>manual</item>
         <item>automatic</item>
+        <item>automatic_once</item>
     </string-array>
 
     <string-array name="orientation">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,7 @@
     <string name="off">Off</string>
     <string name="manual">Manual</string>
     <string name="automatic">Automatic</string>
+    <string name="automatic_once">Automatic once</string>
     <string name="visible">Show in seek bar</string>
     <string name="fallback_piped_proxy">Fallback to Piped proxy</string>
     <string name="fallback_piped_proxy_desc">Load videos via the proxy if connecting to YouTube directly doesn\'t work for the current video (increases the initial loading times). If disabled, YouTube music content likely won\'t play due to YT restrictions.</string>


### PR DESCRIPTION
Adds a new SponsorBlock skip option, which only skips the segment when watching the first time. This allows the user to go back and rewatch a segment if they wish to do so. 
When rewatching an already skipped segment, the manual skip option is shown instead.

https://github.com/libre-tube/LibreTube/assets/63370021/d80e73e2-9096-4dae-89d1-3d3d7c32d4b9

