### PR TITLE
fix: check if streams is initialized

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -141,11 +141,11 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     private lateinit var streams: Streams
     val isShort
         get() = run {
-            val heightGreaterThanWidth = streams.videoStreams.firstOrNull()?.let {
+            val heightGreaterThanWidth = ::streams.isInitialized && streams.videoStreams.firstOrNull()?.let {
                 (it.height ?: 0) > (it.width ?: 0)
-            }
+            } == true
 
-            PlayingQueue.getCurrent()?.isShort == true || heightGreaterThanWidth == true
+            PlayingQueue.getCurrent()?.isShort == true || heightGreaterThanWidth
         }
 
     // if null, it's been set to automatic


### PR DESCRIPTION
Fixes a crash when trying to rotate the player before it is initialized, most likely introduced in https://github.com/libre-tube/LibreTube/pull/6768/commits/76d7c622f8b2664fb614c8cc5a64f6b08ce8f6a4.