### PR TITLE
fix: audio player stuck when swipe up, correct transition duration

### DIFF
--- a/app/src/main/res/xml/audio_player_scene.xml
+++ b/app/src/main/res/xml/audio_player_scene.xml
@@ -16,6 +16,7 @@
         </KeyFrameSet>
         <OnClick
             motion:clickAction="toggle"
+            motion:duration="500"
             motion:targetId="@+id/miniPlayerControls" />
     </Transition>
 

--- a/app/src/main/res/xml/audio_player_scene.xml
+++ b/app/src/main/res/xml/audio_player_scene.xml
@@ -14,12 +14,9 @@
                 motion:framePosition="90"
                 motion:motionTarget="@+id/miniPlayerControls" />
         </KeyFrameSet>
-        <OnSwipe
-            motion:dragDirection="dragDown"
-            motion:dragScale="6"
-            motion:maxAcceleration="40"
-            motion:touchAnchorId="@+id/audio_player_container"
-            motion:touchAnchorSide="bottom" />
+        <OnClick
+            motion:clickAction="toggle"
+            motion:targetId="@+id/miniPlayerControls" />
     </Transition>
 
     <ConstraintSet android:id="@+id/start">


### PR DESCRIPTION
When doing a swipe up, the audio player couldn't be minimized anymore. I added a click event for the miniplayer to have a transition and set the duration to 500ms.

closes #5205