### PR TITLE
fix: visibility of UI elements in Downloads

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
@@ -87,7 +86,6 @@ class DownloadsFragment : DynamicLayoutManagerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.deleteAll.isInvisible = true
         var selectedSortType =
             PreferenceHelper.getInt(PreferenceKeys.SELECTED_DOWNLOAD_SORT_TYPE, 0)
         val filterOptions = resources.getStringArray(R.array.downloadSortOptions)
@@ -166,25 +164,31 @@ class DownloadsFragment : DynamicLayoutManagerFragment() {
             object : RecyclerView.AdapterDataObserver() {
                 override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
                     super.onItemRangeRemoved(positionStart, itemCount)
-                    val binding = _binding ?: return
-                    if (binding.downloads.adapter?.itemCount == 0) {
-                        binding.downloads.isGone = true
-                        binding.downloadsEmpty.isVisible = true
-                    }
+                    toggleButtonsVisibility()
                 }
             }
         )
 
-        if (dbDownloads.isNotEmpty()) {
-            binding.deleteAll.isVisible = true
-            binding.deleteAll.setOnClickListener {
-                showDeleteAllDialog(binding.root.context, adapter)
-            }
-        }
+        toggleButtonsVisibility()
 
         binding.shuffleBackground.setOnClickListener {
             BackgroundHelper.playOnBackgroundOffline(requireContext(), null)
         }
+
+        binding.deleteAll.setOnClickListener {
+            showDeleteAllDialog(binding.root.context, adapter)
+        }
+    }
+
+    private fun toggleButtonsVisibility() {
+        val binding = _binding ?: return
+
+        val isEmpty = binding.downloads.adapter?.itemCount == 0
+        binding.downloadsEmpty.isVisible = isEmpty
+        binding.downloads.isGone = isEmpty
+        binding.sortType.isGone = isEmpty
+        binding.deleteAll.isGone = isEmpty
+        binding.shuffleBackground.isGone = isEmpty
     }
 
     private fun sortDownloadList(sortType: Int, previousSortType: Int? = null) {

--- a/app/src/main/res/layout/fragment_downloads.xml
+++ b/app/src/main/res/layout/fragment_downloads.xml
@@ -11,19 +11,19 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="10dp"
-        android:paddingVertical="5dp"
+        android:clickable="true"
+        android:drawablePadding="10dp"
         android:focusable="true"
         android:fontFamily="@font/roboto"
+        android:paddingVertical="5dp"
         android:text="@string/sort_by"
-
-        android:clickable="true"
         android:textSize="15sp"
         android:textStyle="bold"
-        android:drawablePadding="10dp"
+        android:visibility="gone"
         app:drawableEndCompat="@drawable/ic_sort"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/downloads_empty"
@@ -70,9 +70,11 @@
         android:contentDescription="@string/shuffle"
         android:src="@drawable/ic_delete"
         android:tooltipText="@string/delete"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        tools:targetApi="o" />
+        tools:targetApi="o"
+        tools:visibility="visible" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/shuffle_background"
@@ -83,8 +85,10 @@
         android:contentDescription="@string/shuffle"
         android:src="@drawable/ic_shuffle"
         android:tooltipText="@string/shuffle"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        tools:targetApi="o" />
+        tools:targetApi="o"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
In this PR, the visibility of some UI elements has been fixed when the list is empty.