### PR TITLE
fix: crash when destroying activity after media session

### DIFF
--- a/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
+++ b/app/src/main/java/com/github/libretube/util/NowPlayingNotification.kt
@@ -346,7 +346,7 @@ class NowPlayingNotification(
      * Destroy the [NowPlayingNotification]
      */
     fun destroySelf() {
-        mediaSession.release()
+        if (this::mediaSession.isInitialized) mediaSession.release()
 
         nManager.cancel(NotificationId.PLAYER_PLAYBACK.id)
     }


### PR DESCRIPTION
see https://github.com/libre-tube/LibreTube/issues/6134#issuecomment-2196574981