### PR TITLE
feat: add "Rich caption rendering" setting

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -71,6 +71,7 @@ object PreferenceKeys {
     const val SEARCH_HISTORY_TOGGLE = "search_history_toggle"
     const val SYSTEM_CAPTION_STYLE = "system_caption_style"
     const val CAPTION_SETTINGS = "caption_settings"
+    const val RICH_CAPTION_RENDERING = "rich_caption_rendering"
     const val SEEK_INCREMENT = "seek_increment"
     const val DEFAULT_RESOLUTION = "default_res"
     const val DEFAULT_RESOLUTION_MOBILE = "default_res_mobile"

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -165,6 +165,12 @@ object PlayerHelper {
             true
         )
 
+    val useRichCaptionRendering: Boolean
+        get() = PreferenceHelper.getBoolean(
+            PreferenceKeys.RICH_CAPTION_RENDERING,
+            false
+        )
+
     private val bufferingGoal: Int
         get() = PreferenceHelper.getString(
             PreferenceKeys.BUFFERING_GOAL,

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -605,8 +605,8 @@ open class CustomExoPlayerView(
         val captionStyle = PlayerHelper.getCaptionStyle(context)
         subtitleView?.apply {
             setApplyEmbeddedFontSizes(false)
-            setViewType(SubtitleView.VIEW_TYPE_WEB)
             setFixedTextSize(Cue.TEXT_SIZE_TYPE_ABSOLUTE, PlayerHelper.captionsTextSize)
+            if (PlayerHelper.useRichCaptionRendering) setViewType(SubtitleView.VIEW_TYPE_WEB)
             if (!PlayerHelper.useSystemCaptionStyle) return
             setApplyEmbeddedStyles(captionStyle == CaptionStyleCompat.DEFAULT)
             setStyle(captionStyle)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,6 +223,7 @@
     <string name="watch_positions_title">Remembered playback positions</string>
     <string name="reset_watch_positions">Reset</string>
     <string name="system_caption_style">System caption style</string>
+    <string name="rich_caption_rendering">Rich caption rendering</string>
     <string name="captions">Captions</string>
     <string name="none">None</string>
     <string name="general">General</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="reset_watch_positions">Reset</string>
     <string name="system_caption_style">System caption style</string>
     <string name="rich_caption_rendering">Rich caption rendering</string>
+    <string name="rich_caption_rendering_summary">Render web captions for a more rich and customized experience.</string>
     <string name="captions">Captions</string>
     <string name="none">None</string>
     <string name="general">General</string>

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -123,6 +123,12 @@
             app:key="caption_settings"
             app:title="@string/caption_settings" />
 
+        <SwitchPreferenceCompat
+            android:icon="@drawable/ic_caption"
+            app:defaultValue="false"
+            app:key="rich_caption_rendering"
+            app:title="@string/rich_caption_rendering" />
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/queue">

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -127,7 +127,8 @@
             android:icon="@drawable/ic_caption"
             app:defaultValue="false"
             app:key="rich_caption_rendering"
-            app:title="@string/rich_caption_rendering" />
+            app:title="@string/rich_caption_rendering"
+            android:summary="@string/rich_caption_rendering_summary"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Adds a new setting - `Rich caption rendering` (**false** by default) under Settings > Player > Appearance.

#### Showcase

https://github.com/libre-tube/LibreTube/assets/40279132/f5c5d743-c51f-4670-9ba0-165833ad1513

- Translations;

## Notes
- This setting does not apply mid-video. e.g. If we are watching a video, and change the setting, the changes only reflect once we open a new video. The settings I tested had the same behaviour, but I would like to confirm that is expected, or if I'm missing something;
- I added a new translation under the id - `rich_caption_rendering`. I don't know if there is anything else I must do regarding this addition.

closes #5306 