### PR TITLE
feat: support for selecting audio codec

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -81,6 +81,7 @@ object PreferenceKeys {
     const val ALTERNATIVE_PIP_CONTROLS = "alternative_pip_controls"
     const val SKIP_SILENCE = "skip_silence"
     const val ENABLED_VIDEO_CODECS = "video_codecs"
+    const val ENABLED_AUDIO_CODECS = "audio_codecs"
     const val AUTOPLAY_COUNTDOWN = "autoplay_countdown"
     const val LBRY_HLS = "lbry_hls"
     const val AUTO_FULLSCREEN_SHORTS = "auto_fullscreen_shorts"

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -339,6 +339,12 @@ object PlayerHelper {
             "all"
         )
 
+    val enabledAudioCodecs: String
+        get() = PreferenceHelper.getString(
+            PreferenceKeys.ENABLED_AUDIO_CODECS,
+            "all"
+        )
+
     val playAutomatically: Boolean
         get() = PreferenceHelper.getBoolean(
             PreferenceKeys.PLAY_AUTOMATICALLY,

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -17,7 +17,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
-import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.PixelCopy
@@ -1359,6 +1358,16 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
                     else -> throw IllegalArgumentException()
                 }
                 this.setPreferredVideoMimeTypes(*mimeType)
+            }
+            val enabledAudioCodecs = PlayerHelper.enabledAudioCodecs
+            if (enabledAudioCodecs != "all") {
+                // map the codecs to their corresponding mimetypes
+                val mimeType = when (enabledAudioCodecs) {
+                    "opus" -> arrayOf("audio/opus")
+                    "mp4" -> arrayOf("audio/mp4a-latm")
+                    else -> throw IllegalArgumentException()
+                }
+                this.setPreferredAudioMimeTypes(*mimeType)
             }
         }
     }

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -424,6 +424,18 @@
         <item>avc</item>
     </string-array>
 
+    <string-array name="audioCodecs">
+        <item>@string/all</item>
+        <item>opus</item>
+        <item>mp4</item>
+    </string-array>
+
+    <string-array name="audioCodecValues">
+        <item>all</item>
+        <item>opus</item>
+        <item>mp4</item>
+    </string-array>
+
     <string-array name="watchPosition">
         <item>@string/always</item>
         <item>@string/videos</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -388,7 +388,8 @@
     <string name="skip_silence">Skip silence</string>
     <string name="help">Help</string>
     <string name="faq">FAQ</string>
-    <string name="codecs">Codecs</string>
+    <string name="codecs">Video codecs</string>
+    <string name="audio_codecs">Audio codecs</string>
     <string name="mark_as_watched">Mark as watched</string>
     <string name="custom_playback_speed">Custom speed</string>
     <string name="custom_playback_speed_summary">Use a different playback speed than for the normal player</string>

--- a/app/src/main/res/xml/audio_video_settings.xml
+++ b/app/src/main/res/xml/audio_video_settings.xml
@@ -113,6 +113,15 @@
             app:title="@string/codecs"
             app:useSimpleSummaryProvider="true" />
 
+        <ListPreference
+            android:entries="@array/audioCodecs"
+            android:entryValues="@array/audioCodecValues"
+            android:icon="@drawable/ic_equalizer"
+            android:key="audio_codecs"
+            app:defaultValue="all"
+            app:title="@string/audio_codecs"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
closes #6537

Please note that HLS only provides mp4a audio streams, choosing opus only works reliably when using DASH.