### PR TITLE
refactor: Avoid boxing for segment pair

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui)
     implementation(libs.androidx.preference)
     implementation(libs.androidx.work.runtime)
+    implementation(libs.androidx.collection)
 
     /* Android Lifecycle */
     implementation(libs.lifecycle.viewmodel)

--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -1,7 +1,9 @@
 package com.github.libretube.api.obj
 
+import androidx.collection.FloatFloatPair
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class Segment(
@@ -10,11 +12,12 @@ data class Segment(
     val category: String? = null,
     val description: String? = null,
     val locked: Int? = null,
-    val segment: List<Double> = listOf(),
+    private val segment: List<Float> = listOf(),
     val userID: String? = null,
     val videoDuration: Double? = null,
     val votes: Int? = null,
     var skipped: Boolean = false
 ) {
-    val segmentStartAndEnd = segment[0] to segment[1]
+    @Transient
+    val segmentStartAndEnd = FloatFloatPair(segment[0], segment[1])
 }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -550,11 +550,9 @@ object PlayerHelper {
             if ((duration - currentPosition).absoluteValue < 500) continue
 
             if (currentPosition in segmentStart until segmentEnd) {
-                if (sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC ||
-                    (
-                            sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE &&
-                                    !segment.skipped
-                            )
+                val key = sponsorBlockConfig[segment.category]
+                if (key == SbSkipOptions.AUTOMATIC ||
+                    (key == SbSkipOptions.AUTOMATIC_ONCE && !segment.skipped)
                 ) {
                     if (sponsorBlockNotifications) {
                         runCatching {
@@ -564,11 +562,8 @@ object PlayerHelper {
                     }
                     seekTo(segmentEnd)
                     segment.skipped = true
-                } else if (sponsorBlockConfig[segment.category] == SbSkipOptions.MANUAL ||
-                    (
-                            sponsorBlockConfig[segment.category] == SbSkipOptions.AUTOMATIC_ONCE &&
-                                    segment.skipped
-                            )
+                } else if (key == SbSkipOptions.MANUAL ||
+                    (key == SbSkipOptions.AUTOMATIC_ONCE && segment.skipped)
                 ) {
                     return segment
                 }

--- a/app/src/main/java/com/github/libretube/ui/dialogs/VoteForSegmentDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/VoteForSegmentDialog.kt
@@ -98,11 +98,10 @@ class VoteForSegmentDialog : DialogFragment() {
             }
 
             binding.segmentsDropdown.items = segments.map {
-                "${it.category} (${
-                    DateUtils.formatElapsedTime(it.segmentStartAndEnd.first.toLong())
-                } - ${
-                    DateUtils.formatElapsedTime(it.segmentStartAndEnd.second.toLong())
-                })"
+                val (start, end) = it.segmentStartAndEnd
+                val (startStr, endStr) = DateUtils.formatElapsedTime(start.toLong()) to
+                        DateUtils.formatElapsedTime(end.toLong())
+                "${it.category} ($startStr - $endStr)"
             }
         }
     }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1142,7 +1142,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
         val durationWithoutSegments = duration - segments.sumOf {
             val (start, end) = it.segmentStartAndEnd
-            end - start
+            end.toDouble() - start.toDouble()
         }.toLong()
         val durationString = DateUtils.formatElapsedTime(duration)
 

--- a/app/src/main/java/com/github/libretube/ui/views/MarkableTimeBar.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/MarkableTimeBar.kt
@@ -67,7 +67,7 @@ class MarkableTimeBar(
         canvas.restore()
     }
 
-    private fun Double.toLength(): Int {
+    private fun Float.toLength(): Int {
         return (this * 1000 / player!!.duration * length).toInt()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ benchmarkMacroJunit4 = "1.2.3"
 baselineprofile = "1.2.3"
 profileinstaller = "1.3.1"
 paging = "3.2.1"
+collection = "1.4.0"
 
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
@@ -74,6 +75,7 @@ androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomato
 androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmarkMacroJunit4" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 androidx-paging = { group = "androidx.paging", name = "paging-runtime-ktx", version.ref = "paging" }
+androidx-collection = { group = "androidx.collection", name = "collection", version.ref = "collection" }
 
 [plugins]
 androidTest = { id = "com.android.test", version.ref = "gradle" }


### PR DESCRIPTION
* Updated [AndroidX Collection](https://developer.android.com/jetpack/androidx/releases/collection) to 1.4.0.
* Used `FloatFloatPair` in `Segment` to avoid boxing.