### PR TITLE
fix(player): allow pausing while loading

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/Player.kt
+++ b/app/src/main/java/com/github/libretube/extensions/Player.kt
@@ -13,7 +13,7 @@ fun Player.togglePlayPauseState() {
             seekTo(0)
         }
 
-        !isPlaying && !isLoading -> play()
+        !isPlaying && totalBufferedDuration > 0 -> play()
         else -> pause()
     }
 }


### PR DESCRIPTION
Fixes https://github.com/libre-tube/LibreTube/issues/4784, the player should only pause when it has no buffer to play, not when it is loading, as it always loads, until the allocated buffer is full.