### PR TITLE
fix: Audio Pausing on quickly volume level adjustment

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/listeners/AudioPlayerThumbnailListener.kt
+++ b/app/src/main/java/com/github/libretube/ui/listeners/AudioPlayerThumbnailListener.kt
@@ -22,9 +22,12 @@ class AudioPlayerThumbnailListener(context: Context, private val listener: Audio
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(v: View, event: MotionEvent): Boolean {
         if (event.action == MotionEvent.ACTION_UP && isMoving) {
-            isMoving = false
             listener.onSwipeEnd()
             return false
+        }
+
+        if (event.action == MotionEvent.ACTION_DOWN) {
+            isMoving = false
         }
 
         runCatching {
@@ -37,8 +40,6 @@ class AudioPlayerThumbnailListener(context: Context, private val listener: Audio
     private inner class GestureListener : GestureDetector.SimpleOnGestureListener() {
 
         override fun onDown(e: MotionEvent): Boolean {
-            if (isMoving) return false
-
             handler.postDelayed(ACTION_INTERVAL, SINGLE_PRESS_TOKEN) {
                 if (!isMoving) listener.onSingleTap()
             }


### PR DESCRIPTION
### Issue explanation

This problem is not easily replicable, since we need to adjust the volume level very quickly.

https://github.com/libre-tube/LibreTube/assets/40279132/5b6a38d2-4fff-4ca2-9814-a3923c1eb76d

When the volume is adjusted very quickly (faster than 400ms), the following methods are called in the following order
1. `onTouch` with `event.action == MotionEvent.ACTION_DOWN`;
2. `onDown`. Here we call: 
```kotlin
handler.postDelayed(ACTION_INTERVAL, SINGLE_PRESS_TOKEN) { // ACTION_INTERVAL = 400ms
    if (!isMoving) listener.onSingleTap()
}
```
3. `onTouch` with `event.action == MotionEvent.ACTION_MOVE`;
4. `onScroll`. Here we set `isMoving = true`;
5. `onTouch` with `event.action == MotionEvent.ACTION_UP`. Here we set `isMoving = false`;
6. At this point, the `handler.postDelayed` runs, and `isMoving` was already reset to `false`, thus pausing the audio, when a scroll took place;

To fix this issue, I propose we reset `isMoving` in `onTouch` method, when `event.action == MotionEvent.ACTION_DOWN`.

### Fixed behaviour
https://github.com/libre-tube/LibreTube/assets/40279132/14103969-2cc6-4575-ada8-9981c0eb1fce

closes #5410 