### PR TITLE
fix: fullscreen video doesn't use landscape

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -520,7 +520,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     }
 
     private fun updateFullscreenOrientation() {
-        if (PlayerHelper.autoFullscreenEnabled || this::streams.isInitialized) return
+        if (PlayerHelper.autoFullscreenEnabled || !this::streams.isInitialized) return
 
         val height = streams.videoStreams.firstOrNull()?.height ?: exoPlayer.videoSize.height
         val width = streams.videoStreams.firstOrNull()?.width ?: exoPlayer.videoSize.width


### PR DESCRIPTION
closes #5065