### PR TITLE
Fix cronet not being used because of httpClient

### DIFF
--- a/app/src/main/java/com/github/libretube/api/RetrofitInstance.kt
+++ b/app/src/main/java/com/github/libretube/api/RetrofitInstance.kt
@@ -3,6 +3,7 @@ package com.github.libretube.api
 import com.github.libretube.BuildConfig
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.helpers.PreferenceHelper
+import com.google.net.cronet.okhttptransport.CronetInterceptor
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -24,6 +25,7 @@ object RetrofitInstance {
                 PreferenceKeys.AUTH_INSTANCE,
                 PIPED_API_URL
             )
+
             false -> apiUrl
         }
 
@@ -65,6 +67,7 @@ object RetrofitInstance {
 
     private fun buildClient(): OkHttpClient {
         val httpClient = OkHttpClient().newBuilder()
+            .addInterceptor(CronetInterceptor.newBuilder(CronetHelper.cronetEngine).build())
 
         if (BuildConfig.DEBUG) {
             val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -17,6 +17,7 @@ import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.toAndroidUri
 import com.github.libretube.extensions.toAndroidUriOrNull
 import com.github.libretube.util.DataSaverMode
+import com.google.net.cronet.okhttptransport.CronetInterceptor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -36,6 +37,7 @@ object ImageHelper {
         val maxCacheSize = PreferenceHelper.getString(PreferenceKeys.MAX_IMAGE_CACHE, "128")
 
         val httpClient = OkHttpClient().newBuilder()
+            .addInterceptor(CronetInterceptor.newBuilder(CronetHelper.cronetEngine).build())
 
         if (BuildConfig.DEBUG) {
             val loggingInterceptor = HttpLoggingInterceptor().apply {


### PR DESCRIPTION
In my testing for debugging #5855, Cronet doesn't appear to be used for API requests and loading images. (At least in the debug builds)