### PR TITLE
refactor: Simplify dearrow process

### DIFF
--- a/app/src/main/java/com/github/libretube/api/PipedApi.kt
+++ b/app/src/main/java/com/github/libretube/api/PipedApi.kt
@@ -1,23 +1,6 @@
 package com.github.libretube.api
 
-import com.github.libretube.api.obj.Channel
-import com.github.libretube.api.obj.ChannelTabResponse
-import com.github.libretube.api.obj.CommentsPage
-import com.github.libretube.api.obj.DeleteUserRequest
-import com.github.libretube.api.obj.EditPlaylistBody
-import com.github.libretube.api.obj.Login
-import com.github.libretube.api.obj.Message
-import com.github.libretube.api.obj.PipedConfig
-import com.github.libretube.api.obj.Playlist
-import com.github.libretube.api.obj.Playlists
-import com.github.libretube.api.obj.SearchResult
-import com.github.libretube.api.obj.SegmentData
-import com.github.libretube.api.obj.StreamItem
-import com.github.libretube.api.obj.Streams
-import com.github.libretube.api.obj.Subscribe
-import com.github.libretube.api.obj.Subscribed
-import com.github.libretube.api.obj.Subscription
-import com.github.libretube.api.obj.Token
+import com.github.libretube.api.obj.*
 import kotlinx.serialization.json.JsonObject
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -47,7 +30,7 @@ interface PipedApi {
     ): SegmentData
 
     @GET("dearrow")
-    suspend fun getDeArrowContent(@Query("videoIds") videoIds: String): JsonObject
+    suspend fun getDeArrowContent(@Query("videoIds") videoIds: String): Map<String, DeArrowContent>
 
     @GET("nextpage/comments/{videoId}")
     suspend fun getCommentsNextPage(

--- a/app/src/main/java/com/github/libretube/util/DeArrowUtil.kt
+++ b/app/src/main/java/com/github/libretube/util/DeArrowUtil.kt
@@ -1,7 +1,6 @@
 package com.github.libretube.util
 
 import android.util.Log
-import com.github.libretube.api.JsonHelper
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.api.obj.ContentItem
 import com.github.libretube.api.obj.DeArrowContent
@@ -9,17 +8,10 @@ import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.toID
 import com.github.libretube.helpers.PreferenceHelper
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.decodeFromJsonElement
 import java.util.TreeSet
 
 object DeArrowUtil {
-    private fun extractTitleAndThumbnail(data: JsonElement): Pair<String?, String?> {
-        val content = try {
-            JsonHelper.json.decodeFromJsonElement<DeArrowContent>(data)
-        } catch (e: Exception) {
-            return null to null
-        }
+    private fun extractTitleAndThumbnail(content: DeArrowContent): Pair<String?, String?> {
         val newTitle = content.titles.firstOrNull { it.votes >= 0 || it.locked }?.title
         val newThumbnail = content.thumbnails.firstOrNull {
             it.thumbnail != null && !it.original && (it.votes >= 0 || it.locked)


### PR DESCRIPTION
Return a `Map` instead of a `JsonObject` from the dearrow API.