### PR TITLE
fix: playing queue actions still visible after miniplayer closed by swipe

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -499,7 +499,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             .animateDown(
                 duration = 300L,
                 dy = 500F,
-                onEnd = ::killPlayerFragment,
+                onEnd = ::onManualPlayerClose,
             )
     }
 


### PR DESCRIPTION
closes #5553