### PR TITLE
fix: Improve home feed layout and fix issue where incorrect cache size was defaulted.

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -19,35 +19,43 @@ import com.github.libretube.util.DataSaverMode
 import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 
 object ImageHelper {
     lateinit var imageLoader: ImageLoader
+
+    private val Context.coilFile get() = cacheDir.resolve("coil")
 
     /**
      * Initialize the image loader
      */
     fun initializeImageLoader(context: Context) {
-        val maxImageCacheSize = PreferenceHelper.getString(
-            PreferenceKeys.MAX_IMAGE_CACHE,
-            ""
-        )
+        val maxCacheSize = PreferenceHelper.getString(PreferenceKeys.MAX_IMAGE_CACHE, "128")
 
         imageLoader = ImageLoader.Builder(context)
             .callFactory(CronetHelper.callFactory)
+            .crossfade(true)
             .apply {
-                when (maxImageCacheSize) {
-                    "" -> {
-                        diskCachePolicy(CachePolicy.DISABLED)
-                    }
+                if (maxCacheSize.isEmpty()) {
+                    diskCachePolicy(CachePolicy.DISABLED)
+                } else {
+                    diskCachePolicy(CachePolicy.ENABLED)
+                    memoryCachePolicy(CachePolicy.ENABLED)
 
-                    else -> diskCache(
-                        DiskCache.Builder()
-                            .directory(context.cacheDir.resolve("coil"))
-                            .maxSizeBytes(maxImageCacheSize.toInt() * 1024 * 1024L)
-                            .build()
+                    val diskCache = generateDiskCache(
+                        directory = context.coilFile,
+                        size = maxCacheSize.toInt()
                     )
+                    diskCache(diskCache)
                 }
             }
+            .build()
+    }
+
+    private fun generateDiskCache(directory: File, size: Int): DiskCache {
+        return DiskCache.Builder()
+            .directory(directory)
+            .maxSizeBytes(size * 1024 * 1024L)
             .build()
     }
 
@@ -56,7 +64,7 @@ object ImageHelper {
      */
     fun loadImage(url: String?, target: ImageView) {
         // only load the image if the data saver mode is disabled
-        if (DataSaverMode.isEnabled(target.context) || url == null) return
+        if (DataSaverMode.isEnabled(target.context) || url.isNullOrEmpty()) return
         val urlToLoad = ProxyHelper.unwrapImageUrl(url)
         target.load(urlToLoad, imageLoader)
     }

--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -167,6 +167,7 @@ class HomeFragment : Fragment() {
             filteredFeed.take(20).toMutableList(),
             forceMode = VideosAdapter.Companion.LayoutMode.RELATED_COLUMN
         )
+        binding.featuredRV.setHasFixedSize(true)
     }
 
     private suspend fun loadBookmarks() {

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -35,7 +35,8 @@
                     android:id="@+id/featuredRV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="10dp"
+                    android:paddingHorizontal="10dp"
+                    android:clipToPadding="false"
                     android:nestedScrollingEnabled="false"
                     android:visibility="gone" />
 
@@ -48,7 +49,8 @@
                     android:id="@+id/watchingRV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="10dp"
+                    android:paddingHorizontal="10dp"
+                    android:clipToPadding="false"
                     android:nestedScrollingEnabled="false"
                     android:visibility="gone" />
 


### PR DESCRIPTION
### Issue

The main issue being addressed in this PR is the fact that by default the **Max image cache size** setting was empty, instead of "128MB" (that is defaulted when we go to Settings > Advanced > Max image cache size).

For a sample of the issue please take a look at this video (on Google Drive - too large) - [Issue replication video](https://drive.google.com/file/d/100EXLmjwwdKpMxl-F8tkpWWbm--05C3h/view?usp=drive_link)
In the video, a `200` represents a new image loaded, and a `304` or nothing, represents images being retrieved from cache.

To test this on your own, here's a patch with the necessary changes - [analyse-current-state.patch](https://github.com/libre-tube/LibreTube/files/13845315/Analyse_image_load_-_currently_.patch).

### What does this PR do?

- Changes the default value from "" to "128";
- Sets recycler view to fixed size, since its size will not change without page reload;
- Adjusts __fragment_home.xml__, so that the horizontal recycler view extends to the end of the screen;
- Added `crossfade` - Please let me know if you want this removed, I added it because it look very much an improvement in my eyes 👀 .

Here's the same analysis with the changes contained in this PR (on Google Drive - too large) - [post-changes sample](https://drive.google.com/file/d/1BT3HVkWN2H7vUQZW9vSO9pBNKMb6Y3l_/view?usp=sharing).

To test this on your own, here's a patch with the necessary changes - 
[Post-changes-sample.patch](https://github.com/libre-tube/LibreTube/files/13845335/Analyse_image_load_-_Post_changes_.patch).

Lastly, here are the current and pos changes samples for visual comparison.

https://github.com/libre-tube/LibreTube/assets/40279132/6b92d025-9eac-4357-8e45-164759657582

https://github.com/libre-tube/LibreTube/assets/40279132/563e58f6-17ee-4a0c-b136-9e4bdeb96c77

Please let me know if this does not make sense, or if I may have missed some business rule(s).