### PR TITLE
fix: unable to view subscribed channels

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -128,6 +128,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
             binding.subRefresh.isRefreshing = true
             isCurrentTabSubChannels = !isCurrentTabSubChannels
 
+            if (viewModel.subscriptions.value == null) viewModel.fetchSubscriptions(requireContext())
             if (isCurrentTabSubChannels) showSubscriptions() else showFeed()
 
             binding.subChannels.isVisible = isCurrentTabSubChannels


### PR DESCRIPTION
This fixes #5791 where you can't view subscribed channels when the initial load is to the homepage.