### PR TITLE
feat(PlayerFragment): smooth out predictive back progress

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -118,6 +118,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import kotlin.math.ceil
+import kotlin.math.pow
 
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -476,7 +477,8 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
             }
 
             override fun handleOnBackProgressed(backEvent: BackEventCompat) {
-                binding.playerMotionLayout.progress = backEvent.progress
+                val smoothedProgress = MAX_PROGRESS * (1 - 2f.pow(-backEvent.progress / MAX_PROGRESS * 5f))
+                binding.playerMotionLayout.progress = smoothedProgress
             }
 
             override fun handleOnBackCancelled() {
@@ -1526,5 +1528,9 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
 
     fun onKeyUp(keyCode: Int): Boolean {
         return _binding?.player?.onKeyBoardAction(keyCode) ?: false
+    }
+
+    companion object {
+        private const val MAX_PROGRESS = 0.4f
     }
 }


### PR DESCRIPTION
Sets a limit for the maximum progress of the predictive back gesture in the PlayerFragment. Before reaching the maximum progress, the amount of displayed progress is gradually smooth out, such that further progress appears less.
This makes the back gesture behave more like the one used by the bottom-sheets.
Ref: f143e0d89430b7dd10aff091a52d125694af6e22