### PR TITLE
feat: display full video sponsorblock categories

### DIFF
--- a/app/src/main/java/com/github/libretube/api/PipedApi.kt
+++ b/app/src/main/java/com/github/libretube/api/PipedApi.kt
@@ -43,7 +43,8 @@ interface PipedApi {
     @GET("sponsors/{videoId}")
     suspend fun getSegments(
         @Path("videoId") videoId: String,
-        @Query("category") category: String
+        @Query("category") category: String,
+        @Query("actionType") actionType: String? = null
     ): SegmentData
 
     @GET("dearrow")

--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -25,4 +25,8 @@ data class Segment(
     @Transient
     @IgnoredOnParcel
     val segmentStartAndEnd = FloatFloatPair(segment[0], segment[1])
+
+    companion object {
+        const val TYPE_FULL = "full"
+    }
 }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -81,7 +81,8 @@ object PlayerHelper {
      */
     private val sbDefaultValues = mapOf(
         "sponsor" to SbSkipOptions.AUTOMATIC,
-        "selfpromo" to SbSkipOptions.AUTOMATIC
+        "selfpromo" to SbSkipOptions.AUTOMATIC,
+        "exclusive_access" to SbSkipOptions.AUTOMATIC,
     )
 
     /**

--- a/app/src/main/java/com/github/libretube/services/OnlinePlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/OnlinePlayerService.kt
@@ -212,7 +212,8 @@ open class OnlinePlayerService : AbstractPlayerService() {
             if (sponsorBlockConfig.isEmpty()) return@runCatching
             sponsorBlockSegments = RetrofitInstance.api.getSegments(
                 videoId,
-                JsonHelper.json.encodeToString(sponsorBlockConfig.keys)
+                JsonHelper.json.encodeToString(sponsorBlockConfig.keys),
+                """["skip","mute","full","poi","chapter"]"""
             ).segments
 
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -319,6 +319,7 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             val segments: List<Segment>? = mediaMetadata.extras?.parcelableList(IntentData.segments)
             viewModel.segments = segments.orEmpty()
 
+            binding.descriptionLayout.setSegments(viewModel.segments)
             playerBinding.exoProgress.setSegments(viewModel.segments)
             playerBinding.sbToggle.isVisible = true
             viewModel.segments.firstOrNull { it.category == PlayerHelper.SPONSOR_HIGHLIGHT_CATEGORY }

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -12,10 +12,13 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.libretube.R
+import com.github.libretube.api.obj.Segment
 import com.github.libretube.api.obj.Streams
 import com.github.libretube.databinding.DescriptionLayoutBinding
+import com.github.libretube.enums.SbSkipOptions
 import com.github.libretube.extensions.formatShort
 import com.github.libretube.helpers.ClipboardHelper
+import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.ui.activities.VideoTagsAdapter
 import com.github.libretube.util.HtmlParser
 import com.github.libretube.util.LinkHandler
@@ -38,6 +41,23 @@ class DescriptionLayout(
             streams?.title?.let { ClipboardHelper.save(context, text = it) }
             true
         }
+    }
+
+    fun setSegments(segments: List<Segment>) {
+        if (PlayerHelper.getSponsorBlockCategories()[SB_SPONSOR_CATEGORY] == SbSkipOptions.OFF) {
+            // only show the badge if the user requested to show sponsors
+           return
+        }
+
+        val segment = segments.filter { it.actionType == Segment.TYPE_FULL }.firstNotNullOfOrNull {
+            when (it.category) {
+                "sponsor" -> context.getString(R.string.category_sponsor)
+                "exclusive_access" -> context.getString(R.string.category_exclusive_access)
+                else -> null
+            }
+        }
+        binding.playerSponsorBadge.isVisible = segment != null
+        binding.playerSponsorBadge.text = segment
     }
 
     @SuppressLint("SetTextI18n")
@@ -149,5 +169,6 @@ class DescriptionLayout(
 
     companion object {
         private const val ANIMATION_DURATION = 250L
+        private const val SB_SPONSOR_CATEGORY = "sponsor_category"
     }
 }

--- a/app/src/main/res/layout/description_layout.xml
+++ b/app/src/main/res/layout/description_layout.xml
@@ -9,6 +9,23 @@
     android:paddingVertical="12dp">
 
     <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="12dp">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/player_sponsor_badge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkable="false"
+            android:visibility="gone"
+            android:text="Sponsor"/>
+
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/player_title_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -501,6 +501,7 @@
         <item>filler</item>
         <item>music_offtopic</item>
         <item>preview</item>
+        <item>exclusive_access</item>
     </string-array>
 
     <string-array name="sponsorBlockSegmentNames">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="category_preview_summary">For segments detailing future content without additional info. If it includes clips that only appear here, this is very likely the wrong category</string>
     <string name="category_highlight">Show video highlight</string>
     <string name="category_highlight_summary">Could either be the advertised title, the thumbnail or the most interesting part of the video. You can skip to it by tapping on it in the chapters section</string>
+    <string name="category_exclusive_access">Exclusive Access</string>
     <string name="license">License</string>
     <string name="color_accent">Accents</string>
     <string name="color_red">Resting red</string>


### PR DESCRIPTION
Displays the full SponsorBlock categories as a chip below the video, similar to how the web version works

![Fully sponsored video](https://github.com/user-attachments/assets/79fbe4a4-b10c-4dc2-8fc6-6b9f6cf3d6de)
![Exclusive access video](https://github.com/user-attachments/assets/afa7bfe9-a4e2-4949-95ba-b131fccfac91)
