### PR TITLE
fix: false message about no comments and btnTop scroll

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -273,6 +273,14 @@ class MainActivity : BaseActivity() {
         this.searchItem = searchItem
         searchView = searchItem.actionView as SearchView
 
+        searchView.setIconifiedByDefault(false)
+        searchView.queryHint = getString(R.string.search_hint)
+        searchView.setBackgroundColor(
+            ThemeHelper.getThemeColor(
+                this@MainActivity,
+                com.google.android.material.R.attr.colorSecondaryContainer
+            )
+        )
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
                 navController.navigate(NavDirections.showSearchResults(query))

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -25,6 +26,8 @@ class CommentsMainFragment : Fragment() {
     private val binding get() = _binding!!
     private val viewModel: CommentsViewModel by activityViewModels()
 
+    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -45,17 +48,19 @@ class CommentsMainFragment : Fragment() {
         val commentsSheet = parentFragment as? CommentsSheet
         commentsSheet?.binding?.btnScrollToTop?.setOnClickListener {
             // scroll back to the top / first comment
-            _binding?.commentsRV?.smoothScrollToPosition(0)
-            viewModel.currentCommentsPosition = 0
+            _binding?.commentsRV?.smoothScrollToPosition(POSITION_START)
+            viewModel.changeCommentPosition(POSITION_START)
         }
 
-        binding.commentsRV.viewTreeObserver.addOnScrollChangedListener {
+        scrollListener = ViewTreeObserver.OnScrollChangedListener {
             // save the last scroll position to become used next time when the sheet is opened
-            viewModel.currentCommentsPosition = layoutManager.findFirstVisibleItemPosition()
-
+            viewModel.changeCommentPosition(layoutManager.findFirstVisibleItemPosition())
             // hide or show the scroll to top button
-            commentsSheet?.binding?.btnScrollToTop?.isVisible = viewModel.currentCommentsPosition != 0
+            commentsSheet?.binding?.btnScrollToTop?.isVisible =
+                viewModel.currentCommentsPosition.value != 0
         }
+        binding.commentsRV.viewTreeObserver.addOnScrollChangedListener(scrollListener)
+
         commentsSheet?.updateFragmentInfo(false, getString(R.string.comments))
 
         val commentPagingAdapter = CommentPagingAdapter(
@@ -97,8 +102,19 @@ class CommentsMainFragment : Fragment() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        binding.commentsRV.viewTreeObserver.removeOnScrollChangedListener(scrollListener)
+        scrollListener = null
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
     }
+
+    companion object {
+        const val POSITION_START = 0
+    }
+
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -74,7 +74,7 @@ class CommentsMainFragment : Fragment() {
                     commentPagingAdapter.loadStateFlow.collect {
                         binding.progress.isVisible = it.refresh is LoadState.Loading
 
-                        if (it.append is LoadState.NotLoading && it.append.endOfPaginationReached) {
+                        if (it.append is LoadState.NotLoading && it.append.endOfPaginationReached && commentPagingAdapter.itemCount == 0) {
                             binding.errorTV.text = getString(R.string.no_comments_available)
                             binding.errorTV.isVisible = true
                             return@collect

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -30,6 +31,8 @@ class CommentsRepliesFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel: CommentsViewModel by activityViewModels()
+
+    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -66,8 +69,36 @@ class CommentsRepliesFragment : Fragment() {
         )
 
         binding.commentsRV.updatePadding(top = 0)
-        binding.commentsRV.layoutManager = LinearLayoutManager(context)
+
+        val layoutManager = LinearLayoutManager(context)
+        binding.commentsRV.layoutManager = layoutManager
+
         binding.commentsRV.adapter = repliesAdapter
+
+        //init scroll position
+        if (viewModel.currentRepliesPosition.value != null) {
+            if (viewModel.currentRepliesPosition.value!! > POSITION_START) {
+                layoutManager.scrollToPosition(viewModel.currentRepliesPosition.value!!)
+            } else {
+                layoutManager.scrollToPosition(POSITION_START)
+            }
+        }
+
+        commentsSheet?.binding?.btnScrollToTop?.setOnClickListener {
+            // scroll back to the top / first comment
+            layoutManager.scrollToPosition(POSITION_START)
+            viewModel.changeReplayPosition(POSITION_START)
+        }
+
+        scrollListener = ViewTreeObserver.OnScrollChangedListener {
+            // save the last scroll position to become used next time when the sheet is opened
+            viewModel.changeReplayPosition(layoutManager.findFirstVisibleItemPosition())
+            // hide or show the scroll to top button
+            commentsSheet?.binding?.btnScrollToTop?.isVisible =
+                viewModel.currentRepliesPosition.value != 0
+        }
+
+        binding.commentsRV.viewTreeObserver.addOnScrollChangedListener(scrollListener)
 
         viewModel.selectedCommentLiveData.postValue(comment.repliesPage)
 
@@ -88,8 +119,18 @@ class CommentsRepliesFragment : Fragment() {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        binding.commentsRV.viewTreeObserver.removeOnScrollChangedListener(scrollListener)
+        scrollListener = null
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        const val POSITION_START = 0
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.libretube.ui.models
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asFlow
@@ -41,7 +42,12 @@ class CommentsViewModel : ViewModel() {
     var channelAvatar: String? = null
     var handleLink: ((url: String) -> Unit)? = null
 
-    var currentCommentsPosition = 0
+    private val _currentCommentsPosition = MutableLiveData(0)
+    val currentCommentsPosition: LiveData<Int> = _currentCommentsPosition
+
+    private val _currentRepliesPosition = MutableLiveData(0)
+    val currentRepliesPosition: LiveData<Int> = _currentRepliesPosition
+
     var commentsSheetDismiss: (() -> Unit)? = null
 
     fun setCommentSheetExpand(value: Boolean?) {
@@ -52,6 +58,18 @@ class CommentsViewModel : ViewModel() {
 
     fun reset() {
         setCommentSheetExpand(null)
-        currentCommentsPosition = 0
+        _currentCommentsPosition.value = 0
+    }
+
+    fun changeCommentPosition(position: Int) {
+        if (position != currentCommentsPosition.value) {
+            _currentCommentsPosition.postValue(position)
+        }
+    }
+
+    fun changeReplayPosition(position: Int) {
+        if (position != currentRepliesPosition.value) {
+            _currentRepliesPosition.postValue(position)
+        }
     }
 }


### PR DESCRIPTION
In new versions (not yet released), comments are broken. Including responses to comments. 
I tried to fix btn Top and corrected the false text output that there are no comments when in fact there are. I haven't figured out the reason yet, so the code may need to be adjusted or supplemented.