### PR TITLE
feat(player): play music at 1x speed

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/Streams.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Streams.kt
@@ -93,6 +93,6 @@ data class Streams(
     }
 
     companion object {
-        var categoryMusic = "Music"
+        const val categoryMusic = "Music"
     }
 }

--- a/app/src/main/java/com/github/libretube/api/obj/Streams.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Streams.kt
@@ -91,4 +91,8 @@ data class Streams(
             shortDescription = description
         )
     }
+
+    companion object {
+        var categoryMusic = "Music"
+    }
 }

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -6,7 +6,6 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.github.libretube.constants.PreferenceKeys
 import java.time.Instant
-import java.util.UUID
 
 object PreferenceHelper {
     /**

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -938,6 +938,11 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             override fun onPlaybackStateChanged(playbackState: Int) {
                 saveWatchPosition()
 
+                if (playbackState == Player.STATE_READY) {
+                    if (streams.category == "Music")
+                        exoPlayer.setPlaybackSpeed(1f)
+                }
+
                 // set the playback speed to one if having reached the end of a livestream
                 if (playbackState == Player.STATE_BUFFERING && binding.player.isLive &&
                     exoPlayer.duration - exoPlayer.currentPosition < 700

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -101,7 +101,6 @@ import com.github.libretube.ui.adapters.VideosAdapter
 import com.github.libretube.ui.dialogs.AddToPlaylistDialog
 import com.github.libretube.ui.dialogs.DownloadDialog
 import com.github.libretube.ui.dialogs.ShareDialog
-import com.github.libretube.ui.sheets.StatsSheet
 import com.github.libretube.ui.extensions.setupSubscriptionButton
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
 import com.github.libretube.ui.listeners.SeekbarPreviewListener
@@ -111,6 +110,7 @@ import com.github.libretube.ui.sheets.BaseBottomSheet
 import com.github.libretube.ui.sheets.ChaptersBottomSheet
 import com.github.libretube.ui.sheets.CommentsSheet
 import com.github.libretube.ui.sheets.PlayingQueueSheet
+import com.github.libretube.ui.sheets.StatsSheet
 import com.github.libretube.util.HtmlParser
 import com.github.libretube.util.LinkHandler
 import com.github.libretube.util.NowPlayingNotification
@@ -939,8 +939,9 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                 saveWatchPosition()
 
                 if (playbackState == Player.STATE_READY) {
-                    if (streams.category == "Music")
+                    if (streams.category == "Music") {
                         exoPlayer.setPlaybackSpeed(1f)
+                    }
                 }
 
                 // set the playback speed to one if having reached the end of a livestream

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -939,7 +939,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                 saveWatchPosition()
 
                 if (playbackState == Player.STATE_READY) {
-                    if (streams.category == "Music") {
+                    if (streams.category == Streams.categoryMusic) {
                         exoPlayer.setPlaybackSpeed(1f)
                     }
                 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/StatsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/StatsSheet.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.media3.exoplayer.ExoPlayer
 import com.github.libretube.databinding.DialogStatsBinding
-import com.github.libretube.ui.sheets.ExpandedBottomSheet
 import com.github.libretube.util.TextUtils
 
 class StatsSheet(


### PR DESCRIPTION
Changes the default video speed for Music videos to 1x. The user can still manually change the speed.
Please note that this can have the side effect of some non-music videos, which are categorized as music videos, being played at the wrong speed.