### PR TITLE
fix: crash when importing subscriptions list with invalid avatars

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/Subscription.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Subscription.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
 data class Subscription(
     val url: String,
     val name: String,
-    val avatar: String,
+    val avatar: String? = null,
     val verified: Boolean
 )


### PR DESCRIPTION
Solves issue of subscription list not loading when channels have old/invalid avatars.

See issue below:


https://github.com/libre-tube/LibreTube/assets/167443179/3d61bab9-52d2-44ab-bb8e-eaa0774c15fb

