### PR TITLE
fix(settings/sponsorblock): allow toggling of contribute setting

### DIFF
--- a/app/src/main/res/xml/sponsorblock_settings.xml
+++ b/app/src/main/res/xml/sponsorblock_settings.xml
@@ -18,7 +18,6 @@
         app:title="@string/sponsorblock_notifications" />
 
     <SwitchPreferenceCompat
-        android:dependency="sb_contribute_key"
         android:summaryOff="@string/disabled"
         android:summaryOn="@string/enabled"
         app:defaultValue="false"


### PR DESCRIPTION
Removes the dependence of the `sb_contribute_key` on itself, which blocked enabling the setting, as it required itself to be enabled first.

![Disable contribute setting](https://github.com/libre-tube/LibreTube/assets/63370021/97ab2318-8e26-43cc-b84d-ab2a297aaec0)
