### PR TITLE
fix: retain exoplayer on orientation change

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -845,12 +845,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         viewModel.player.removeListener(playerListener)
         viewModel.player.pause()
 
-        runCatching {
-            if (!viewModel.isOrientationChangeInProgress) {
-                viewModel.player.stop()
-            }
-        }
-
         if (PlayerHelper.pipEnabled) {
             // disable the auto PiP mode for SDK >= 32
             PictureInPictureCompat
@@ -1347,11 +1341,6 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     }
 
     private fun createExoPlayer() {
-//        viewModel.keepOrCreatePlayer(requireContext()).let { (player, trackSelector) ->
-//            localViewModel.player = player
-//            localViewModel.trackSelector = trackSelector
-//        }
-
         viewModel.player.setWakeMode(C.WAKE_MODE_NETWORK)
         viewModel.player.addListener(playerListener)
 


### PR DESCRIPTION
This PR is basically the last step of https://github.com/libre-tube/LibreTube/pull/6307
Now you should feel the improvement upon rotation change ;)

The ExoPlayer is no longer stopped on onDestroy, because it is already released in its viewmodel onDestroy method.