### PR TITLE
fix: don't show audio player when tapping video player notification

### DIFF
--- a/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
@@ -175,7 +175,7 @@ abstract class AbstractPlayerService : MediaLibraryService(), MediaLibrarySessio
 
         val notificationProvider = NowPlayingNotification(
             this,
-            backgroundOnly = true,
+            backgroundOnly = isAudioOnlyPlayer,
             offlinePlayer = isOfflinePlayer,
             intentActivity = intentActivity
         )


### PR DESCRIPTION
closes  #6737