### PR TITLE
feat: improve video end screen

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -345,8 +345,10 @@ object PlayerHelper {
 
     fun shouldPlayNextVideo(isPlaylist: Boolean = false): Boolean {
         // if there is no next video, it obviously should not be played
-        if (PlayingQueue.getNext() == null)
+        if (!PlayingQueue.hasNext()) {
             return false
+        }
+
         return autoPlayEnabled || (
             isPlaylist && PreferenceHelper.getBoolean(
                 PreferenceKeys.AUTOPLAY_PLAYLISTS,

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -41,6 +41,7 @@ import com.github.libretube.enums.PlayerEvent
 import com.github.libretube.enums.SbSkipOptions
 import com.github.libretube.extensions.updateParameters
 import com.github.libretube.obj.VideoStats
+import com.github.libretube.util.PlayingQueue
 import com.github.libretube.util.TextUtils
 import java.util.Locale
 import java.util.concurrent.Executors
@@ -343,6 +344,9 @@ object PlayerHelper {
             )
 
     fun shouldPlayNextVideo(isPlaylist: Boolean = false): Boolean {
+        // if there is no next video, it obviously should not be played
+        if (PlayingQueue.getNext() == null)
+            return false
         return autoPlayEnabled || (
             isPlaylist && PreferenceHelper.getBoolean(
                 PreferenceKeys.AUTOPLAY_PLAYLISTS,

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -113,11 +113,11 @@ import com.github.libretube.util.PlayingQueue
 import com.github.libretube.util.TextUtils
 import com.github.libretube.util.TextUtils.toTimeInSeconds
 import com.github.libretube.util.YoutubeHlsPlaylistParser
-import java.util.concurrent.Executors
-import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
+import kotlin.math.abs
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class PlayerFragment : Fragment(), OnlinePlayerOptions {
@@ -313,7 +313,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                         playNextVideo()
                     }
                 } else {
-                    binding.player.showController()
+                    binding.player.showControllerPermanently()
                 }
             }
 

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -269,6 +269,12 @@ open class CustomExoPlayerView(
         super.showController()
     }
 
+    fun showControllerPermanently() {
+        // remove the previous callback from the queue to prevent a flashing behavior
+        cancelHideControllerTask()
+        super.showController()
+    }
+
     override fun onTouchEvent(event: MotionEvent) = false
 
     private fun initRewindAndForward() {


### PR DESCRIPTION
Fixes a problem where the controller was not displayed on the video end screen when "Insert related videos" was disabled. The improved version should now cover edge cases like the last video of a playlist.
I also changed it to show the controller on the end screen permanently (i.e. it doesn't hide after a few seconds), as I found that it was easy to miss. 