### PR TITLE
fix: shuffle button crash when playlist is empty

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -253,7 +253,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
                         PlayingQueue.add(*queue.toTypedArray())
                         NavigationHelper.navigateVideo(
                             requireContext(),
-                            queue.first().url,
+                            queue.firstOrNull()?.url,
                             playlistId = playlistId,
                             keepQueue = true
                         )


### PR DESCRIPTION
It fixes the issue https://github.com/libre-tube/LibreTube/issues/6558