### PR TITLE
feat: cache feed response

### DIFF
--- a/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
@@ -25,6 +25,7 @@ object SubscriptionHelper {
 
     private var feed: List<StreamItem> = listOf()
     private var lastFeedFetchTime: Long = 0
+
     /*
      * Minimum time that has to pass until the feed is refreshed.
      * Currently set to 5 minutes
@@ -123,8 +124,9 @@ object SubscriptionHelper {
         val currentTime = System.currentTimeMillis()
         // if we already have a fetched feed, that is fresher than `UPDATE_TIME_INTERVAL` and were not force refreshing,
         // we just return the feed
-        if (feed.isNotEmpty() && currentTime - lastFeedFetchTime <= UPDATE_TIME_INTERVAL && !forceRefresh)
+        if (feed.isNotEmpty() && currentTime - lastFeedFetchTime <= UPDATE_TIME_INTERVAL && !forceRefresh) {
             return feed
+        }
 
         feed = if (token.isNotEmpty()) {
             RetrofitInstance.authApi.getFeed(token)

--- a/app/src/main/java/com/github/libretube/ui/dialogs/AddToPlaylistDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/AddToPlaylistDialog.kt
@@ -5,7 +5,6 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.util.Log
-import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels

--- a/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
@@ -24,11 +24,11 @@ import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.parcelable.DownloadData
 import com.github.libretube.util.TextUtils
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import retrofit2.HttpException
-import java.io.IOException
 
 class DownloadDialog : DialogFragment() {
     private lateinit var videoId: String

--- a/app/src/main/java/com/github/libretube/ui/dialogs/SubmitSegmentDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/SubmitSegmentDialog.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.util.Log
-import android.widget.ArrayAdapter
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope

--- a/app/src/main/java/com/github/libretube/ui/dialogs/VoteForSegmentDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/VoteForSegmentDialog.kt
@@ -5,7 +5,6 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
-import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope

--- a/app/src/main/java/com/github/libretube/ui/extensions/ViewAnimations.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/ViewAnimations.kt
@@ -9,11 +9,7 @@ import android.view.View
  * @param dy The distance to move the view along the Y-axis.
  * @param onEnd An optional lambda function that is invoked when the animation ends.
  */
-fun View.animateDown(
-    duration: Long,
-    dy: Float,
-    onEnd: () -> Unit = { }
-) {
+fun View.animateDown(duration: Long, dy: Float, onEnd: () -> Unit = { }) {
     this
         .animate()
         .withEndAction { onEnd.invoke() }

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -33,11 +33,11 @@ import com.github.libretube.ui.dialogs.ShareDialog
 import com.github.libretube.ui.extensions.setupSubscriptionButton
 import com.github.libretube.ui.sheets.AddChannelToGroupSheet
 import com.github.libretube.util.deArrow
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import retrofit2.HttpException
-import java.io.IOException
 
 class ChannelFragment : DynamicLayoutManagerFragment() {
     private var _binding: FragmentChannelBinding? = null

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -116,16 +116,16 @@ import com.github.libretube.util.TextUtils
 import com.github.libretube.util.TextUtils.toTimeInSeconds
 import com.github.libretube.util.YoutubeHlsPlaylistParser
 import com.github.libretube.util.deArrow
+import java.io.IOException
+import java.util.*
+import java.util.concurrent.Executors
+import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import retrofit2.HttpException
-import java.io.IOException
-import java.util.*
-import java.util.concurrent.Executors
-import kotlin.math.abs
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class PlayerFragment : Fragment(), OnlinePlayerOptions {
@@ -493,7 +493,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             .animateDown(
                 duration = 300L,
                 dy = 500F,
-                onEnd = ::killPlayerFragment,
+                onEnd = ::killPlayerFragment
             )
     }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -106,7 +106,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
 
         binding.subRefresh.setOnRefreshListener {
             viewModel.fetchSubscriptions(requireContext())
-            viewModel.fetchFeed(requireContext())
+            viewModel.fetchFeed(requireContext(), true)
         }
 
         binding.sortTV.setOnClickListener {

--- a/app/src/main/java/com/github/libretube/ui/models/SubscriptionsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/SubscriptionsViewModel.kt
@@ -21,10 +21,10 @@ class SubscriptionsViewModel : ViewModel() {
 
     var subscriptions = MutableLiveData<List<Subscription>?>()
 
-    fun fetchFeed(context: Context) {
+    fun fetchFeed(context: Context, forceRefresh: Boolean = false) {
         viewModelScope.launch(Dispatchers.IO) {
             val videoFeed = try {
-                SubscriptionHelper.getFeed()
+                SubscriptionHelper.getFeed(forceRefresh)
             } catch (e: Exception) {
                 context.toastFromMainDispatcher(R.string.server_error)
                 Log.e(TAG(), e.toString())

--- a/app/src/main/java/com/github/libretube/ui/views/SingleViewTouchableMotionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/SingleViewTouchableMotionLayout.kt
@@ -64,7 +64,6 @@ class SingleViewTouchableMotionLayout(context: Context, attributeSet: AttributeS
             distanceX: Float,
             distanceY: Float
         ): Boolean {
-
             if (distanceY < -15F) {
                 swipeDownListener.forEach { it.invoke() }
                 return true

--- a/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
+++ b/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
@@ -257,13 +257,13 @@ class NowPlayingNotification(
 
     private fun createPlaybackState(@PlaybackStateCompat.State state: Int): PlaybackStateCompat {
         val stateActions = PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
-                PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-                PlaybackStateCompat.ACTION_REWIND or
-                PlaybackStateCompat.ACTION_FAST_FORWARD or
-                PlaybackStateCompat.ACTION_PLAY_PAUSE or
-                PlaybackStateCompat.ACTION_PAUSE or
-                PlaybackStateCompat.ACTION_PLAY or
-                PlaybackStateCompat.ACTION_SEEK_TO
+            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
+            PlaybackStateCompat.ACTION_REWIND or
+            PlaybackStateCompat.ACTION_FAST_FORWARD or
+            PlaybackStateCompat.ACTION_PLAY_PAUSE or
+            PlaybackStateCompat.ACTION_PAUSE or
+            PlaybackStateCompat.ACTION_PLAY or
+            PlaybackStateCompat.ACTION_SEEK_TO
 
         return PlaybackStateCompat.Builder()
             .setActions(stateActions)
@@ -306,8 +306,13 @@ class NowPlayingNotification(
 
             STOP -> {
                 when (notificationType) {
-                    NowPlayingNotificationType.AUDIO_ONLINE -> BackgroundHelper.stopBackgroundPlay(context)
-                    NowPlayingNotificationType.AUDIO_OFFLINE -> BackgroundHelper.stopBackgroundPlay(context, OfflinePlayerService::class.java)
+                    NowPlayingNotificationType.AUDIO_ONLINE -> BackgroundHelper.stopBackgroundPlay(
+                        context
+                    )
+                    NowPlayingNotificationType.AUDIO_OFFLINE -> BackgroundHelper.stopBackgroundPlay(
+                        context,
+                        OfflinePlayerService::class.java
+                    )
                     else -> Unit
                 }
             }
@@ -422,7 +427,7 @@ class NowPlayingNotification(
             VIDEO_ONLINE,
             VIDEO_OFFLINE,
             AUDIO_ONLINE,
-            AUDIO_OFFLINE,
+            AUDIO_OFFLINE
         }
     }
 }


### PR DESCRIPTION
Adds a light cache to the initial feed response. This improves the user experience by eliminating the need to load the feed a second time when switching from Home to the Subscriptions tab, as well as eliminating unnecessary requests. The response is cached for 5 minutes, using pull-to-refresh ignores the caching and always requests a new version from the server.