### PR TITLE
fix: hide disabled dislike

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/Intent.kt
+++ b/app/src/main/java/com/github/libretube/extensions/Intent.kt
@@ -1,7 +1,6 @@
 package com.github.libretube.extensions
 
 import android.content.Intent
-import android.os.Build
 import android.os.Parcelable
 import androidx.core.content.IntentCompat
 import java.io.Serializable

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -886,7 +886,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
             textLike.text = streams.likes.formatShort()
             if (streams.dislikes >= 0) {
-                textDislike.visibility = View.VISIBLE
+                textDislike.isVisible = true
                 textDislike.text = streams.dislikes.formatShort()
             }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -885,10 +885,8 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             playerViewsInfo.text = getString(R.string.normal_views, views, localizeDate(streams))
 
             textLike.text = streams.likes.formatShort()
-            if (streams.dislikes >= 0) {
-                textDislike.isVisible = true
-                textDislike.text = streams.dislikes.formatShort()
-            }
+            textDislike.isVisible = streams.dislikes >= 0
+            textDislike.text = streams.dislikes.formatShort()
 
             ImageHelper.loadImage(streams.uploaderAvatar, binding.playerChannelImage)
             playerChannelName.text = streams.uploader

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -885,7 +885,11 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             playerViewsInfo.text = getString(R.string.normal_views, views, localizeDate(streams))
 
             textLike.text = streams.likes.formatShort()
-            textDislike.text = streams.dislikes.formatShort()
+            if (streams.dislikes >= 0) {
+                textDislike.visibility = View.VISIBLE
+                textDislike.text = streams.dislikes.formatShort()
+            }
+
             ImageHelper.loadImage(streams.uploaderAvatar, binding.playerChannelImage)
             playerChannelName.text = streams.uploader
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -39,7 +39,6 @@ import com.google.android.material.chip.Chip
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 class SubscriptionsFragment : Fragment() {
     private var _binding: FragmentSubscriptionsBinding? = null

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -93,6 +93,7 @@
                         android:drawablePadding="5dp"
                         app:drawableStartCompat="@drawable/ic_dislike"
                         app:drawableStartDimen="12dp"
+                        android:visibility="gone"
                         tools:text="1.3K" />
 
                 </LinearLayout>


### PR DESCRIPTION
Hides the dislikes icon and text when if they are disabled (API returns -1). 

| Before                                                                                                                                     	| After                                                                                                                                      	|
|--------------------------------------------------------------------------------------------------------------------------------------------	|--------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Screenshot of a video showing -1 dislikes](https://github.com/libre-tube/LibreTube/assets/63370021/cf264820-0185-48c0-b0d2-65a7716adba3) 	| ![Screenshot of a video showing no dislikes](https://github.com/libre-tube/LibreTube/assets/63370021/c249321f-f863-4407-ad44-341a995f2e20) 	|