### PR TITLE
fix: Incorrect actions management through bluetooth devices

### DIFF
--- a/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
+++ b/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
@@ -262,6 +262,7 @@ class NowPlayingNotification(
                 PlaybackStateCompat.ACTION_FAST_FORWARD or
                 PlaybackStateCompat.ACTION_PLAY_PAUSE or
                 PlaybackStateCompat.ACTION_PAUSE or
+                PlaybackStateCompat.ACTION_PLAY or
                 PlaybackStateCompat.ACTION_SEEK_TO
 
         return PlaybackStateCompat.Builder()


### PR DESCRIPTION
Ensure the player pauses and plays correctly through the action of input devices.

closes #5422 