### PR TITLE
fix: crash when instances refreshed during instance selection (out of bounds)

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/WelcomeActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/WelcomeActivity.kt
@@ -18,6 +18,7 @@ import com.github.libretube.ui.adapters.InstancesAdapter
 import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.models.WelcomeModel
 import com.github.libretube.ui.preferences.BackupRestoreSettings
+import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -49,7 +50,7 @@ class WelcomeActivity : BaseActivity() {
         // ALl the binding values are optional due to two different possible layouts (normal, landscape)
         viewModel.instances.observe(this) { instances ->
             binding.instancesRecycler.layoutManager = LinearLayoutManager(this@WelcomeActivity)
-            binding.instancesRecycler.adapter = InstancesAdapter(instances, viewModel.selectedInstanceIndex.value) { index ->
+            binding.instancesRecycler.adapter = InstancesAdapter(ImmutableList.copyOf(instances), viewModel.selectedInstanceIndex.value) { index ->
                 viewModel.selectedInstanceIndex.value = index
                 binding.okay.alpha = 1f
             }

--- a/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
@@ -8,9 +8,10 @@ import com.github.libretube.R
 import com.github.libretube.api.obj.PipedInstance
 import com.github.libretube.databinding.InstanceRowBinding
 import com.github.libretube.ui.viewholders.InstancesViewHolder
+import com.google.common.collect.ImmutableList
 
 class InstancesAdapter(
-    private val instances: List<PipedInstance>,
+    private val instances: ImmutableList<PipedInstance>,
     initialSelectionApiIndex: Int?,
     private val onSelectInstance: (index: Int) -> Unit
 ) : RecyclerView.Adapter<InstancesViewHolder>() {

--- a/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
@@ -26,6 +26,7 @@ import com.github.libretube.ui.dialogs.DeleteAccountDialog
 import com.github.libretube.ui.dialogs.LoginDialog
 import com.github.libretube.ui.dialogs.LogoutDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.common.collect.ImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -184,6 +185,8 @@ class InstanceSettings : BasePreferenceFragment() {
         val layoutInflater = LayoutInflater.from(context)
         val binding = SimpleOptionsRecyclerBinding.inflate(layoutInflater)
         binding.optionsRecycler.layoutManager = LinearLayoutManager(context)
+
+        val instances = ImmutableList.copyOf(this.instances)
         binding.optionsRecycler.adapter = InstancesAdapter(instances, selectedIndex) {
             selectedInstance = instances[it].apiUrl
         }


### PR DESCRIPTION
closes  #6924