### PR TITLE
feat(ui): save scroll position in trends

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.github.libretube.R
 import com.github.libretube.databinding.FragmentTrendsBinding
 import com.github.libretube.ui.activities.SettingsActivity
@@ -39,6 +41,7 @@ class TrendsFragment : DynamicLayoutManagerFragment() {
         viewModel.trendingVideos.observe(viewLifecycleOwner) { videos ->
             if (videos == null) return@observe
 
+            binding.recview.layoutManager?.onRestoreInstanceState(viewModel.recyclerViewState)
             binding.recview.adapter = VideosAdapter(videos.toMutableList())
             binding.homeRefresh.isRefreshing = false
             binding.progressBar.isGone = true
@@ -57,6 +60,12 @@ class TrendsFragment : DynamicLayoutManagerFragment() {
         binding.homeRefresh.setOnRefreshListener {
             viewModel.fetchTrending(requireContext())
         }
+
+        viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) {
+                viewModel.recyclerViewState = _binding?.recview?.layoutManager?.onSaveInstanceState()
+            }
+        })
 
         viewModel.fetchTrending(requireContext())
     }

--- a/app/src/main/java/com/github/libretube/ui/models/TrendsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/TrendsViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.ui.models
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.MutableLiveData
@@ -20,6 +21,7 @@ import java.io.IOException
 
 class TrendsViewModel: ViewModel() {
     val trendingVideos = MutableLiveData<List<StreamItem>>()
+    var recyclerViewState: Parcelable? = null
 
     fun fetchTrending(context: Context) {
         viewModelScope.launch {


### PR DESCRIPTION
previously when we swtiched to other tab and came back to trends it reloaded, after switching to viewmodel it is good,
 but when we scroll and switch to other tab and come back to trends, it resets to the top position.
this enhances that.