### PR TITLE
fix: auto fullscreen stops working after first rotation

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -706,7 +706,10 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
         viewModel.isFullscreen.value = false
 
-        if (mainActivity.screenOrientationPref == ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT) {
+        if (
+            !PlayerHelper.autoFullscreenEnabled &&
+            mainActivity.screenOrientationPref == ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+        ) {
             mainActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -445,7 +445,15 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
                 if (_binding == null) return
 
-                if (currentId == transitionEndId) {
+                if (currentId == transitionStartId) {
+                    viewModel.isMiniPlayerVisible.value = false
+                    // re-enable captions
+                    updateCurrentSubtitle(currentSubtitle)
+                    binding.player.useController = true
+                    commentsViewModel.setCommentSheetExpand(true)
+                    mainMotionLayout.progress = 0F
+                    changeOrientationMode()
+                } else if (currentId == transitionEndId) {
                     viewModel.isMiniPlayerVisible.value = true
                     // disable captions temporarily
                     updateCurrentSubtitle(null)
@@ -454,14 +462,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                     binding.sbSkipBtn.isGone = true
                     mainMotionLayout.progress = 1F
                     (activity as MainActivity).requestOrientationChange()
-                } else if (currentId == transitionStartId) {
-                    viewModel.isMiniPlayerVisible.value = false
-                    // re-enable captions
-                    updateCurrentSubtitle(currentSubtitle)
-                    binding.player.useController = true
-                    commentsViewModel.setCommentSheetExpand(true)
-                    mainMotionLayout.progress = 0F
-                    changeOrientationMode()
                 }
             }
         })


### PR DESCRIPTION
Fix orientation bug where screen get stuck after first orientation change.

Bug was in an if that where removing `SCREEN_ORIENTATION_SENSOR` from `mainActivity.requestedOrientation` ignoring autoFullscreenEnabled prefs.

I'm not sure if I've done some regression on other things as I don't know yet all the app behaviours, every suggestion is welcome.