### PR TITLE
feat: add option to save playback speed

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -62,6 +62,7 @@ object PreferenceKeys {
     const val RELATED_STREAMS = "related_streams_toggle"
     const val CUSTOM_PLAYBACK_SPEED = "custom_playback_speed"
     const val PLAYBACK_SPEED = "playback_speed"
+    const val SAVE_PLAYBACK_SPEED = "save_playback_speed"
     const val BACKGROUND_PLAYBACK_SPEED = "background_playback_speed"
     const val FULLSCREEN_ORIENTATION = "fullscreen_orientation"
     const val PAUSE_ON_SCREEN_OFF = "pause_screen_off"

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
@@ -72,6 +72,13 @@ class PlaybackOptionsSheet(
             binding.speed.value.round(2),
             binding.pitch.value.round(2)
         )
+
+        if (PreferenceHelper.getBoolean(PreferenceKeys.SAVE_PLAYBACK_SPEED, false)) {
+            PreferenceHelper.putString(
+                PreferenceKeys.PLAYBACK_SPEED,
+                player.playbackParameters.speed.toString()
+            )
+        }
     }
 
     companion object {

--- a/app/src/main/res/drawable/ic_baseline_save.xml
+++ b/app/src/main/res/drawable/ic_baseline_save.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,6 +125,7 @@
     <string name="update_summary">Check for update</string>
     <string name="app_uptodate">Running the latest version.</string>
     <string name="playback_speed">Playback speed</string>
+    <string name="save_playback_speed">Save playback speed</string>
     <string name="advanced">Advanced</string>
     <string name="player">Player</string>
     <string name="appearance_summary">Adjust the app to your liking.</string>

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -147,6 +147,12 @@
             app:valueFrom="0.2"
             app:valueTo="4.0" />
 
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_baseline_save"
+            app:defaultValue="false"
+            app:key="save_playback_speed"
+            app:title="@string/save_playback_speed" />
+
         <ListPreference
             android:defaultValue=""
             android:icon="@drawable/ic_caption"


### PR DESCRIPTION
Adds a new setting for saving the playback speed when changing it. This can be useful when wanting to change the playback speed only for a shorter duration (a couple of videos), as it eliminates the need to manually change it for each video, or to go to the settings each time the user wants to change the default speed.

![Screenshot of the settings page with a new 'Save playback speed' setting](https://github.com/libre-tube/LibreTube/assets/63370021/eda6f519-7dd2-438f-8ce3-35346d376592)
