### PR TITLE
feat: Show stream count under summary notification

### DIFF
--- a/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
+++ b/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
@@ -138,6 +138,7 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
         val newStreams = applicationContext.resources
             .getQuantityString(R.plurals.channel_new_streams, streams.size, streams.size)
         val summary = NotificationCompat.InboxStyle()
+            .setSummaryText(newStreams)
         streams.forEach {
             summary.addLine(it.title)
         }


### PR DESCRIPTION
Display the new streams message as the inbox style's summary.

Screenshots

* Android versions below 7.0

![Screenshot_20230828_195448](https://github.com/libre-tube/LibreTube/assets/31027858/a644926b-dee1-4721-9468-e5842091095e)

* Android 7.0 and later

![Screenshot_20230828-195937_LibreTube Debug](https://github.com/libre-tube/LibreTube/assets/31027858/511260ff-f6e1-4263-bb15-821a7712ce32)
