### PR TITLE
feat: seperate trends fragment into a viewmodel to improve ux

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
@@ -2,32 +2,23 @@ package com.github.libretube.ui.fragments
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.view.isGone
-import androidx.lifecycle.lifecycleScope
+import androidx.fragment.app.activityViewModels
 import com.github.libretube.R
-import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.databinding.FragmentTrendsBinding
-import com.github.libretube.extensions.TAG
-import com.github.libretube.helpers.LocaleHelper
 import com.github.libretube.ui.activities.SettingsActivity
 import com.github.libretube.ui.adapters.VideosAdapter
 import com.github.libretube.ui.base.DynamicLayoutManagerFragment
-import com.github.libretube.util.deArrow
+import com.github.libretube.ui.models.TrendsViewModel
 import com.google.android.material.snackbar.Snackbar
-import java.io.IOException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import retrofit2.HttpException
 
 class TrendsFragment : DynamicLayoutManagerFragment() {
     private var _binding: FragmentTrendsBinding? = null
     private val binding get() = _binding!!
+    private val viewModel: TrendsViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,52 +36,33 @@ class TrendsFragment : DynamicLayoutManagerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        fetchTrending()
-        binding.homeRefresh.isEnabled = true
-        binding.homeRefresh.setOnRefreshListener {
-            fetchTrending()
-        }
-    }
+        viewModel.trendingVideos.observe(viewLifecycleOwner) { videos ->
+            if (videos == null) return@observe
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
-
-    private fun fetchTrending() {
-        lifecycleScope.launch {
-            val response = try {
-                withContext(Dispatchers.IO) {
-                    val region = LocaleHelper.getTrendingRegion(requireContext())
-                    RetrofitInstance.api.getTrending(region).deArrow()
-                }
-            } catch (e: IOException) {
-                println(e)
-                Log.e(TAG(), "IOException, you might not have internet connection")
-                Toast.makeText(context, R.string.unknown_error, Toast.LENGTH_SHORT).show()
-                return@launch
-            } catch (e: HttpException) {
-                Log.e(TAG(), "HttpException, unexpected response")
-                Toast.makeText(context, R.string.server_error, Toast.LENGTH_SHORT).show()
-                return@launch
-            }
-
-            val binding = _binding ?: return@launch
+            binding.recview.adapter = VideosAdapter(videos.toMutableList())
             binding.homeRefresh.isRefreshing = false
             binding.progressBar.isGone = true
 
-            // show a [SnackBar] if there are no trending videos available
-            if (response.isEmpty()) {
+            if (videos.isEmpty()) {
                 Snackbar.make(binding.root, R.string.change_region, Snackbar.LENGTH_LONG)
                     .setAction(R.string.settings) {
                         val settingsIntent = Intent(context, SettingsActivity::class.java)
                         startActivity(settingsIntent)
                     }
                     .show()
-                return@launch
             }
-
-            binding.recview.adapter = VideosAdapter(response.toMutableList())
         }
+
+        binding.homeRefresh.isEnabled = true
+        binding.homeRefresh.setOnRefreshListener {
+            viewModel.fetchTrending(requireContext())
+        }
+
+        viewModel.fetchTrending(requireContext())
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/models/TrendsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/TrendsViewModel.kt
@@ -1,0 +1,44 @@
+package com.github.libretube.ui.models
+
+import android.content.Context
+import android.util.Log
+import android.widget.Toast
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.libretube.R
+import com.github.libretube.api.RetrofitInstance
+import com.github.libretube.api.obj.StreamItem
+import com.github.libretube.extensions.TAG
+import com.github.libretube.helpers.LocaleHelper
+import com.github.libretube.util.deArrow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import retrofit2.HttpException
+import java.io.IOException
+
+class TrendsViewModel: ViewModel() {
+    val trendingVideos = MutableLiveData<List<StreamItem>>()
+
+    fun fetchTrending(context: Context) {
+        viewModelScope.launch {
+            try {
+                  val region = LocaleHelper.getTrendingRegion(context)
+                  val response = withContext(Dispatchers.IO) {
+                      RetrofitInstance.api.getTrending(region).deArrow()
+                  }
+                  trendingVideos.postValue(response)
+            } catch (e: IOException) {
+                println(e)
+                Log.e(TAG(), "IOException, you might not have internet connection")
+                Toast.makeText(context, R.string.unknown_error, Toast.LENGTH_SHORT).show()
+                return@launch
+            } catch (e: HttpException) {
+                Log.e(TAG(), "HttpException, unexpected response")
+                Toast.makeText(context, R.string.server_error, Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+        }
+    }
+}


### PR DESCRIPTION
this is inspired from rafale rasmos' latest home related pr, now trends has its own lifecycle in a viewmodel and doesnt reloads everytime. especially good for those who keep trends as default.

edit: fook you @reviewdog