### PR TITLE
fix: improve constrast between background and buttons

### DIFF
--- a/app/src/main/res/layout-land/fragment_player.xml
+++ b/app/src/main/res/layout-land/fragment_player.xml
@@ -11,7 +11,7 @@
         android:id="@+id/player_scrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:background="?colorSurfaceContainerLow"
+        android:background="?android:colorBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/related_container"
         app:layout_constraintHorizontal_bias="0.5"

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -11,7 +11,7 @@
         android:id="@+id/player_scrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:background="?colorSurfaceContainerLow"
+        android:background="?android:colorBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"


### PR DESCRIPTION
I tried many possible colours but ultimately decided to go for `android:background`. These were the reasons:
- With `android:background`, the colour matches the status bar;
- I think it is one of the most aesthetically appealing combinations;
- YouTube follows a similar approach of a darker background with lighter buttons.

Here are the possible colours - [Link to material-components colours](https://github.com/material-components/material-components-android/blob/master/docs/theming/Color.md)

Below are all the combinations I checked. Please let me know if we should choose another colour.

### colorSurfaceBright

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/1c3e6e7c-fdd2-441d-b9f0-0380e885f273)" width="250" height="550" />  
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/fd553f6a-0240-408e-9328-f2d21fbe3a20" width="250" height="550" />

### colorSurfaceContainer

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/8ad96ce5-4b57-49b4-b9b6-5b4206256054" width="250" height="550" />
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/8728073b-b527-44b5-a2a4-d5bfcde8dded" width="250" height="550" />

### colorSurfaceContainerHigh

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/aa629a2b-5a14-4cea-b2f5-fdd4fdeeed92" width="250" height="550" />
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/b8386af5-4c78-4fb8-acaf-395ea6209bbb" width="250" height="550" />

### colorSurfaceContainerHighest

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/3db2ed18-05c0-41f6-9fcc-b88bda76fe12" width="250" height="550" />
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/9f6f2bfe-0646-4644-8256-b561c4459413" width="250" height="550" />

### colorSurfaceDim

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/77efe480-7347-4dbf-9c28-126283c29f7e" width="250" height="550" />
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/ebbc31db-ccff-4adf-bde2-49790d996517" width="250" height="550" />

### android:background

<img src="https://github.com/libre-tube/LibreTube/assets/40279132/45b386e0-8234-427e-aa0f-786ca561c3df" width="250" height="550" />
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/1feccf46-fb5b-4fb0-bb01-a310916132f4" width="250" height="550" />

closes #5363 