### PR TITLE
feat(ui): add playback speed shortcut

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -514,13 +514,13 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         }
 
         playerBinding.speedShortcut.setOnClickListener {
-            PlaybackOptionsSheet(exoPlayer).show(childFragmentManager,null)
+            PlaybackOptionsSheet(exoPlayer).show(childFragmentManager, null)
         }
 
         playerBinding.speedShortcut.setOnLongClickListener {
             val defaultSpeed = 1f
             exoPlayer.setPlaybackSpeed(defaultSpeed)
-            Toast.makeText(context,R.string.resetspeedshortcut,Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, R.string.resetspeedshortcut, Toast.LENGTH_SHORT).show()
             return@setOnLongClickListener true
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -105,6 +105,7 @@ import com.github.libretube.ui.models.PlayerViewModel
 import com.github.libretube.ui.sheets.BaseBottomSheet
 import com.github.libretube.ui.sheets.ChaptersBottomSheet
 import com.github.libretube.ui.sheets.CommentsSheet
+import com.github.libretube.ui.sheets.PlaybackOptionsSheet
 import com.github.libretube.ui.sheets.PlayingQueueSheet
 import com.github.libretube.ui.sheets.StatsSheet
 import com.github.libretube.util.NowPlayingNotification
@@ -114,7 +115,6 @@ import com.github.libretube.util.TextUtils
 import com.github.libretube.util.TextUtils.toTimeInSeconds
 import com.github.libretube.util.YoutubeHlsPlaylistParser
 import com.github.libretube.util.deArrow
-import com.google.android.material.elevation.SurfaceColors
 import java.io.IOException
 import java.util.*
 import java.util.concurrent.Executors
@@ -511,6 +511,17 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         playerBinding.queueToggle.isVisible = true
         playerBinding.queueToggle.setOnClickListener {
             PlayingQueueSheet().show(childFragmentManager, null)
+        }
+
+        playerBinding.speedShortcut.setOnClickListener {
+            PlaybackOptionsSheet(exoPlayer).show(childFragmentManager,null)
+        }
+
+        playerBinding.speedShortcut.setOnLongClickListener {
+            val defaultSpeed = 1f
+            exoPlayer.setPlaybackSpeed(defaultSpeed)
+            Toast.makeText(context,R.string.resetspeedshortcut,Toast.LENGTH_SHORT).show()
+            return@setOnLongClickListener true
         }
 
         // FullScreen button trigger

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -109,6 +109,13 @@
                     app:tint="@android:color/white" />
 
                 <ImageButton
+                    android:id="@+id/speed_shortcut"
+                    style="@style/PlayerControlTop"
+                    android:layout_marginEnd="2dp"
+                    android:src="@drawable/ic_speed"
+                    app:tint="@android:color/white" />
+
+                <ImageButton
                     android:id="@+id/toggle_options"
                     style="@style/PlayerControlTop"
                     android:src="@drawable/ic_player_settings"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -501,6 +501,7 @@
     <string name="invalid_input">Invalid input</string>
     <string name="add_to_group">Add to group</string>
     <string name="uptime">%.2f%% uptime</string>
+    <string name="resetspeedshortcut">Playback speed is normal(1.0)</string>
 
     <!-- Notification channel strings -->
     <string name="download_channel_name">Download Service</string>


### PR DESCRIPTION
Closes #5349 

youtube also uses this as this is most useful among options, and about the cluttered experience, i think the lock button in portrait mode and the sponssorblock toggle shortcut are utter useless .
close if you dont want, if merged i can remove useless sponsor toggle and lock button when player is not in fullscreen.
youtube uses more options like shuffle controls etc. but we have queue sheet for that
this can be moved also beside timebar beside total video length.