### PR TITLE
fix: clarify setting description

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,7 +350,7 @@
     <string name="volume">Volume</string>
     <string name="auto">Auto</string>
     <string name="swipe_controls">Swipe controls</string>
-    <string name="swipe_controls_summary">Use swipe gesture to adjust the brightness and volume</string>
+    <string name="swipe_controls_summary">Swipe to adjust the brightness and volume while in fullscreen mode</string>
     <string name="pinch_control">Pinch control</string>
     <string name="pinch_control_summary">Use pinch gesture to zoom in/out</string>
     <string name="defaults">Defaults</string>


### PR DESCRIPTION
Tweak `swipe_controls_summary` to describe what it does more accurately.

see #5439 