### PR TITLE
fix: Error on Settings > Player > Playback speed

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/SliderPreference.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/SliderPreference.kt
@@ -34,8 +34,10 @@ class SliderPreference(
     }
 
     private var prefValue: Float
-        get() = PreferenceHelper.getString(key, defValue.toString()).toFloat()
+        get() = PreferenceHelper.getString(key, defValue.toString()).toFloat().ensureValid()
         set(value) = PreferenceHelper.putString(key, value.toString())
+
+    private fun Float.ensureValid(): Float = this - (this % stepSize)
 
     override fun getSummary(): CharSequence = getDisplayedCurrentValue(prefValue)
 


### PR DESCRIPTION
When a SliderPreference is processing a preference with a value outside the supported values - **valueFrom + x * stepSize** an error is shown. This is happening on the issue #5355 

We could go for 3 approaches:
1. Change the step on the settings (the issue might persist on other SliderPreference settings);
2. Change the step on the video settings (users currently set on an odd number can be impacted);
3. Add a safeguard on the SliderPreference component itself;

I went for the 3. but I understand if you think we should go for 1. or 2. - Let me know which approach is more suitable 😊 