### PR TITLE
feat: Show upload time in stream notifications

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/ContentItem.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/ContentItem.kt
@@ -16,7 +16,7 @@ data class ContentItem(
     val isShort: Boolean? = null,
     val uploaderVerified: Boolean? = null,
     val uploaderName: String? = null,
-    val uploaded: Long? = null,
+    val uploaded: Long = 0,
     val shortDescription: String? = null,
     // Channel and Playlist attributes
     val name: String? = null,

--- a/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
@@ -20,7 +20,7 @@ data class StreamItem(
     val duration: Long? = null,
     val views: Long? = null,
     val uploaderVerified: Boolean? = null,
-    val uploaded: Long? = null,
+    val uploaded: Long = 0,
     val shortDescription: String? = null,
     val isShort: Boolean = false
 ) : Parcelable {

--- a/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
+++ b/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
@@ -8,11 +8,11 @@ import com.github.libretube.db.obj.SearchHistoryItem
 import com.github.libretube.db.obj.WatchHistoryItem
 import com.github.libretube.extensions.toID
 import com.github.libretube.helpers.PreferenceHelper
-import java.time.Instant
-import java.time.ZoneId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.toKotlinLocalDate
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 object DatabaseHelper {
     private const val MAX_SEARCH_HISTORY_SIZE = 20
@@ -28,12 +28,8 @@ object DatabaseHelper {
         val watchHistoryItem = WatchHistoryItem(
             videoId,
             stream.title,
-            stream.uploaded?.let {
-                Instant.ofEpochMilli(it)
-                    .atZone(ZoneId.systemDefault())
-                    .toLocalDate()
-                    .toKotlinLocalDate()
-            },
+            Instant.fromEpochMilliseconds(stream.uploaded)
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date,
             stream.uploaderName,
             stream.uploaderUrl?.toID(),
             stream.uploaderAvatar,

--- a/app/src/main/java/com/github/libretube/db/obj/LocalPlaylistItem.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/LocalPlaylistItem.kt
@@ -30,7 +30,6 @@ data class LocalPlaylistItem(
             uploaderUrl = uploaderUrl,
             uploaderAvatar = ProxyHelper.rewriteUrl(uploaderAvatar),
             uploadedDate = uploadDate,
-            uploaded = null,
             duration = duration
         )
     }

--- a/app/src/main/java/com/github/libretube/db/obj/WatchHistoryItem.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/WatchHistoryItem.kt
@@ -26,7 +26,7 @@ data class WatchHistoryItem(
         title = title,
         thumbnail = thumbnailUrl,
         uploaderName = uploader,
-        uploaded = uploadDate?.toMillis(),
+        uploaded = uploadDate?.toMillis() ?: 0,
         uploaderAvatar = uploaderAvatar,
         uploaderUrl = uploaderUrl,
         duration = duration

--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchAdapter.kt
@@ -83,7 +83,7 @@ class SearchAdapter(
             thumbnailDuration.setFormattedDuration(item.duration, item.isShort)
             videoTitle.text = item.title
             val viewsString = item.views.takeIf { it != -1L }?.formatShort().orEmpty()
-            val uploadDate = item.uploaded?.takeIf { it > 0 }?.let {
+            val uploadDate = item.uploaded.takeIf { it > 0 }?.let {
                 " ${TextUtils.SEPARATOR} ${TextUtils.formatRelativeDate(root.context, it)}"
             }.orEmpty()
             videoInfo.text = root.context.getString(

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
@@ -120,7 +120,7 @@ class VideosAdapter(
         val fragmentManager = activity.supportFragmentManager
 
         val uploadDate =
-            video.uploaded?.takeIf { it > 0 }?.let { TextUtils.formatRelativeDate(context, it) }
+            video.uploaded.takeIf { it > 0 }?.let { TextUtils.formatRelativeDate(context, it) }
 
         // Trending layout
         holder.trendingRowBinding?.apply {

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -308,9 +308,7 @@ class SubscriptionsFragment : Fragment() {
         // add an "all caught up item"
         if (selectedSortOrder == 0) {
             val lastCheckedFeedTime = PreferenceHelper.getLastCheckedFeedTime()
-            val caughtUpIndex = feed.indexOfFirst {
-                (it.uploaded ?: 0L) / 1000 < lastCheckedFeedTime
-            }
+            val caughtUpIndex = feed.indexOfFirst { it.uploaded / 1000 < lastCheckedFeedTime }
             if (caughtUpIndex > 0) {
                 sortedFeed.add(
                     caughtUpIndex,

--- a/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
+++ b/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
@@ -168,7 +168,7 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
     private suspend fun createStreamNotification(
         group: String,
         stream: StreamItem
-    ): Triple<Int, Long?, Notification> { // Notification ID, uploaded date and notification object
+    ): Triple<Int, Long, Notification> { // Notification ID, uploaded date and notification object
         val videoId = stream.url!!.toID()
         val intent = Intent(applicationContext, MainActivity::class.java)
             .setFlags(INTENT_FLAGS)
@@ -192,6 +192,8 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
                     .bigPicture(thumbnail)
                     .bigLargeIcon(null as Bitmap?) // Hides the icon when expanding
             )
+            .setWhen(stream.uploaded)
+            .setShowWhen(true)
 
         return Triple(notificationId, stream.uploaded, notificationBuilder.build())
     }


### PR DESCRIPTION
* Use the upload timestamp in individual stream notifications.
* Make `StreamItem`'s `uploaded` field a non-null value.