### PR TITLE
feat(VideosAdapter): clearly indicate future videos as upcoming

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/PlaylistAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/PlaylistAdapter.kt
@@ -83,7 +83,7 @@ class PlaylistAdapter(
             videoInfo.text = streamItem.uploaderName
             channelImage.isGone = true
 
-            thumbnailDuration.setFormattedDuration(streamItem.duration ?: -1, streamItem.isShort)
+            thumbnailDuration.setFormattedDuration(streamItem.duration ?: -1, streamItem.isShort, streamItem.uploaded)
 
             ImageHelper.loadImage(streamItem.thumbnail, thumbnail)
 

--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchChannelAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchChannelAdapter.kt
@@ -71,7 +71,7 @@ class SearchChannelAdapter : ListAdapter<ContentItem, SearchViewHolder>(SearchCa
     private fun bindVideo(item: ContentItem, binding: VideoRowBinding, position: Int) {
         binding.apply {
             ImageHelper.loadImage(item.thumbnail, thumbnail)
-            thumbnailDuration.setFormattedDuration(item.duration, item.isShort)
+            thumbnailDuration.setFormattedDuration(item.duration, item.isShort, item.uploaded)
             videoTitle.text = item.title
             videoInfo.text = TextUtils.formatViewsString(root.context, item.views, item.uploaded)
 

--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchResultsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchResultsAdapter.kt
@@ -80,7 +80,7 @@ class SearchResultsAdapter(
     private fun bindVideo(item: ContentItem, binding: VideoRowBinding, position: Int) {
         binding.apply {
             ImageHelper.loadImage(item.thumbnail, thumbnail)
-            thumbnailDuration.setFormattedDuration(item.duration, item.isShort)
+            thumbnailDuration.setFormattedDuration(item.duration, item.isShort, item.uploaded)
             videoTitle.text = item.title
             videoInfo.text = TextUtils.formatViewsString(root.context, item.views, item.uploaded)
 

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideosAdapter.kt
@@ -112,7 +112,7 @@ class VideosAdapter(
             textViewTitle.text = video.title
             textViewChannel.text = TextUtils.formatViewsString(root.context, video.views ?: -1, video.uploaded, video.uploaderName)
 
-            video.duration?.let { thumbnailDuration.setFormattedDuration(it, video.isShort) }
+            video.duration?.let { thumbnailDuration.setFormattedDuration(it, video.isShort, video.uploaded) }
             channelImage.setOnClickListener {
                 NavigationHelper.navigateChannel(root.context, video.uploaderUrl)
             }
@@ -141,7 +141,7 @@ class VideosAdapter(
             videoTitle.text = video.title
             videoInfo.text = TextUtils.formatViewsString(root.context, video.views ?: -1, video.uploaded)
 
-            thumbnailDuration.text = video.duration?.let { DateUtils.formatElapsedTime(it) }
+            video.duration?.let { thumbnailDuration.setFormattedDuration(it, video.isShort, video.uploaded) }
             ImageHelper.loadImage(video.thumbnail, thumbnail)
 
             if (forceMode != LayoutMode.CHANNEL_ROW) {

--- a/app/src/main/java/com/github/libretube/ui/adapters/WatchHistoryAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/WatchHistoryAdapter.kt
@@ -59,7 +59,8 @@ class WatchHistoryAdapter(
             ImageHelper.loadImage(video.thumbnailUrl, thumbnail)
 
             if (video.duration != null) {
-                thumbnailDuration.setFormattedDuration(video.duration, null)
+                // we pass in 0 for the uploadDate, as a future video cannot be watched already
+                thumbnailDuration.setFormattedDuration(video.duration, null, 0)
             } else {
                 thumbnailDurationCard.isGone = true
             }

--- a/app/src/main/java/com/github/libretube/ui/extensions/SetFormattedDuration.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetFormattedDuration.kt
@@ -4,10 +4,11 @@ import android.text.format.DateUtils
 import android.widget.TextView
 import com.github.libretube.R
 
-fun TextView.setFormattedDuration(duration: Long, isShort: Boolean?) {
+fun TextView.setFormattedDuration(duration: Long, isShort: Boolean?, uploadDate: Long) {
     this.text = when {
         isShort == true -> context.getString(R.string.yt_shorts)
         duration < 0L -> context.getString(R.string.live)
+        uploadDate > System.currentTimeMillis() -> context.getString(R.string.upcoming)
         else -> DateUtils.formatElapsedTime(duration)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="appearance_summary">Adjust the app to your liking</string>
     <string name="advanced_summary">Downloads, and reset</string>
     <string name="live">Live</string>
+    <string name="upcoming">Upcoming</string>
     <string name="shareTo">Share URL to</string>
     <string name="normal_views">%1$s views%2$s</string>
     <string name="defaultIcon">Default</string>


### PR DESCRIPTION
Replaces the duration of future videos (i.e. Premieres) as 'Upcoming'. This helps to differentiate them from normal videos.

![Video with upcoming as the duration](https://github.com/user-attachments/assets/980cbe99-a137-4881-a0e6-1c6f604a8ae1)
