### PR TITLE
fix(channelgroups): update values on confirm

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
@@ -2,7 +2,6 @@ package com.github.libretube.ui.sheets
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -48,6 +47,12 @@ class ChannelGroupsSheet : ExpandedBottomSheet() {
         }
 
         binding.confirm.setOnClickListener {
+            channelGroupsModel.groups.value = adapter.groups
+            channelGroupsModel.groups.value?.forEachIndexed { index, group -> group.index = index }
+            CoroutineScope(Dispatchers.IO).launch {
+                DatabaseHolder.Database.subscriptionGroupsDao()
+                    .updateAll(channelGroupsModel.groups.value.orEmpty())
+            }
             dismiss()
         }
 
@@ -62,20 +67,8 @@ class ChannelGroupsSheet : ExpandedBottomSheet() {
             ): Boolean {
                 val from = viewHolder.absoluteAdapterPosition
                 val to = target.absoluteAdapterPosition
-
-                Log.e("move", "move")
-
-                channelGroupsModel.groups.value = channelGroupsModel.groups.value.orEmpty()
-                    .toMutableList()
-                    .also { it.move(from, to) }
+                adapter.groups.move(from, to)
                 adapter.notifyItemMoved(from, to)
-
-                channelGroupsModel.groups.value?.forEachIndexed { index, group -> group.index = index }
-                CoroutineScope(Dispatchers.IO).launch {
-                    DatabaseHolder.Database.subscriptionGroupsDao()
-                        .updateAll(channelGroupsModel.groups.value.orEmpty())
-                }
-
                 return true
             }
 


### PR DESCRIPTION
Fixes a problem with https://github.com/libre-tube/LibreTube/pull/4551 where it was not possible to move over multiple items, e.g. moving an item from bottom to top.
By only saving once the user presses the confirm button, this has the added benefit of allowing the user to undo the reorder by dismissing the sheet.