### PR TITLE
fix: Error on Settings > Player > Playback speed

### DIFF
--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -186,7 +186,7 @@
             android:icon="@drawable/ic_speed"
             app:defValue="1.0"
             app:key="playback_speed"
-            app:stepSize="0.1"
+            app:stepSize="0.05"
             app:title="@string/playback_speed"
             app:valueFrom="0.2"
             app:valueTo="4.0" />


### PR DESCRIPTION
When a SliderPreference is processing a preference with a value outside the supported values - valueFrom + x * stepSize an error is shown.

closes #5355 