### PR TITLE
refactor: don't use Cronet directly for downloading

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
@@ -37,7 +37,6 @@ object DownloadHelper {
     const val THUMBNAIL_DIR = "thumbnail"
     const val DOWNLOAD_CHUNK_SIZE = 8L * 1024
     const val DEFAULT_TIMEOUT = 15 * 1000
-    const val DEFAULT_RETRY = 3
     private const val VIDEO_MIMETYPE = "video/*"
 
     fun getDownloadDir(context: Context, path: String): Path {


### PR DESCRIPTION
- this allows to remove Cronet as per https://github.com/libre-tube/LibreTube/issues/6867 or make it optional, depending on the state of the discussion
- apart from this, the refactor here has been needed for a long time to make the download service more comprehensive
- using OkHttp instead of a `HttpUrlConnection` instance directly allows us to act on a higher level, the HTTP client might also fix some issues experienced by users

possibly resolves https://github.com/libre-tube/LibreTube/issues/5661