### PR TITLE
Clear notification when app is killed from recent tasks.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -369,6 +369,10 @@
             android:enabled="true"
             android:exported="false" />
 
+        <service android:name=".services.OnClearFromRecentService"
+            android:enabled="true"
+            android:exported="false" />
+
         <receiver
             android:name=".receivers.NotificationReceiver"
             android:enabled="true"

--- a/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
+++ b/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
@@ -31,6 +31,7 @@ import com.github.libretube.helpers.BackgroundHelper
 import com.github.libretube.helpers.ImageHelper
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.obj.PlayerNotificationData
+import com.github.libretube.services.OnClearFromRecentService
 import com.github.libretube.ui.activities.MainActivity
 import java.util.UUID
 
@@ -334,6 +335,7 @@ class NowPlayingNotification(
                     super.onIsPlayingChanged(isPlaying)
                 }
             })
+            context.startService(Intent(context, OnClearFromRecentService::class.java))
         }
 
         createOrUpdateNotification()


### PR DESCRIPTION
When app is killed from recent task, notification still persists.
This PR fixes https://github.com/libre-tube/LibreTube/issues/5833