### PR TITLE
fix: set music playback speed only once

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -312,9 +312,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             saveWatchPosition()
 
             if (playbackState == Player.STATE_READY) {
-                if (streams.category == Streams.categoryMusic) {
-                    exoPlayer.setPlaybackSpeed(1f)
-                }
             }
 
             // set the playback speed to one if having reached the end of a livestream
@@ -988,6 +985,10 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                 }
 
                 setCurrentChapterName()
+
+                if (streams.category == Streams.categoryMusic) {
+                    exoPlayer.setPlaybackSpeed(1f)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/libre-tube/LibreTube/issues/5626. The playback speed for music videos was set to 1.0x on every event, instead of only once when starting the video.