### PR TITLE
fix: correctly display transparent channelImages

### DIFF
--- a/app/src/main/res/layout/channel_row.xml
+++ b/app/src/main/res/layout/channel_row.xml
@@ -10,6 +10,7 @@
         android:layout_marginVertical="5dp"
         android:layout_marginStart="50dp"
         android:layout_marginEnd="55dp"
+        android:background="@android:color/white"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:shapeAppearance="@style/CircleImageView" />

--- a/app/src/main/res/layout/channel_subscription_row.xml
+++ b/app/src/main/res/layout/channel_subscription_row.xml
@@ -14,6 +14,7 @@
         android:layout_height="40dp"
         android:layout_gravity="center"
         android:layout_marginStart="8dp"
+        android:background="@android:color/white"
         app:shapeAppearance="@style/CircleImageView" />
 
     <TextView

--- a/app/src/main/res/layout/comments_row.xml
+++ b/app/src/main/res/layout/comments_row.xml
@@ -21,7 +21,7 @@
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:layout_marginEnd="16dp"
-            android:background="@android:color/darker_gray"
+            android:background="@android:color/white"
             app:shapeAppearance="@style/CircleImageView"
             tools:src="@mipmap/ic_launcher" />
 
@@ -122,6 +122,7 @@
                     android:layout_height="14dp"
                     android:layout_marginEnd="8dp"
                     android:visibility="gone"
+                    android:background="@android:color/white"
                     tools:visibility="gone"
                     app:shapeAppearance="@style/CircleImageView" />
 

--- a/app/src/main/res/layout/fragment_channel.xml
+++ b/app/src/main/res/layout/fragment_channel.xml
@@ -36,6 +36,7 @@
                     android:layout_width="45dp"
                     android:layout_height="45dp"
                     android:layout_gravity="center"
+                    android:background="@android:color/white"
                     app:shapeAppearance="@style/CircleImageView" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -86,6 +86,7 @@
                     android:layout_height="40dp"
                     android:layout_gravity="center"
                     android:layout_marginEnd="4dp"
+                    android:background="@android:color/white"
                     app:shapeAppearance="@style/CircleImageView" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/subscription_group_channel_row.xml
+++ b/app/src/main/res/layout/subscription_group_channel_row.xml
@@ -13,6 +13,7 @@
         android:layout_height="36dp"
         android:layout_gravity="center"
         android:layout_marginStart="8dp"
+        android:background="@android:color/white"
         app:shapeAppearance="@style/CircleImageView" />
 
     <TextView

--- a/app/src/main/res/layout/trending_row.xml
+++ b/app/src/main/res/layout/trending_row.xml
@@ -107,6 +107,7 @@
             android:id="@+id/channel_image"
             android:layout_width="40dp"
             android:layout_height="40dp"
+            android:background="@android:color/white"
             tools:srcCompat="@mipmap/ic_launcher" />
 
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/video_row.xml
+++ b/app/src/main/res/layout/video_row.xml
@@ -111,6 +111,7 @@
 
             <ImageView
                 android:id="@+id/channel_image"
+                android:background="@android:color/white"
                 android:layout_width="27dp"
                 android:layout_height="27dp" />
 


### PR DESCRIPTION
Fixes an issue where transparent profile pictures were not readable in dark mode because YouTube uses a light background for the image by default. This change has the side effect of making unloaded profile pictures appear white.

| Before                                                                                                                                    	| After                                                                                                                               	|
|-------------------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------	|
| ![ChannelImage with transparent background](https://github.com/libre-tube/LibreTube/assets/63370021/f53dad80-cbb6-4c42-b9f3-25b1904f9daa) 	| ![ChannelImage with white background](https://github.com/libre-tube/LibreTube/assets/63370021/e25ba513-5b95-46ab-a1cf-a771b532a969) 	|
