### PR TITLE
fix: correctly display colors in system panel

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ThemeHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ThemeHelper.kt
@@ -6,7 +6,9 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Color
+import android.os.Build
 import android.text.Spanned
+import android.view.Window
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.text.HtmlCompat
@@ -18,6 +20,38 @@ import com.google.android.material.color.DynamicColors
 import com.google.android.material.color.MaterialColors
 
 object ThemeHelper {
+
+    /**
+     * Set the colors of the system bars (status bat and navigation bar)
+     */
+    fun setSystemBarColors(context: Context, window: Window, isBottomNavVisible: Boolean) {
+        setStatusBarColor(context, window)
+        setNavigationBarColor(context, window, isBottomNavVisible)
+    }
+
+    /**
+     * Set the background color of the status bar
+     */
+    private fun setStatusBarColor(context: Context, window: Window) {
+        window.statusBarColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            getThemeColor(context, android.R.attr.colorBackground)
+        } else {
+            if (isDarkMode(context)) getThemeColor(context, android.R.attr.colorBackground)
+            else getThemeColor(context, com.google.android.material.R.attr.colorOnBackground)
+        }
+    }
+
+    /**
+     * Set the background color of the navigation bar
+     */
+    private fun setNavigationBarColor(context: Context, window: Window, isBottomNavVisible: Boolean) {
+        window.navigationBarColor = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && !isDarkMode(context)) {
+            getThemeColor(context, com.google.android.material.R.attr.colorOnBackground)
+        } else {
+            if (isBottomNavVisible) getThemeColor(context, com.google.android.material.R.attr.colorSurfaceContainer)
+            else getThemeColor(context, android.R.attr.colorBackground)
+        }
+    }
 
     /**
      * Set the theme, including accent color and night mode
@@ -129,7 +163,8 @@ object ThemeHelper {
     }
 
     fun isDarkMode(context: Context): Boolean {
-        val darkModeFlag = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val darkModeFlag =
+            context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
         return darkModeFlag == Configuration.UI_MODE_NIGHT_YES
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -94,12 +94,8 @@ class MainActivity : BaseActivity() {
             R.id.homeFragment
         }
 
-        // sets the navigation bar color to the previously calculated color
-        window.navigationBarColor = if (binding.bottomNav.menu.size() > 0) {
-            ThemeHelper.getThemeColor(this, com.google.android.material.R.attr.colorSurfaceContainer)
-        } else {
-            ThemeHelper.getThemeColor(this, android.R.attr.colorBackground)
-        }
+        // sets the color if the navigation bar is visible
+        ThemeHelper.setSystemBarColors(this, window, binding.bottomNav.menu.size() > 0)
 
         // set default tab as start fragment
         navController.graph = navController.navInflater.inflate(R.navigation.nav).also {
@@ -165,7 +161,7 @@ class MainActivity : BaseActivity() {
 
                 R.id.searchResultFragment -> {
                     navController.popBackStack(R.id.searchFragment, true) ||
-                        navController.popBackStack()
+                            navController.popBackStack()
                 }
 
                 else -> {

--- a/app/src/main/java/com/github/libretube/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/base/BaseActivity.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.ui.base
 
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.github.libretube.R
@@ -37,6 +38,10 @@ open class BaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         // set the app theme (e.g. Material You)
         ThemeHelper.updateTheme(this)
+
+        // Set the navigation and statusBar color if SDK < 23
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+            ThemeHelper.setSystemBarColors(this, window, false)
 
         // set the apps language
         LocaleHelper.updateLanguage(this)


### PR DESCRIPTION
Fixes issue https://github.com/libre-tube/LibreTube/issues/5574

Correctly displayed colors in the system panel (status bar, navigation bar) in the light mode.