### PR TITLE
fix: wrong comment opening bug fixed

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/ChaptersAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/ChaptersAdapter.kt
@@ -26,7 +26,7 @@ class ChaptersAdapter(
     }
 
     override fun onBindViewHolder(holder: ChaptersViewHolder, position: Int) {
-        val chapter = chapters[position]
+        val chapter = chapters[holder.absoluteAdapterPosition]
         holder.binding.apply {
             if (chapter.highlightDrawable != null) {
                 chapterImage.setImageDrawable(chapter.highlightDrawable)
@@ -74,4 +74,6 @@ class ChaptersAdapter(
     }
 
     override fun getItemCount() = chapters.size
+
+    override fun getItemViewType(position: Int) = position
 }


### PR DESCRIPTION
**About fix:** When we are fast scrolling through comments and suddenly click on any comment, sometimes it opens the wrong comment's reply.

**Reason:**  This is only happening on fast scrolling as per my view. The main reason is the position we getting in onViewBinding is wrong. As per my knowledge, it happens when the recycle view recycleView can't find unique layout(on fast scroll). 

**Solution:** This approach means that each item will have a unique view type based on its position in the RecyclerView. So that, also on fast scroll rcv can identify unique views(not the optimised approach but using this approach we can solve this bug). 

Closes #4428