### PR TITLE
fix: maximise player when playing new video

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/NavigationHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/NavigationHelper.kt
@@ -26,6 +26,7 @@ import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.fragments.AudioPlayerFragment
 import com.github.libretube.ui.fragments.PlayerFragment
 import com.github.libretube.ui.views.SingleViewTouchableMotionLayout
+import com.github.libretube.util.PlayingQueue
 
 object NavigationHelper {
     private val handler = Handler(Looper.getMainLooper())
@@ -70,6 +71,9 @@ object NavigationHelper {
         val activity = ContextHelper.unwrapActivity<MainActivity>(context)
         val attachedToRunningPlayer = activity.runOnPlayerFragment {
             this.playNextVideo(videoUrlOrId.toID())
+            PlayingQueue.clear()
+            // maximize player
+            this.binding.playerMotionLayout.transitionToStart()
             true
         }
         if (attachedToRunningPlayer) return


### PR DESCRIPTION
Fixes a regression from 12be4c716cd88fd00f413defd96a7d63292000ed, whereupon trying to play a new video, the player would stay minimized. Additionally, the playing video would be added to the queue, causing the previously played video to be played again.
This is confusing to users, as it breaks the expectation of the player opening when trying to play a video.

Whilst, this causes the player to open, the previously video will continue to play, until the new one is loaded, which might also be unexpected. Maybe it should be paused during the loading time and the spinner be shown?