### PR TITLE
feat(settings/sponsorblock): allow changing sb user id

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,6 +472,7 @@
     <string name="segment_type">Segment type</string>
     <string name="sb_invalid_segment">Invalid segment start or end</string>
     <string name="contribute_to_sponsorblock">Contribute to SponsorBlock</string>
+    <string name="sponsorblock_user_id">SponsorBlock Username</string>
     <string name="filename_too_long">Filename too long!</string>
 
     <!-- Notification channel strings -->

--- a/app/src/main/res/xml/sponsorblock_settings.xml
+++ b/app/src/main/res/xml/sponsorblock_settings.xml
@@ -25,6 +25,11 @@
         app:key="sb_contribute_key"
         app:title="@string/contribute_to_sponsorblock" />
 
+    <EditTextPreference
+        android:dependency="sb_contribute_key"
+        app:key="sb_user_id"
+        app:title="@string/sponsorblock_user_id" />
+
     <SwitchPreferenceCompat
         app:defaultValue="false"
         app:key="dearrow"


### PR DESCRIPTION
Adds a setting to change the used SponsorBlock user ID. Users may want to change (or view) it, as SponsorBlock keeps track of the amount of submitted segments.

![Setting with SponsorBlock username setting](https://github.com/libre-tube/LibreTube/assets/63370021/ed56d670-5839-4999-9f89-b6607344a80d)
