### PR TITLE
fix: Auto-fullscreen doesn't work after switching to another app

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1687,17 +1687,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         ) {
             return
         }
-
-        if (PlayerHelper.autoFullscreenEnabled) {
-            when (newConfig.orientation) {
-                // go to fullscreen mode
-                Configuration.ORIENTATION_LANDSCAPE -> setFullscreen()
-                // exit fullscreen if not landscape
-                else -> unsetFullscreen()
-            }
-        } else {
-            restartActivityIfNeeded()
-        }
     }
 
     private fun disableController() {


### PR DESCRIPTION
I tried to understand the reason for this issue (https://github.com/libre-tube/LibreTube/issues/5800), deleting part of the code helped.

The auto orientation still performs its functions when needed and it does not break after the second auto-rotation (i.e. 1 - to landscape, 2 - to portrait, etc.).

In addition, auto-orientation works even after exiting and returning to the application (the steps described in the issue).

p.s. with this part of the code, the `onConfigurationChanged()` method does not respond to the auto-orientation of the screen at all for some reason,  after the second auto-rotation. Problem maybe `restartActivityIfNeeded()` method. Therefore, I hope for the help of more experienced colleagues.