### PR TITLE
fix: oldest videos repeatedly displayed when loading channel videos

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -116,7 +116,7 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
 
         try {
             if (binding.tabChips.checkedChipId == binding.videos.id) {
-                fetchChannelNextPage(nextPages[0] ?: return@launch)?.let {
+                fetchChannelNextPage(nextPages[0] ?: return@launch).let {
                     nextPages[0] = it
                 }
             } else {
@@ -127,7 +127,7 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
                     tab.name == possibleTabs[currentTabIndex - 1].identifierName
                 }
                 val nextPage = nextPages[currentTabIndex] ?: return@launch
-                fetchTabNextPage(nextPage, channelTab)?.let {
+                fetchTabNextPage(nextPage, channelTab).let {
                     nextPages[currentTabIndex] = it
                 }
             }


### PR DESCRIPTION
### Merry Christmas! 🎅 

Removed null check from `.let`call.

https://github.com/libre-tube/LibreTube/assets/40279132/7c94664f-da9b-4b3d-b279-20491232bc27

closes #5361 