### PR TITLE
fix: crash if player view is not attached to lifecycle

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -260,7 +260,7 @@ abstract class CustomExoPlayerView(
 
         supportFragmentManager.setFragmentResultListener(
             PlayingQueueSheet.PLAYING_QUEUE_REQUEST_KEY,
-            findViewTreeLifecycleOwner()!!
+            findViewTreeLifecycleOwner() ?: activity
         ) { _, args ->
             (player as? MediaController)?.navigateVideo(
                 args.getString(IntentData.videoId) ?: return@setFragmentResultListener


### PR DESCRIPTION
closes #6795
clsoes #6796