### PR TITLE
fix: enter PiP mode when clicking link in description

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1088,7 +1088,11 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         if (videoId.isNullOrEmpty()) {
             // not a YouTube video link, thus handle normally
             val intent = Intent(Intent.ACTION_VIEW, uri)
+
+            // start PiP mode if enabled
+            onUserLeaveHint()
             startActivity(intent)
+
             return
         }
 


### PR DESCRIPTION
closes https://github.com/libre-tube/LibreTube/issues/2022