### PR TITLE
fix: parse playlist descriptions as html

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -148,7 +148,7 @@ class PlaylistFragment : Fragment() {
                 )
             }
 
-            binding.playlistDescription.text = response.description
+            binding.playlistDescription.text = response.description?.parseAsHtml()
             // hide playlist description text view if not provided
             binding.playlistDescription.isGone = response.description.orEmpty().isBlank()
 


### PR DESCRIPTION
closes #5121