### PR TITLE
feat(Playlist): display views and upload date

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/PlaylistAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/PlaylistAdapter.kt
@@ -80,12 +80,14 @@ class PlaylistAdapter(
 
         holder.binding.apply {
             videoTitle.text = streamItem.title
-            videoInfo.text = streamItem.uploaderName
-            channelImageContainer.isGone = true
+            videoInfo.text = TextUtils.formatViewsString(root.context, streamItem.views ?: -1, streamItem.uploaded, streamItem.uploaderName)
+            videoInfo.maxLines = 2
 
-            thumbnailDuration.setFormattedDuration(streamItem.duration ?: -1, streamItem.isShort, streamItem.uploaded)
+            // piped does not load channel avatars for playlist views
+            channelContainer.isGone = true
 
             ImageHelper.loadImage(streamItem.thumbnail, thumbnail)
+            thumbnailDuration.setFormattedDuration(streamItem.duration ?: -1, streamItem.isShort, streamItem.uploaded)
 
             root.setOnClickListener {
                 NavigationHelper.navigateVideo(root.context, streamItem.url, playlistId)


### PR DESCRIPTION
As the Piped API now provides the number of views/upload date for a playlist item, we can display them in the playlist view.

Ref: https://github.com/libre-tube/LibreTube/issues/4401

~~This however leads to the channel being displayed below the views/upload date, which is suboptimal. I'm not sure what is the best way to solve that, either displaying it the info line itself (like for other related streams) or modifying to view to display it above the video info?~~
Since related streams already show channel, views and upload date in this way, I think it is best to continue doing so here. It also works when the information is missing, such as when using created playlists.



| Before                                                                                                                            	| After                                                                                                                 	|
|-----------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------	|
| ![Playlist with items only showing the uploader](https://github.com/user-attachments/assets/64373418-b7d6-4249-8010-1b200051fb49) 	| ![Playlist with items showing views](https://github.com/user-attachments/assets/cf5a7d58-a2b9-4152-b12e-43d8ddb247af) 	|