### PR TITLE
fix: clear views on VideoAdapter's onBindViewHolder

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
@@ -103,6 +103,8 @@ class VideosAdapter(
 
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: VideosViewHolder, position: Int) {
+        holder.trendingRowBinding?.thumbnail?.setImageDrawable(null)
+
         val video = streamItems[position]
         val videoId = video.url?.toID()
 


### PR DESCRIPTION
## Issue
- When scrolling horizontally on the feed, because we are using a recycler view and not resetting the image before a thumbnail is successfully loaded, the image from the view that was previously recycled shows up - The magnitude of this issue depends on the quality of the user's network - fast internet speeds minimize the problem - issue replication below:

https://github.com/libre-tube/LibreTube/assets/40279132/d6320d98-e91e-4726-aee9-29cce98d289f

## What does this PR do?
- Resets the view before loading a new image to it;

## Showcase
https://github.com/libre-tube/LibreTube/assets/40279132/a26f1d4f-32ba-499e-b703-a204d6bc963f