### PR TITLE
fix: remembered channel group resets when switching fragment

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -288,7 +288,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
     private fun initChannelGroups() {
         val binding = _binding ?: return
 
-        binding.chipAll.isChecked = true
+        binding.chipAll.isChecked = selectedFilterGroup == 0
         binding.chipAll.setOnLongClickListener {
             playByGroup(0)
             true


### PR DESCRIPTION
see https://github.com/libre-tube/LibreTube/issues/6134#issuecomment-2168463357