### PR TITLE
fix: properly display tags in description 

### DIFF
--- a/app/src/main/res/layout/video_tag_row.xml
+++ b/app/src/main/res/layout/video_tag_row.xml
@@ -8,6 +8,7 @@
         style="@style/Widget.Material3.CardView.Elevated"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="1dp"
         android:layout_marginHorizontal="3dp">
 
         <TextView


### PR DESCRIPTION
Increases the bottom margin of tags in a video description, letting them display their shadow properly.

| Before                                                                                                                                        	| After                                                                                                                                       	|
|-----------------------------------------------------------------------------------------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Tags in the description with a broken shadow](https://github.com/libre-tube/LibreTube/assets/63370021/95090371-c8ea-4325-a266-e30d21357044) 	| ![Tags in the description properly displayed](https://github.com/libre-tube/LibreTube/assets/63370021/740a6f06-edce-4af0-b6b0-af84c1e699dd) 	|