### PR TITLE
fix(SubscriptionsFragment): use null safe call

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -426,7 +426,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
 
     fun removeItem(videoId: String) {
         feedAdapter?.removeItemById(videoId)
-        sortedFeed.removeAll { it.url!!.toID() != videoId }
+        sortedFeed.removeAll { it.url?.toID() != videoId }
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
Fixes a crash when trying to mark a video as played, that is above the all caught up item.