### PR TITLE
fix: crash when comments are opened when video isn't initialized

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -406,6 +406,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         }
 
         binding.commentsToggle.setOnClickListener {
+            if (!this::streams.isInitialized) return@setOnClickListener
             // set the max height to not cover the currently playing video
             commentsViewModel.handleLink = this::handleLink
             updateMaxSheetHeight()


### PR DESCRIPTION
closes #5064 