### PR TITLE
fix: scroll state not preserved after rotation change at some places

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -1,6 +1,8 @@
 package com.github.libretube.ui.fragments
 
+import android.content.res.Configuration
 import android.os.Bundle
+import android.os.Parcelable
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -12,6 +14,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.github.libretube.R
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.api.obj.ChannelTab
@@ -61,6 +64,7 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
     private var searchChannelAdapter: SearchChannelAdapter? = null
 
     private var isAppBarFullyExpanded: Boolean = true
+    private var recyclerViewState: Parcelable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -108,6 +112,13 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
 
             loadNextPage()
         }
+
+        binding.channelRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                recyclerViewState = binding.channelRecView.layoutManager?.onSaveInstanceState()
+            }
+        })
 
         fetchChannel()
     }
@@ -337,5 +348,12 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
         }
 
         return newContent.nextpage
+    }
+
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.channelRecView.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -1,7 +1,9 @@
 package com.github.libretube.ui.fragments
 
 import android.annotation.SuppressLint
+import android.content.res.Configuration
 import android.os.Bundle
+import android.os.Parcelable
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -72,6 +74,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
             field = value
         }
     private val sortOptions by lazy { resources.getStringArray(R.array.playlistSortOptions) }
+    private var recyclerViewState: Parcelable? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -105,6 +108,14 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
         playerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
             binding.playlistRecView.updatePadding(bottom = if (it) 64f.dpToPx() else 0)
         }
+
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.playlistRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                recyclerViewState = binding.playlistRecView.layoutManager?.onSaveInstanceState()
+            }
+        })
 
         fetchPlaylist()
     }
@@ -401,5 +412,11 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
             playlistAdapter?.updateItems(response.relatedStreams)
             isLoading = false
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.playlistRecView.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -1,8 +1,11 @@
 package com.github.libretube.ui.fragments
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.Parcelable
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -46,6 +49,7 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
     private val handler = Handler(Looper.getMainLooper())
     private val playerViewModel: PlayerViewModel by activityViewModels()
     private var isLoading = false
+    private var recyclerViewState: Parcelable? = null
 
     private var selectedStatusFilter = PreferenceHelper.getInt(
         PreferenceKeys.SELECTED_HISTORY_STATUS_FILTER,
@@ -142,6 +146,14 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
                 }
             }.show(childFragmentManager)
         }
+
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.watchHistoryRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                recyclerViewState = binding.watchHistoryRecView.layoutManager?.onSaveInstanceState()
+            }
+        })
 
         showWatchHistory(allHistory)
     }
@@ -254,6 +266,12 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
                 else -> throw IllegalArgumentException()
             }
         }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.watchHistoryRecView.layoutManager?.onRestoreInstanceState(recyclerViewState)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/res/layout/fragment_watch_history.xml
+++ b/app/src/main/res/layout/fragment_watch_history.xml
@@ -36,12 +36,12 @@
         android:visibility="gone">
 
         <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/playlist_app_bar"
+            android:id="@+id/watch_history_app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
-                android:id="@+id/playlist_collapsing_tb"
+                android:id="@+id/watch_history_collapsing_tb"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:layout_scrollFlags="scroll"


### PR DESCRIPTION
Affected fragments: SubscriptionsFragment, WatchHistoryFragment, ChannelFragment, PlaylistFragment

closes https://github.com/libre-tube/LibreTube/issues/5808