### PR TITLE
fix: improve exoplayer scoping

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -49,7 +49,7 @@ import com.github.libretube.ui.dialogs.ImportTempPlaylistDialog
 import com.github.libretube.ui.fragments.AudioPlayerFragment
 import com.github.libretube.ui.fragments.DownloadsFragment
 import com.github.libretube.ui.fragments.PlayerFragment
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.models.SearchViewModel
 import com.github.libretube.ui.models.SubscriptionsViewModel
 import com.github.libretube.util.UpdateChecker
@@ -66,7 +66,7 @@ class MainActivity : BaseActivity() {
 
     private var startFragmentId = R.id.homeFragment
 
-    private val playerViewModel: PlayerViewModel by viewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by viewModels()
     private val searchViewModel: SearchViewModel by viewModels()
     private val subscriptionsViewModel: SubscriptionsViewModel by viewModels()
 
@@ -158,7 +158,7 @@ class MainActivity : BaseActivity() {
         setupSubscriptionsBadge()
 
         onBackPressedDispatcher.addCallback {
-            if (playerViewModel.isFullscreen.value == true) {
+            if (commonPlayerViewModel.isFullscreen.value == true) {
                 val fullscreenUnsetSuccess = runOnPlayerFragment {
                     unsetFullscreen()
                     true
@@ -564,7 +564,7 @@ class MainActivity : BaseActivity() {
             }
         }
 
-        playerViewModel.isFullscreen.value = false
+        commonPlayerViewModel.isFullscreen.value = false
         requestOrientationChange()
     }
 

--- a/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
@@ -24,7 +24,6 @@ import androidx.media3.datasource.FileDataSource
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.SingleSampleMediaSource
-import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.ui.PlayerView
 import com.github.libretube.compat.PictureInPictureCompat
 import com.github.libretube.compat.PictureInPictureParamsCompat
@@ -60,7 +59,6 @@ class OfflinePlayerActivity : BaseActivity() {
     private lateinit var binding: ActivityOfflinePlayerBinding
     private lateinit var videoId: String
     private lateinit var playerView: PlayerView
-    private lateinit var trackSelector: DefaultTrackSelector
     private var timeFrameReceiver: TimeFrameReceiver? = null
     private var nowPlayingNotification: NowPlayingNotification? = null
 
@@ -205,7 +203,7 @@ class OfflinePlayerActivity : BaseActivity() {
 
             setMediaSource(videoUri, audioUri, subtitleUri)
 
-            trackSelector.updateParameters {
+            viewModel.trackSelector.updateParameters {
                 setPreferredTextRoleFlags(C.ROLE_FLAG_CAPTION)
                 setPreferredTextLanguage("en")
             }

--- a/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
@@ -21,7 +21,6 @@ import androidx.media3.common.MediaItem.SubtitleConfiguration
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.datasource.FileDataSource
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.source.SingleSampleMediaSource
@@ -46,7 +45,8 @@ import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.interfaces.TimeFrameReceiver
 import com.github.libretube.ui.listeners.SeekbarPreviewListener
 import com.github.libretube.ui.models.ChaptersViewModel
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
+import com.github.libretube.ui.models.OfflinePlayerViewModel
 import com.github.libretube.util.NowPlayingNotification
 import com.github.libretube.util.OfflineTimeFrameReceiver
 import com.github.libretube.util.PauseableTimer
@@ -59,14 +59,14 @@ import kotlin.io.path.exists
 class OfflinePlayerActivity : BaseActivity() {
     private lateinit var binding: ActivityOfflinePlayerBinding
     private lateinit var videoId: String
-    private lateinit var player: ExoPlayer
     private lateinit var playerView: PlayerView
     private lateinit var trackSelector: DefaultTrackSelector
     private var timeFrameReceiver: TimeFrameReceiver? = null
     private var nowPlayingNotification: NowPlayingNotification? = null
 
     private lateinit var playerBinding: ExoStyledPlayerControlViewBinding
-    private val playerViewModel: PlayerViewModel by viewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by viewModels()
+    private val viewModel: OfflinePlayerViewModel by viewModels { OfflinePlayerViewModel.Factory }
     private val chaptersViewModel: ChaptersViewModel by viewModels()
 
     private val watchPositionTimer = PauseableTimer(
@@ -106,7 +106,7 @@ class OfflinePlayerActivity : BaseActivity() {
                     SeekbarPreviewListener(
                         timeFrameReceiver ?: return,
                         binding.player.binding,
-                        player.duration
+                        viewModel.player.duration
                     )
                 )
             }
@@ -116,14 +116,14 @@ class OfflinePlayerActivity : BaseActivity() {
     private val playerActionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             val event = intent.serializableExtra<PlayerEvent>(PlayerHelper.CONTROL_TYPE) ?: return
-            PlayerHelper.handlePlayerAction(player, event)
+            PlayerHelper.handlePlayerAction(viewModel.player, event)
         }
     }
 
     private val pipParams get() = PictureInPictureParamsCompat.Builder()
-        .setActions(PlayerHelper.getPiPModeActions(this, player.isPlaying))
-        .setAutoEnterEnabled(PlayerHelper.pipEnabled && player.isPlaying)
-        .setAspectRatio(player.videoSize)
+        .setActions(PlayerHelper.getPiPModeActions(this, viewModel.player.isPlaying))
+        .setAutoEnterEnabled(PlayerHelper.pipEnabled && viewModel.player.isPlaying)
+        .setAspectRatio(viewModel.player.videoSize)
         .build()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -142,8 +142,8 @@ class OfflinePlayerActivity : BaseActivity() {
         playVideo()
 
         requestedOrientation = PlayerHelper.getOrientation(
-            player.videoSize.width,
-            player.videoSize.height
+            viewModel.player.videoSize.width,
+            viewModel.player.videoSize.height
         )
 
         ContextCompat.registerReceiver(
@@ -159,17 +159,13 @@ class OfflinePlayerActivity : BaseActivity() {
     }
 
     private fun initializePlayer() {
-        trackSelector = DefaultTrackSelector(this)
-
-        player = PlayerHelper.createPlayer(this, trackSelector, false)
-        player.setWakeMode(C.WAKE_MODE_LOCAL)
-        player.addListener(playerListener)
-        playerViewModel.player = player
+        viewModel.player.setWakeMode(C.WAKE_MODE_LOCAL)
+        viewModel.player.addListener(playerListener)
 
         playerView = binding.player
         playerView.setShowSubtitleButton(true)
         playerView.subtitleView?.isVisible = true
-        playerView.player = player
+        playerView.player = viewModel.player
         playerBinding = binding.player.binding
 
         playerBinding.fullscreen.isInvisible = true
@@ -183,7 +179,7 @@ class OfflinePlayerActivity : BaseActivity() {
             chaptersViewModel
         )
 
-        nowPlayingNotification = NowPlayingNotification(this, player, NowPlayingNotification.Companion.NowPlayingNotificationType.VIDEO_OFFLINE)
+        nowPlayingNotification = NowPlayingNotification(this, viewModel.player, NowPlayingNotification.Companion.NowPlayingNotificationType.VIDEO_OFFLINE)
     }
 
     private fun playVideo() {
@@ -218,12 +214,12 @@ class OfflinePlayerActivity : BaseActivity() {
                 OfflineTimeFrameReceiver(this@OfflinePlayerActivity, it)
             }
 
-            player.playWhenReady = PlayerHelper.playAutomatically
-            player.prepare()
+            viewModel.player.playWhenReady = PlayerHelper.playAutomatically
+            viewModel.player.prepare()
 
             if (PlayerHelper.watchPositionsVideo) {
                 PlayerHelper.getStoredWatchPosition(videoId, downloadInfo.duration)?.let {
-                    player.seekTo(it)
+                    viewModel.player.seekTo(it)
                 }
             }
 
@@ -261,17 +257,17 @@ class OfflinePlayerActivity : BaseActivity() {
                     mediaSource = MergingMediaSource(mediaSource, subtitleSource)
                 }
 
-                player.setMediaSource(mediaSource)
+                viewModel.player.setMediaSource(mediaSource)
             }
 
-            videoUri != null -> player.setMediaItem(
+            videoUri != null -> viewModel.player.setMediaItem(
                 MediaItem.Builder()
                     .setUri(videoUri)
                     .setSubtitleConfigurations(listOfNotNull(subtitle))
                     .build()
             )
 
-            audioUri != null -> player.setMediaItem(
+            audioUri != null -> viewModel.player.setMediaItem(
                 MediaItem.Builder()
                     .setUri(audioUri)
                     .setSubtitleConfigurations(listOfNotNull(subtitle))
@@ -283,20 +279,20 @@ class OfflinePlayerActivity : BaseActivity() {
     private fun saveWatchPosition() {
         if (!PlayerHelper.watchPositionsVideo) return
 
-        PlayerHelper.saveWatchPosition(player, videoId)
+        PlayerHelper.saveWatchPosition(viewModel.player, videoId)
     }
 
     override fun onResume() {
-        playerViewModel.isFullscreen.value = true
+        commonPlayerViewModel.isFullscreen.value = true
         super.onResume()
     }
 
     override fun onPause() {
-        playerViewModel.isFullscreen.value = false
+        commonPlayerViewModel.isFullscreen.value = false
         super.onPause()
 
         if (PlayerHelper.pauseOnQuit) {
-            player.pause()
+            viewModel.player.pause()
         }
     }
 
@@ -307,10 +303,8 @@ class OfflinePlayerActivity : BaseActivity() {
         nowPlayingNotification = null
         watchPositionTimer.destroy()
 
-        playerViewModel.player = null
         runCatching {
-            player.stop()
-            player.release()
+            viewModel.player.stop()
         }
 
         runCatching {
@@ -321,7 +315,7 @@ class OfflinePlayerActivity : BaseActivity() {
     }
 
     override fun onUserLeaveHint() {
-        if (PlayerHelper.pipEnabled && player.isPlaying) {
+        if (PlayerHelper.pipEnabled && viewModel.player.isPlaying) {
             PictureInPictureCompat.enterPictureInPictureMode(this, pipParams)
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -44,7 +44,7 @@ import com.github.libretube.ui.activities.MainActivity
 import com.github.libretube.ui.interfaces.AudioPlayerOptions
 import com.github.libretube.ui.listeners.AudioPlayerThumbnailListener
 import com.github.libretube.ui.models.ChaptersViewModel
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.sheets.ChaptersBottomSheet
 import com.github.libretube.ui.sheets.PlaybackOptionsSheet
 import com.github.libretube.ui.sheets.PlayingQueueSheet
@@ -61,7 +61,7 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
 
     private lateinit var audioHelper: AudioHelper
     private val mainActivity get() = context as MainActivity
-    private val viewModel: PlayerViewModel by activityViewModels()
+    private val viewModel: CommonPlayerViewModel by activityViewModels()
     private val chaptersModel: ChaptersViewModel by activityViewModels()
 
     // for the transition
@@ -370,7 +370,6 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
     }
 
     private fun handleServiceConnection() {
-        viewModel.player = playerService?.player
         playerService?.onStateOrPlayingChanged = { isPlaying ->
             updatePlayPauseButton()
             isPaused = !isPlaying
@@ -393,8 +392,6 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
         runCatching {
             activity?.unbindService(connection)
         }
-
-        viewModel.player = null
 
         super.onDestroy()
     }

--- a/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
@@ -34,7 +34,7 @@ import com.github.libretube.ui.adapters.PlaylistsAdapter
 import com.github.libretube.ui.base.DynamicLayoutManagerFragment
 import com.github.libretube.ui.dialogs.CreatePlaylistDialog
 import com.github.libretube.ui.dialogs.CreatePlaylistDialog.Companion.CREATE_PLAYLIST_DIALOG_REQUEST_KEY
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.sheets.BaseBottomSheet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -44,7 +44,7 @@ class LibraryFragment : DynamicLayoutManagerFragment() {
     private var _binding: FragmentLibraryBinding? = null
     private val binding get() = _binding!!
 
-    private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -64,7 +64,7 @@ class LibraryFragment : DynamicLayoutManagerFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // listen for the mini player state changing
-        playerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
+        commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
             updateFABMargin(it)
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -41,7 +41,7 @@ import com.github.libretube.ui.adapters.PlaylistAdapter
 import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.base.DynamicLayoutManagerFragment
 import com.github.libretube.ui.extensions.addOnBottomReachedListener
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.sheets.BaseBottomSheet
 import com.github.libretube.ui.sheets.PlaylistOptionsBottomSheet
 import com.github.libretube.util.PlayingQueue
@@ -68,7 +68,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
     private var isBookmarked = false
 
     // view models
-    private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
     private var selectedSortOrder = PreferenceHelper.getInt(PreferenceKeys.PLAYLIST_SORT_ORDER, 0)
         set(value) {
             PreferenceHelper.putInt(PreferenceKeys.PLAYLIST_SORT_ORDER, value)
@@ -106,7 +106,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
         }
         updateBookmarkRes()
 
-        playerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
+        commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
             binding.playlistRecView.updatePadding(bottom = if (it) 64f.dpToPx() else 0)
         }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -38,7 +38,7 @@ import com.github.libretube.ui.adapters.VideosAdapter
 import com.github.libretube.ui.base.DynamicLayoutManagerFragment
 import com.github.libretube.ui.extensions.addOnBottomReachedListener
 import com.github.libretube.ui.models.EditChannelGroupsModel
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.models.SubscriptionsViewModel
 import com.github.libretube.ui.sheets.ChannelGroupsSheet
 import com.github.libretube.ui.sheets.FilterSortBottomSheet
@@ -55,7 +55,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
     private val binding get() = _binding!!
 
     private val viewModel: SubscriptionsViewModel by activityViewModels()
-    private val playerModel: PlayerViewModel by activityViewModels()
+    private val playerModel: CommonPlayerViewModel by activityViewModels()
     private val channelGroupsModel: EditChannelGroupsModel by activityViewModels()
     private var selectedFilterGroup
         set(value) = PreferenceHelper.putInt(PreferenceKeys.SELECTED_CHANNEL_GROUP, value)

--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -33,7 +33,7 @@ import com.github.libretube.helpers.ProxyHelper
 import com.github.libretube.ui.adapters.WatchHistoryAdapter
 import com.github.libretube.ui.base.DynamicLayoutManagerFragment
 import com.github.libretube.ui.extensions.addOnBottomReachedListener
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.sheets.BaseBottomSheet
 import com.github.libretube.util.PlayingQueue
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -46,7 +46,7 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
     private val binding get() = _binding!!
 
     private val handler = Handler(Looper.getMainLooper())
-    private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
     private var isLoading = false
     private var recyclerViewState: Parcelable? = null
 
@@ -84,7 +84,7 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        playerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
+        commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
             _binding?.watchHistoryRecView?.updatePadding(bottom = if (it) 64f.dpToPx() else 0)
         }
 

--- a/app/src/main/java/com/github/libretube/ui/listeners/PlayerGestureController.kt
+++ b/app/src/main/java/com/github/libretube/ui/listeners/PlayerGestureController.kt
@@ -15,7 +15,7 @@ import androidx.core.os.postDelayed
 import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.interfaces.PlayerGestureOptions
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import kotlin.math.abs
 
 class PlayerGestureController(activity: BaseActivity, private val listener: PlayerGestureOptions) :
@@ -28,7 +28,7 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
     private val orientation get() = Resources.getSystem().configuration.orientation
     private val elapsedTime get() = SystemClock.elapsedRealtime()
 
-    private val playerViewModel: PlayerViewModel by activity.viewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by activity.viewModels()
     private val handler = Handler(Looper.getMainLooper())
 
     private val gestureDetector: GestureDetector
@@ -46,7 +46,7 @@ class PlayerGestureController(activity: BaseActivity, private val listener: Play
         gestureDetector = GestureDetector(activity, GestureListener(), handler)
         scaleGestureDetector = ScaleGestureDetector(activity, ScaleGestureListener(), handler)
 
-        playerViewModel.isFullscreen.observe(activity) {
+        commonPlayerViewModel.isFullscreen.observe(activity) {
             isFullscreen = it
             listener.onFullscreenChange(it)
         }

--- a/app/src/main/java/com/github/libretube/ui/models/CommonPlayerViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommonPlayerViewModel.kt
@@ -1,0 +1,10 @@
+package com.github.libretube.ui.models
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class CommonPlayerViewModel : ViewModel() {
+    val isMiniPlayerVisible = MutableLiveData(false)
+    val isFullscreen = MutableLiveData(false)
+    var maxSheetHeightPx = 0
+}

--- a/app/src/main/java/com/github/libretube/ui/models/OfflinePlayerViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/OfflinePlayerViewModel.kt
@@ -12,6 +12,7 @@ import com.github.libretube.helpers.PlayerHelper
 @UnstableApi
 class OfflinePlayerViewModel(
     val player: ExoPlayer,
+    val trackSelector: DefaultTrackSelector,
 ) : ViewModel() {
 
     companion object {
@@ -21,6 +22,7 @@ class OfflinePlayerViewModel(
                 val trackSelector = DefaultTrackSelector(context)
                 OfflinePlayerViewModel(
                     player = PlayerHelper.createPlayer(context, trackSelector, false),
+                    trackSelector = trackSelector,
                 )
             }
         }

--- a/app/src/main/java/com/github/libretube/ui/models/OfflinePlayerViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/OfflinePlayerViewModel.kt
@@ -1,0 +1,33 @@
+package com.github.libretube.ui.models
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import com.github.libretube.helpers.PlayerHelper
+
+@UnstableApi
+class OfflinePlayerViewModel(
+    val player: ExoPlayer,
+) : ViewModel() {
+
+    companion object {
+        val Factory = viewModelFactory {
+            initializer {
+                val context = this[APPLICATION_KEY]!!
+                val trackSelector = DefaultTrackSelector(context)
+                OfflinePlayerViewModel(
+                    player = PlayerHelper.createPlayer(context, trackSelector, false),
+                )
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        player.release()
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
@@ -13,13 +13,13 @@ import com.github.libretube.R
 import com.github.libretube.databinding.CommentsSheetBinding
 import com.github.libretube.ui.fragments.CommentsMainFragment
 import com.github.libretube.ui.models.CommentsViewModel
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 
 class CommentsSheet : UndimmedBottomSheet() {
     private var _binding: CommentsSheetBinding? = null
     val binding get() = _binding!!
 
-    private val playerViewModel: PlayerViewModel by activityViewModels()
+    private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
     private val commentsViewModel: CommentsViewModel by activityViewModels()
 
     override fun onCreateView(
@@ -72,7 +72,7 @@ class CommentsSheet : UndimmedBottomSheet() {
         _binding = null
     }
 
-    override fun getSheetMaxHeightPx() = playerViewModel.maxSheetHeightPx
+    override fun getSheetMaxHeightPx() = commonPlayerViewModel.maxSheetHeightPx
 
     override fun getDragHandle() = binding.dragHandle
 

--- a/app/src/main/java/com/github/libretube/ui/views/AutoplayCountdownView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/AutoplayCountdownView.kt
@@ -15,14 +15,14 @@ import com.github.libretube.compat.PictureInPictureCompat
 import com.github.libretube.databinding.AutoplayCountdownBinding
 import com.github.libretube.helpers.ContextHelper
 import com.github.libretube.ui.activities.MainActivity
-import com.github.libretube.ui.models.PlayerViewModel
+import com.github.libretube.ui.models.CommonPlayerViewModel
 
 class AutoplayCountdownView(
     context: Context,
     attributeSet: AttributeSet?
 ) : FrameLayout(context, attributeSet) {
     private val layoutInflater = LayoutInflater.from(context)
-    private val playerViewModel: PlayerViewModel get() = ViewModelProvider(
+    private val commonPlayerViewModel: CommonPlayerViewModel get() = ViewModelProvider(
         context as MainActivity
     ).get()
 
@@ -69,7 +69,7 @@ class AutoplayCountdownView(
         binding.playNext.isVisible = !isInPipMode
 
         // only show countdown when mini player not visible
-        this.isVisible = playerViewModel.isMiniPlayerVisible.value == false
+        this.isVisible = commonPlayerViewModel.isMiniPlayerVisible.value == false
         binding.currentState.text = context.getString(
             R.string.playing_next,
             currentTimerState.toString()

--- a/app/src/main/java/com/github/libretube/ui/views/OnlinePlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/OnlinePlayerView.kt
@@ -27,6 +27,7 @@ import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.dialogs.SubmitDeArrowDialog
 import com.github.libretube.ui.dialogs.SubmitSegmentDialog
 import com.github.libretube.ui.interfaces.OnlinePlayerOptions
+import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.models.PlayerViewModel
 import com.github.libretube.ui.sheets.PlayingQueueSheet
 import com.github.libretube.util.PlayingQueue
@@ -38,6 +39,7 @@ class OnlinePlayerView(
 ) : CustomExoPlayerView(context, attributeSet) {
     private var playerOptions: OnlinePlayerOptions? = null
     private var playerViewModel: PlayerViewModel? = null
+    private var commonPlayerViewModel: CommonPlayerViewModel? = null
     private var trackSelector: TrackSelector? = null
     private var viewLifecycleOwner: LifecycleOwner? = null
 
@@ -149,16 +151,18 @@ class OnlinePlayerView(
 
     fun initPlayerOptions(
         playerViewModel: PlayerViewModel,
+        commonPlayerViewModel: CommonPlayerViewModel,
         viewLifecycleOwner: LifecycleOwner,
         trackSelector: TrackSelector,
         playerOptions: OnlinePlayerOptions
     ) {
         this.playerViewModel = playerViewModel
+        this.commonPlayerViewModel = commonPlayerViewModel
         this.viewLifecycleOwner = viewLifecycleOwner
         this.trackSelector = trackSelector
         this.playerOptions = playerOptions
 
-        playerViewModel.isFullscreen.observe(viewLifecycleOwner) { isFullscreen ->
+        commonPlayerViewModel.isFullscreen.observe(viewLifecycleOwner) { isFullscreen ->
             WindowHelper.toggleFullscreen(activity.window, isFullscreen)
             updateTopBarMargin()
 
@@ -258,7 +262,7 @@ class OnlinePlayerView(
     override fun hideController() {
         super.hideController()
 
-        if (playerViewModel?.isFullscreen?.value == true) {
+        if (commonPlayerViewModel?.isFullscreen?.value == true) {
             toggleSystemBars(false)
         }
         updateTopBarMargin()
@@ -267,13 +271,13 @@ class OnlinePlayerView(
     override fun showController() {
         super.showController()
 
-        if (playerViewModel?.isFullscreen?.value == true && !isPlayerLocked) {
+        if (commonPlayerViewModel?.isFullscreen?.value == true && !isPlayerLocked) {
             toggleSystemBars(true)
         }
     }
 
     override fun isFullscreen(): Boolean {
-        return playerViewModel?.isFullscreen?.value ?: super.isFullscreen()
+        return commonPlayerViewModel?.isFullscreen?.value ?: super.isFullscreen()
     }
 
     override fun minimizeOrExitPlayer() {


### PR DESCRIPTION
This PR splits the PlayerViewModel, so that each fragment or activity where an exoplayer is used has its own properly scoped exoplayer. The result is that an exoplayer is created when the viewmodel of a fragment that needs a player is created and destroyed when the viewmodel is. The exoplayer is no longer recreated upon orientation change.
This means that media keeps playing without interruptions upon orientation change, fixing https://github.com/libre-tube/LibreTube/issues/5754#issuecomment-2230222744

The exoplayer no longer lives inside the player fragment or in the activity scoped viewmodel.