### PR TITLE
fix: ResettableLazyManager not being reset on changing instances.

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
@@ -34,6 +34,7 @@ class InstanceSettings : BasePreferenceFragment() {
     override val titleResourceId: Int = R.string.instance
     private val token get() = PreferenceHelper.getToken()
     private var instances = listOf<PipedInstance>()
+    private val authInstanceToggle get() = findPreference<SwitchPreferenceCompat>(PreferenceKeys.AUTH_INSTANCE_TOGGLE)!!
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.instance_settings, rootKey)
@@ -44,7 +45,6 @@ class InstanceSettings : BasePreferenceFragment() {
         )!!
         val authInstance = findPreference<ListPreference>(PreferenceKeys.AUTH_INSTANCE)!!
         val instancePrefs = listOf(instancePref, authInstance)
-
         val appContext = requireContext().applicationContext
 
         lifecycleScope.launch {
@@ -60,15 +60,6 @@ class InstanceSettings : BasePreferenceFragment() {
             } catch (e: Exception) {
                 appContext.toastFromMainDispatcher(e.message.orEmpty())
             }
-        }
-
-        instancePref.setOnPreferenceChangeListener { _, _ ->
-            if (!authInstanceToggle.isChecked) {
-                logoutAndUpdateUI()
-            }
-            RetrofitInstance.lazyMgr.reset()
-            ActivityCompat.recreate(requireActivity())
-            true
         }
 
         authInstance.setOnPreferenceChangeListener { _, _ ->
@@ -190,6 +181,7 @@ class InstanceSettings : BasePreferenceFragment() {
             .setView(binding.root)
             .setPositiveButton(R.string.okay) { _, _ ->
                 preference.value = selectedInstance
+                resetForNewInstance()
             }
             .setNegativeButton(R.string.cancel, null)
             .show()
@@ -201,6 +193,14 @@ class InstanceSettings : BasePreferenceFragment() {
         findPreference<Preference>(PreferenceKeys.LOGIN_REGISTER)?.isVisible = true
         findPreference<Preference>(PreferenceKeys.LOGOUT)?.isVisible = false
         findPreference<Preference>(PreferenceKeys.DELETE_ACCOUNT)?.isEnabled = false
+    }
+
+    private fun resetForNewInstance() {
+        if (!authInstanceToggle.isChecked) {
+            logoutAndUpdateUI()
+        }
+        RetrofitInstance.lazyMgr.reset()
+        ActivityCompat.recreate(requireActivity())
     }
 
     companion object {


### PR DESCRIPTION
## Issue
- When an instance is changed on `InstanceSettings.kt`, the function `instancePref.setOnPreferenceChangeListener` is not being invoked, despite assignment `preference.value = selectedInstance` on L192. This results on `ResettableLazyManager` not being reset, leading to the API not being reloaded, to take into account the new instance selected.

###  Issue replication
https://github.com/libre-tube/LibreTube/assets/40279132/89e47af1-d957-4b06-9fc4-b48f7eb52ee2

## What does this PR do?
- Ensure `ResettableLazyManager` is reset when a new instance is selected. (Please validate my approach)

## Showcase

https://github.com/libre-tube/LibreTube/assets/40279132/bfb51e45-37a8-430d-8f48-f39b7c14c911

Please let me know if you see a better approach to fixing the issue.