### PR TITLE
fix(player): rename SB Username to SB UserID

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,7 +472,7 @@
     <string name="segment_type">Segment type</string>
     <string name="sb_invalid_segment">Invalid segment start or end</string>
     <string name="contribute_to_sponsorblock">Contribute to SponsorBlock</string>
-    <string name="sponsorblock_user_id">SponsorBlock Username</string>
+    <string name="sponsorblock_user_id">SponsorBlock UserID</string>
     <string name="filename_too_long">Filename too long!</string>
 
     <!-- Notification channel strings -->


### PR DESCRIPTION
Renames the user visible `SponsorBlock Username` string to `SponsorBlock UserID` based on the suggestion from @ajayyy in https://github.com/libre-tube/LibreTube/pull/4749#discussion_r1327891171.