### PR TITLE
fix: switch back to home bookmarks layout on home screen

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -167,7 +167,10 @@ class HomeFragment : Fragment() {
         makeVisible(binding.bookmarksTV, binding.bookmarksRV)
         with (binding.bookmarksRV) {
             layoutManager = LinearLayoutManager(context, HORIZONTAL, false)
-            adapter = PlaylistBookmarkAdapter(bookmarks.toMutableList())
+            adapter = PlaylistBookmarkAdapter(
+                bookmarks.toMutableList(),
+                PlaylistBookmarkAdapter.Companion.BookmarkMode.HOME
+            )
         }
     }
 


### PR DESCRIPTION
That change in behavior had been accidentally introduced with #5491