### PR TITLE
fix: use string ressource for channel video tab

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -240,6 +240,7 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
         tabList.removeAll { tab ->
             tab.name != VIDEOS_TAB_KEY
         }
+        tabList[0] = ChannelTab(getString(tabNamesMap[VIDEOS_TAB_KEY]!!), "")
         response.tabs.forEach { channelTab ->
             val tabName = tabNamesMap[channelTab.name]?.let { getString(it) }
                 ?: channelTab.name.replaceFirstChar(Char::titlecase)


### PR DESCRIPTION
Fixes an issue, were the Channel video tab name was still using the `VIDEOS_TAB_KEY` as its display name.

| Before                                                                                                                          	| After                                                                                                                                           	|
|---------------------------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Channel tabbar with wrong name](https://github.com/libre-tube/LibreTube/assets/63370021/acc3ac37-a032-4c92-935e-f6096c5a0e62) 	| ![Channel tabbar with correctly capitalized name](https://github.com/libre-tube/LibreTube/assets/63370021/a32a4019-2c6b-4fd5-b0c4-cfe0cdf873b1) 	|