### PR TITLE
fix: allow pausing when buffer is less than min buffer

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/Player.kt
+++ b/app/src/main/java/com/github/libretube/extensions/Player.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.extensions
 
 import androidx.media3.common.Player
+import com.github.libretube.helpers.PlayerHelper
 
 fun Player.togglePlayPauseState() {
     when {
@@ -13,7 +14,7 @@ fun Player.togglePlayPauseState() {
             seekTo(0)
         }
 
-        !isPlaying && totalBufferedDuration > 0 -> play()
+        !isPlaying && totalBufferedDuration > PlayerHelper.MINIMUM_BUFFER_DURATION -> play()
         else -> pause()
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -46,7 +46,7 @@ object PlayerHelper {
     const val CONTROL_TYPE = "control_type"
     const val SPONSOR_HIGHLIGHT_CATEGORY = "poi_highlight"
     const val ROLE_FLAG_AUTO_GEN_SUBTITLE = C.ROLE_FLAG_SUPPLEMENTARY
-    const val MINIMUM_BUFFER_DURATION =  1000 * 10 // exo default is 50s
+    const val MINIMUM_BUFFER_DURATION = 1000 * 10 // exo default is 50s
 
     /**
      * A list of all categories that are not disabled by default

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -46,6 +46,7 @@ object PlayerHelper {
     const val CONTROL_TYPE = "control_type"
     const val SPONSOR_HIGHLIGHT_CATEGORY = "poi_highlight"
     const val ROLE_FLAG_AUTO_GEN_SUBTITLE = C.ROLE_FLAG_SUPPLEMENTARY
+    const val MINIMUM_BUFFER_DURATION =  1000 * 10 // exo default is 50s
 
     /**
      * A list of all categories that are not disabled by default
@@ -437,7 +438,7 @@ object PlayerHelper {
             // cache the last three minutes
             .setBackBuffer(1000 * 60 * 3, true)
             .setBufferDurationsMs(
-                1000 * 10, // exo default is 50s
+                MINIMUM_BUFFER_DURATION,
                 bufferingGoal,
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS,
                 DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS

--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchAdapter.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encodeToString
 
 class SearchAdapter(
     private val isChannelAdapter: Boolean = false,
-    private val timeStamp: Long = 0,
+    private val timeStamp: Long = 0
 ) : ListAdapter<ContentItem, SearchViewHolder>(SearchCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SearchViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
@@ -21,7 +21,6 @@ import com.github.libretube.db.DatabaseHelper
 import com.github.libretube.db.obj.SearchHistoryItem
 import com.github.libretube.extensions.TAG
 import com.github.libretube.extensions.hideKeyboard
-import com.github.libretube.extensions.toID
 import com.github.libretube.extensions.toastFromMainDispatcher
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.ui.adapters.SearchAdapter
@@ -106,7 +105,7 @@ class SearchResultFragment : Fragment() {
             val searchQuery = query.toHttpUrlOrNull()?.let {
                 val videoId = TextUtils.getVideoIdFromUrl(it.toString()) ?: query
                 timeStamp = it.queryParameter("t")?.toTimeInSeconds()
-                "${ShareDialog.YOUTUBE_FRONTEND_URL}/watch?v=${videoId}"
+                "${ShareDialog.YOUTUBE_FRONTEND_URL}/watch?v=$videoId"
             } ?: query
 
             repeatOnLifecycle(Lifecycle.State.CREATED) {


### PR DESCRIPTION
Fixes a regression in 42d081f04e132bc4ff5dbf408c596bd1f6927992.
Currently, the player only allows pausing when loading, when the current buffer is 0, which is only the case when no network connection is available. The player should pause as long as the current buffered time is less than the minimum buffer needed for playing.