### PR TITLE
fix: download fails due to filename length

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
@@ -149,7 +149,7 @@ class DownloadDialog : DialogFragment() {
                 return@onDownloadConfirm
             }
 
-            if (fileName.length > MAX_FILE_NAME_LENGTH - 20) { // reserve 20 chars for quality and extension
+            if (fileName.toByteArray().size > MAX_FILE_NAME_BYTES - 32) { // reserve 32 bytes for quality and extension
                 Toast.makeText(context, R.string.filename_too_long, Toast.LENGTH_SHORT).show()
                 return@onDownloadConfirm
             }
@@ -265,7 +265,7 @@ class DownloadDialog : DialogFragment() {
         /**
          * Max file name length at Android systems
          */
-        private const val MAX_FILE_NAME_LENGTH = 255
+        private const val MAX_FILE_NAME_BYTES = 255
 
         private const val VIDEO_DOWNLOAD_QUALITY = "video_download_quality"
         private const val VIDEO_DOWNLOAD_FORMAT = "video_download_format"


### PR DESCRIPTION
closes  #6317