### PR TITLE
fix: restoring nav after process death

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -103,10 +103,9 @@ class MainActivity : BaseActivity() {
         }
 
         // set default tab as start fragment
-        navController.graph.setStartDestination(startFragmentId)
-
-        // navigate to the default fragment
-        navController.navigate(startFragmentId)
+        navController.graph = navController.navInflater.inflate(R.navigation.nav).also {
+            it.setStartDestination(startFragmentId)
+        }
 
         binding.bottomNav.setOnApplyWindowInsetsListener(null)
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,8 +43,7 @@
         app:layout_constraintBottom_toTopOf="@+id/bottomNav"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/appBarLayout"
-        app:navGraph="@navigation/nav" />
+        app:layout_constraintTop_toBottomOf="@id/appBarLayout" />
 
     <FrameLayout
         android:id="@+id/container"


### PR DESCRIPTION
This pr fixes restoring from process death. LibreTube navigates to the start fragment after process death, which is not necessary as fragments are restored automatically. On top of that, the bottom navigation bar has its own mechanism of saving and restoring. This sometimes leads to an inconsistent UI state if the last selected navigation item before process death does not have the start fragment as root. The selected menu item does not reflect the displayed tab in this case.

This change actually sets the newly created navigation graph and removes the workaround of navigating to the start fragment to display it. The main activity xml was edited to prevent inflating the navigation graph twice.