### PR TITLE
fix: double tap required to view comment replies

### DIFF
--- a/app/src/main/res/layout/comments_row.xml
+++ b/app/src/main/res/layout/comments_row.xml
@@ -75,6 +75,7 @@
                 android:textAlignment="viewStart"
                 android:textIsSelectable="true"
                 android:textSize="15sp"
+                android:focusable="false"
                 tools:text="Comment Text" />
 
             <LinearLayout


### PR DESCRIPTION
This is a single-line change.

Previous behaviour: Requires double tap to open any comments. 

Current behaviour: Single click to open comments. (just like YT).