### PR TITLE
fix: don't show history when closing video on channel page

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -247,7 +247,7 @@ class MainActivity : BaseActivity() {
     private fun isSearchInProgress(): Boolean {
         if (!::navController.isInitialized) return false
         val id = navController.currentDestination?.id ?: return false
-        return id in listOf(R.id.searchFragment, R.id.searchResultFragment)
+        return id in listOf(R.id.searchFragment, R.id.searchResultFragment, R.id.channelFragment)
     }
 
     override fun invalidateMenu() {


### PR DESCRIPTION
This pull request makes the following changes:

Fixes issue #5115 



