### PR TITLE
fix: wrong back order when new fragment opened from audio/video player

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -262,6 +262,13 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
         setOnBackPressed(onBackPressedCallback)
 
         viewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) { isMiniPlayerVisible ->
+            // re-add the callback on top of the back pressed dispatcher listeners stack,
+            // so that it's the first one to become called while the full player is visible
+            if (!isMiniPlayerVisible) {
+                onBackPressedCallback.remove()
+                setOnBackPressed(onBackPressedCallback)
+            }
+
             // if the player is minimized, the fragment behind the player should handle the event
             onBackPressedCallback.isEnabled = isMiniPlayerVisible != true
         }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -486,6 +486,13 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         setOnBackPressed(onBackPressedCallback)
 
         commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) { isMiniPlayerVisible ->
+            // re-add the callback on top of the back pressed dispatcher listeners stack,
+            // so that it's the first one to become called while the full player is visible
+            if (!isMiniPlayerVisible) {
+                onBackPressedCallback.remove()
+                setOnBackPressed(onBackPressedCallback)
+            }
+
             // if the player is minimized, the fragment behind the player should handle the event
             onBackPressedCallback.isEnabled = isMiniPlayerVisible != true
         }


### PR DESCRIPTION
closes  #6880