### PR TITLE
fix: don't toggle system bars in player fragment when locking player

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -146,7 +146,7 @@ open class CustomExoPlayerView(
             // change locked status
             isPlayerLocked = !isPlayerLocked
 
-            toggleSystemBars(!isPlayerLocked)
+            if (isFullscreen()) toggleSystemBars(!isPlayerLocked)
         }
 
         resizeMode = when (resizeModePref) {


### PR DESCRIPTION
closes #5552