### PR TITLE
fix: crash when opening video in landscape with autofullscreen enabled

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1182,6 +1182,8 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
     }
 
     private fun setPlayerResolution(resolution: Int, isSelectedByUser: Boolean = false) {
+        if (!::playerController.isInitialized) return
+
         val transformedResolution = if (!isSelectedByUser && isShort) {
             ceil(resolution * 16.0 / 9.0).toInt()
         } else {


### PR DESCRIPTION
closes #6807