### PR TITLE
fix: Avoid accidental link clicking

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/CommentsAdapter.kt
@@ -1,13 +1,13 @@
 package com.github.libretube.ui.adapters
 
 import android.annotation.SuppressLint
-import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Toast
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.os.bundleOf
+import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -73,7 +73,7 @@ class CommentsAdapter(
         holder.binding.apply {
             commentInfos.text = comment.author + TextUtils.SEPARATOR + comment.commentedTime
 
-            commentText.movementMethod = LinkMovementMethod.getInstance()
+            commentText.movementMethod = LinkMovementMethodCompat.getInstance()
             commentText.text = comment.commentText?.replace("</a>", "</a> ")
                 ?.parseAsHtml(tagHandler = HtmlParser(LinkHandler(handleLink ?: {})))
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -14,7 +14,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.text.format.DateUtils
-import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
 import android.view.LayoutInflater
 import android.view.View
@@ -28,6 +27,7 @@ import androidx.core.graphics.drawable.toDrawable
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.core.os.postDelayed
+import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.text.parseAsHtml
 import androidx.core.view.WindowCompat
 import androidx.core.view.isGone
@@ -120,16 +120,16 @@ import com.github.libretube.util.TextUtils
 import com.github.libretube.util.TextUtils.toTimeInSeconds
 import com.github.libretube.util.YoutubeHlsPlaylistParser
 import com.github.libretube.util.deArrow
-import java.io.IOException
-import java.util.*
-import java.util.concurrent.Executors
-import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import retrofit2.HttpException
+import java.io.IOException
+import java.util.*
+import java.util.concurrent.Executors
+import kotlin.math.abs
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class PlayerFragment : Fragment(), OnlinePlayerOptions {
@@ -1093,7 +1093,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     ) {
         // detect whether the description is html formatted
         if (description.contains("<") && description.contains(">")) {
-            descTextView.movementMethod = LinkMovementMethod.getInstance()
+            descTextView.movementMethod = LinkMovementMethodCompat.getInstance()
             descTextView.text = description.replace("</a>", "</a> ")
                 .parseAsHtml(tagHandler = HtmlParser(LinkHandler(this::handleLink)))
         } else {


### PR DESCRIPTION
Fix an issue on all current versions of Android where it is possible to activate links even when touching outside their line bounds.