### PR TITLE
chore: add abort on lint function

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,11 @@ android {
     namespace = "com.github.libretube"
 
     tasks.register("testClasses")
+
+    lint {
+        abortOnError = false
+        checkReleaseBuilds = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
looks like there are too many string issues, but this can be merged for future aspects as it prevents many lint issues locally