### PR TITLE
style: tweak speed/pitch bottom sheet layout

### DIFF
--- a/app/src/main/res/layout/playback_bottom_sheet.xml
+++ b/app/src/main/res/layout/playback_bottom_sheet.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <FrameLayout
         android:id="@+id/standard_bottom_sheet"
@@ -26,12 +27,12 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingHorizontal="20dp">
+                android:orientation="vertical">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="23dp"
                     android:text="@string/playback_speed" />
 
                 <androidx.recyclerview.widget.RecyclerView
@@ -39,7 +40,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:orientation="horizontal" />
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="20dp"
+                    android:clipToPadding="false"
+                    app:layoutManager="LinearLayoutManager"
+                    tools:listitem="@layout/slider_label_item"/>
 
                 <com.google.android.material.slider.Slider
                     android:id="@+id/speed"
@@ -48,11 +53,14 @@
                     android:stepSize="0.05"
                     android:value="1.0"
                     android:valueFrom="0.2"
-                    android:valueTo="4.0" />
+                    android:valueTo="4.0"
+                    android:layout_marginHorizontal="10dp" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="23dp"
+                    android:layout_marginTop="10dp"
                     android:text="@string/playback_pitch" />
 
                 <androidx.recyclerview.widget.RecyclerView
@@ -60,7 +68,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:orientation="horizontal" />
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="20dp"
+                    android:clipToPadding="false"
+                    app:layoutManager="LinearLayoutManager"
+                    tools:listitem="@layout/slider_label_item"/>
 
                 <com.google.android.material.slider.Slider
                     android:id="@+id/pitch"
@@ -69,7 +81,8 @@
                     android:stepSize="0.1"
                     android:value="1.0"
                     android:valueFrom="0.5"
-                    android:valueTo="2.0" />
+                    android:valueTo="2.0"
+                    android:layout_marginHorizontal="10dp" />
 
             </LinearLayout>
 
@@ -78,9 +91,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:paddingHorizontal="10dp"
+                android:layout_marginHorizontal="17dp"
+                android:paddingHorizontal="5dp"
                 android:text="@string/skip_silence" />
 
         </LinearLayout>


### PR DESCRIPTION
- Improve layout of video/audio speed sheet;
- Add `tools:listitem="@layout/slider_label_item"`to recyclerviews, to improve preview;

Please let me know if you think this change didn't result in an improvement.

### Before
https://github.com/libre-tube/LibreTube/assets/40279132/f0806605-fcea-438f-ab68-02ef33e52173

### Now
https://github.com/libre-tube/LibreTube/assets/40279132/ba8bf452-b8e4-4cfb-9fe2-aebb5d990a93

### Side by Side (Before - in the Left, Now - in the right)
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/d858152a-1d77-4298-b8a7-550afee96f60" width="35%" height="35%"/>   
<img src="https://github.com/libre-tube/LibreTube/assets/40279132/0c6ffaa5-14bc-469e-b6c7-fc49265dc2ad" width="35%" height="35%"/>
