### PR TITLE
chore: improve save feed summary

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,7 +297,7 @@
     <string name="preferences">Preferences</string>
     <string name="backup_customInstances">Custom Instances</string>
     <string name="save_feed">Load feed in background</string>
-    <string name="save_feed_summary">Load the subscription feed in the background and prevent it from being auto-refreshed</string>
+    <string name="save_feed_summary">Load the subscription feed in the background and prevent it from being reloaded when switching tabs</string>
     <string name="play_next">Play next</string>
     <string name="navigation_bar">Navigation bar</string>
     <string name="change_region">Trending seems to be unavailable for the current region. Please select another in the settings.</string>


### PR DESCRIPTION
Improves the summary of the "Load feed in background" option to help users understand what exactly changes when this option is turned on, see https://github.com/libre-tube/LibreTube/pull/5429.
I also think that enabling this option by default is worthwhile, as it both improves the user experience and reduces the load on the server, with very little to no downside.