### PR TITLE
fix: Free view bindings in dialogs

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/StatsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/StatsSheet.kt
@@ -14,20 +14,23 @@ class StatsSheet(
     private val player: ExoPlayer,
     private val videoId: String
 ) : ExpandedBottomSheet() {
+    private var _binding: DialogStatsBinding? = null
+    private val binding get() = _binding!!
 
-    lateinit var binding: DialogStatsBinding
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DialogStatsBinding.inflate(layoutInflater)
+        _binding = DialogStatsBinding.inflate(layoutInflater)
         return binding.root
     }
 
     @SuppressLint("SetTextI18n")
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val binding = binding
+
         binding.videoId.setText(videoId)
         binding.videoInfo.setText(
             "${player.videoFormat?.codecs.orEmpty()} ${
@@ -46,5 +49,10 @@ class StatsSheet(
         binding.videoQuality.setText(
             "${player.videoFormat?.width}x${player.videoFormat?.height} ${player.videoFormat?.frameRate?.toInt()}fps"
         )
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
@@ -12,24 +12,30 @@ import com.github.libretube.ui.adapters.BottomSheetAdapter
 import kotlinx.coroutines.launch
 
 open class BaseBottomSheet : ExpandedBottomSheet() {
+    private var _binding: BottomSheetBinding? = null
+    private val binding get() = _binding!!
+
     private lateinit var items: List<BottomSheetItem>
     private lateinit var listener: (index: Int) -> Unit
-    private lateinit var binding: BottomSheetBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = BottomSheetBinding.inflate(layoutInflater)
+        _binding = BottomSheetBinding.inflate(layoutInflater)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
+        val binding = binding
         binding.optionsRecycler.layoutManager = LinearLayoutManager(requireContext())
         binding.optionsRecycler.adapter = BottomSheetAdapter(items, listener)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     fun setItems(items: List<BottomSheetItem>, listener: (suspend (index: Int) -> Unit)?) = apply {

--- a/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
@@ -17,7 +17,9 @@ import com.github.libretube.ui.models.CommentsViewModel
 import com.github.libretube.ui.models.PlayerViewModel
 
 class CommentsSheet : UndimmedBottomSheet() {
-    lateinit var binding: CommentsSheetBinding
+    private var _binding: CommentsSheetBinding? = null
+    val binding get() = _binding!!
+
     private val playerViewModel: PlayerViewModel by activityViewModels()
     private val commentsViewModel: CommentsViewModel by activityViewModels()
 
@@ -26,7 +28,7 @@ class CommentsSheet : UndimmedBottomSheet() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = CommentsSheetBinding.inflate(layoutInflater)
+        _binding = CommentsSheetBinding.inflate(layoutInflater)
         return binding.root
     }
 
@@ -35,28 +37,28 @@ class CommentsSheet : UndimmedBottomSheet() {
 
         commentsViewModel.commentsSheetDismiss = this::dismiss
 
-        binding.apply {
-            dragHandle.viewTreeObserver.addOnGlobalLayoutListener(object :
-                ViewTreeObserver.OnGlobalLayoutListener {
-                override fun onGlobalLayout() {
-                    dragHandle.viewTreeObserver.removeOnGlobalLayoutListener(this)
+        val binding = binding
 
-                    // limit the recyclerview height to not cover the video
-                    binding.standardBottomSheet.layoutParams =
-                        binding.commentFragContainer.layoutParams.apply {
-                            height = playerViewModel.maxSheetHeightPx
-                        }
-                }
-            })
+        binding.dragHandle.viewTreeObserver.addOnGlobalLayoutListener(object :
+            ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                binding.dragHandle.viewTreeObserver.removeOnGlobalLayoutListener(this)
 
-            btnBack.setOnClickListener {
-                if (childFragmentManager.backStackEntryCount > 0) {
-                    childFragmentManager.popBackStack()
-                }
+                // limit the recyclerview height to not cover the video
+                binding.standardBottomSheet.layoutParams =
+                    binding.commentFragContainer.layoutParams.apply {
+                        height = playerViewModel.maxSheetHeightPx
+                    }
             }
+        })
 
-            btnClose.setOnClickListener { dismiss() }
+        binding.btnBack.setOnClickListener {
+            if (childFragmentManager.backStackEntryCount > 0) {
+                childFragmentManager.popBackStack()
+            }
         }
+
+        binding.btnClose.setOnClickListener { dismiss() }
 
         childFragmentManager.commit {
             replace<CommentsMainFragment>(R.id.commentFragContainer)
@@ -70,6 +72,11 @@ class CommentsSheet : UndimmedBottomSheet() {
                 else -> dismiss()
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun getSheetMaxHeightPx() = playerViewModel.maxSheetHeightPx

--- a/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
@@ -26,8 +26,10 @@ class EditChannelGroupSheet(
     private var group: SubscriptionGroup,
     private val onGroupChanged: (SubscriptionGroup) -> Unit
 ) : ExpandedBottomSheet() {
+    private var _binding: DialogEditChannelGroupBinding? = null
+    private val binding get() = _binding!!
+
     private val subscriptionsModel: SubscriptionsViewModel by activityViewModels()
-    private lateinit var binding: DialogEditChannelGroupBinding
     private var channels = listOf<Subscription>()
 
     override fun onCreateView(
@@ -35,7 +37,13 @@ class EditChannelGroupSheet(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DialogEditChannelGroupBinding.inflate(layoutInflater)
+        _binding = DialogEditChannelGroupBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val binding = binding
+
         binding.groupName.setText(group.name)
 
         binding.channelsRV.layoutManager = LinearLayoutManager(context)
@@ -60,8 +68,11 @@ class EditChannelGroupSheet(
             onGroupChanged(group)
             dismiss()
         }
+    }
 
-        return binding.root
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun fetchSubscriptions() {
@@ -81,6 +92,7 @@ class EditChannelGroupSheet(
     }
 
     private fun showChannels(channels: List<Subscription>, query: String?) {
+        val binding = binding
         binding.channelsRV.adapter = SubscriptionGroupChannelsAdapter(
             channels.filter { query == null || it.name.lowercase().contains(query.lowercase()) },
             group

--- a/app/src/main/java/com/github/libretube/ui/sheets/IconsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IconsBottomSheet.kt
@@ -9,19 +9,26 @@ import com.github.libretube.databinding.BottomSheetBinding
 import com.github.libretube.ui.adapters.IconsSheetAdapter
 
 class IconsBottomSheet : ExpandedBottomSheet() {
-    private lateinit var binding: BottomSheetBinding
+    private var _binding: BottomSheetBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = BottomSheetBinding.inflate(layoutInflater)
+        _binding = BottomSheetBinding.inflate(layoutInflater)
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val binding = binding
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IconsSheetAdapter()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
@@ -26,6 +26,7 @@ class IntentChooserSheet(
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val binding = binding
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IntentChooserAdapter(packages, url)
     }

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
@@ -16,20 +16,22 @@ import com.github.libretube.ui.adapters.SliderLabelsAdapter
 class PlaybackOptionsSheet(
     private val player: ExoPlayer
 ) : ExpandedBottomSheet() {
-    private lateinit var binding: PlaybackBottomSheetBinding
+    private var _binding: PlaybackBottomSheetBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = PlaybackBottomSheetBinding.inflate(layoutInflater)
+        _binding = PlaybackBottomSheetBinding.inflate(layoutInflater)
         return binding.root
     }
 
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+        val binding = binding
+
         binding.speedShortcuts.layoutManager = GridLayoutManager(context, SUGGESTED_SPEEDS.size)
         binding.pitchShortcuts.layoutManager = GridLayoutManager(context, SUGGESTED_PITCHES.size)
 
@@ -58,6 +60,11 @@ class PlaybackOptionsSheet(
             player.skipSilenceEnabled = isChecked
             PreferenceHelper.putBoolean(PreferenceKeys.SKIP_SILENCE, isChecked)
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun onChange() {


### PR DESCRIPTION
Allow dialog view bindings to be garbage collected when the dialog is destroyed.