### PR TITLE
fix: Improve player to mini-player transition + bottom space when there are no navigation tabs 

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/NavBarHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/NavBarHelper.kt
@@ -16,15 +16,22 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationBarView
 
 object NavBarHelper {
+
     private const val SEPARATOR = ","
+
+    fun hasTabs(): Boolean {
+        val prefsItems = getNavBarPrefs()
+
+        val tabsUnchanged = prefsItems.isEmpty()
+        val allTabsHidden = prefsItems.all { it.contains("-") }
+
+        return tabsUnchanged || !allTabsHidden
+    }
 
     // contains "-" -> invisible menu item, else -> visible menu item
     fun getNavBarItems(context: Context): List<MenuItem> {
         val prefItems = try {
-            PreferenceHelper.getString(
-                PreferenceKeys.NAVBAR_ITEMS,
-                ""
-            ).split(SEPARATOR)
+            getNavBarPrefs()
         } catch (e: Exception) {
             Log.e("fail to parse nav items", e.toString())
             return getDefaultNavBarItems(context)
@@ -126,4 +133,11 @@ object NavBarHelper {
         val index = getDefaultNavBarItems(context).indexOfFirst { it.itemId == itemId }
         PreferenceHelper.putInt(PreferenceKeys.START_FRAGMENT, index)
     }
+
+    private fun getNavBarPrefs(): List<String> {
+        return PreferenceHelper
+            .getString(PreferenceKeys.NAVBAR_ITEMS, "")
+            .split(SEPARATOR)
+    }
+
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -33,6 +33,7 @@ import com.github.libretube.extensions.toID
 import com.github.libretube.helpers.AudioHelper
 import com.github.libretube.helpers.BackgroundHelper
 import com.github.libretube.helpers.ImageHelper
+import com.github.libretube.helpers.NavBarHelper
 import com.github.libretube.helpers.NavigationHelper
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.ThemeHelper
@@ -216,6 +217,7 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
     private fun initializeTransitionLayout() {
         mainActivity.binding.container.isVisible = true
         val mainMotionLayout = mainActivity.binding.mainMotionLayout
+        mainMotionLayout.progress = 0F
 
         val surfaceColor = SurfaceColors.getColorForElevation(requireContext(), 3f)
         binding.audioPlayerContainer.setBackgroundColor(surfaceColor)
@@ -227,7 +229,9 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
                 endId: Int,
                 progress: Float
             ) {
-                mainMotionLayout.progress = abs(progress)
+                if (NavBarHelper.hasTabs()) {
+                    mainMotionLayout.progress = abs(progress)
+                }
                 transitionEndId = endId
                 transitionStartId = startId
             }
@@ -235,7 +239,9 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
             override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
                 if (currentId == transitionEndId) {
                     viewModel.isMiniPlayerVisible.value = true
-                    mainMotionLayout.progress = 1F
+                    if (NavBarHelper.hasTabs()) {
+                        mainMotionLayout.progress = 1F
+                    }
                 } else if (currentId == transitionStartId) {
                     viewModel.isMiniPlayerVisible.value = false
                     mainMotionLayout.progress = 0F

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -79,6 +79,7 @@ import com.github.libretube.extensions.togglePlayPauseState
 import com.github.libretube.extensions.updateParameters
 import com.github.libretube.helpers.BackgroundHelper
 import com.github.libretube.helpers.ImageHelper
+import com.github.libretube.helpers.NavBarHelper
 import com.github.libretube.helpers.NavigationHelper
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.PlayerHelper.SPONSOR_HIGHLIGHT_CATEGORY
@@ -423,6 +424,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     private fun initializeTransitionLayout() {
         mainActivity.binding.container.isVisible = true
         val mainMotionLayout = mainActivity.binding.mainMotionLayout
+        mainMotionLayout.progress = 0F
 
         binding.playerMotionLayout.addTransitionListener(object : TransitionAdapter() {
             override fun onTransitionChange(
@@ -433,7 +435,9 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             ) {
                 if (_binding == null) return
 
-                mainMotionLayout.progress = abs(progress)
+                if (NavBarHelper.hasTabs()) {
+                    mainMotionLayout.progress = abs(progress)
+                }
                 disableController()
                 commentsViewModel.setCommentSheetExpand(false)
                 chaptersBottomSheet?.dismiss()
@@ -459,7 +463,9 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                     disableController()
                     commentsViewModel.setCommentSheetExpand(null)
                     binding.sbSkipBtn.isGone = true
-                    mainMotionLayout.progress = 1F
+                    if (NavBarHelper.hasTabs()) {
+                        mainMotionLayout.progress = 1F
+                    }
                     (activity as MainActivity).requestOrientationChange()
                 }
             }

--- a/app/src/main/res/xml/activity_main_scene.xml
+++ b/app/src/main/res/xml/activity_main_scene.xml
@@ -12,14 +12,27 @@
                 android:translationY="0dp"
                 motion:framePosition="0"
                 motion:motionTarget="@+id/bottomNav" />
+
             <KeyAttribute
-                android:translationY="55dp"
-                motion:framePosition="75"
+                android:translationY="80dp"
+                motion:framePosition="1"
                 motion:motionTarget="@+id/bottomNav" />
+
+            <KeyAttribute
+                android:translationY="0dp"
+                motion:framePosition="100"
+                motion:motionTarget="@+id/bottomNav" />
+
             <KeyAttribute
                 android:scaleY="1"
-                motion:framePosition="50"
+                motion:framePosition="30"
                 motion:motionTarget="@+id/container" />
+
+            <KeyAttribute
+                android:translationY="0dp"
+                motion:framePosition="35"
+                motion:motionTarget="@+id/container" />
+
             <KeyAttribute
                 android:translationY="-80dp"
                 motion:framePosition="100"


### PR DESCRIPTION
- Adjusts scene for a smoother transition;
- Fixes vertical positioning when transitioning to mini-player when there are no tabs;

closes #2548 

### Current transitions (for comparison)

https://github.com/libre-tube/LibreTube/assets/40279132/0fa8d107-eda9-4f72-953f-e09aad33338f

https://github.com/libre-tube/LibreTube/assets/40279132/15122b62-7bdd-4a16-895d-a2770d41ebbf

### New transitions

https://github.com/libre-tube/LibreTube/assets/40279132/94d24616-eecd-4a89-87d3-8855ca135e9a

https://github.com/libre-tube/LibreTube/assets/40279132/4997baab-6455-4de1-abaa-1e8bfa6b28f8

https://github.com/libre-tube/LibreTube/assets/40279132/1639bf6a-c752-483d-8e8e-1374963b2d0f

https://github.com/libre-tube/LibreTube/assets/40279132/594d146e-0c15-426f-b4c4-666767324737

### Cons

In my opinion, the downside of this approach is that we have to manually check whether there are navigation tabs, which is sub-optimal 😞
Let me know if you think of a better approach.
