### PR TITLE
fix: crash when different threads access playing queue

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -692,9 +692,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
     @SuppressLint("SourceLockedOrientationActivity")
     fun unsetFullscreen() {
-        // set status bar icon color back to theme color
-        windowInsetsControllerCompat.isAppearanceLightStatusBars = !ThemeHelper.isDarkMode(requireContext())
-
         viewModel.isFullscreen.value = false
 
         if (!PlayerHelper.autoFullscreenEnabled) {
@@ -705,6 +702,9 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         updateResolutionOnFullscreenChange(false)
 
         binding.player.updateMarginsByFullscreenMode()
+
+        // set status bar icon color back to theme color after fullscreen dialog closed!
+        windowInsetsControllerCompat.isAppearanceLightStatusBars = !ThemeHelper.isDarkMode(requireContext())
     }
 
     /**


### PR DESCRIPTION
This prevents concurrent access of the playing queue from different threads by using Java's `synchronized` feature.

closes #6023