### PR TITLE
fix: don't allow empty input in EditNumberPreference

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/base/BasePreferenceFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/base/BasePreferenceFragment.kt
@@ -89,7 +89,7 @@ abstract class BasePreferenceFragment : PreferenceFragmentCompat() {
                     .setView(binding.root)
                     .setPositiveButton(android.R.string.ok) { _, _ ->
                         val newValue = binding.input.text.toString()
-                        if (preference is EditNumberPreference && newValue.any { !it.isDigit() }) {
+                        if (preference is EditNumberPreference && newValue.toIntOrNull() == null) {
                             Toast.makeText(context, R.string.invalid_input, Toast.LENGTH_LONG).show()
                             return@setPositiveButton
                         }


### PR DESCRIPTION
closes #6665