### PR TITLE
fix: broken offline video duration

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
@@ -183,7 +183,7 @@ class OfflinePlayerActivity : BaseActivity() {
                     val subtitleSource = SingleSampleMediaSource.Factory(FileDataSource.Factory())
                         .createMediaSource(subtitle, C.TIME_UNSET)
 
-                    mediaSource = MergingMediaSource(subtitleSource, mediaSource)
+                    mediaSource = MergingMediaSource(mediaSource, subtitleSource)
                 }
 
                 player.setMediaSource(mediaSource)


### PR DESCRIPTION
closes #5007 caused by #5004 