### PR TITLE
feat(LocalFeedRepository): fetch only enabled channel tabs

### DIFF
--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -6,6 +6,7 @@ import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.db.DatabaseHolder
 import com.github.libretube.db.obj.SubscriptionsFeedItem
+import com.github.libretube.enums.ContentFilter
 import com.github.libretube.extensions.parallelMap
 import com.github.libretube.helpers.NewPipeExtractorInstance
 import com.github.libretube.helpers.PreferenceHelper
@@ -19,7 +20,13 @@ import java.time.Instant
 
 class LocalFeedRepository : FeedRepository {
     private val relevantTabs =
-        arrayOf(ChannelTabs.LIVESTREAMS, ChannelTabs.VIDEOS, ChannelTabs.SHORTS)
+        listOf(
+            ContentFilter.LIVESTREAMS to ChannelTabs.LIVESTREAMS,
+            ContentFilter.VIDEOS to ChannelTabs.VIDEOS,
+            ContentFilter.SHORTS to ChannelTabs.SHORTS
+        ).mapNotNull { (filter, tab) ->
+            if (filter.isEnabled) tab else null
+        }.toTypedArray()
 
     override suspend fun getFeed(forceRefresh: Boolean): List<StreamItem> {
         val nowMillis = Instant.now().toEpochMilli()


### PR DESCRIPTION
Updates the local feed extraction to only fetch channel tabs that are enabled. This cuts down the amount of requests that are sent, but ultimately not used.

As a side note, in my [fork](https://github.com/FineFindus/LibreTube/blob/70c0ab04cdf926f09d115dc3f0389767e1afd0f0/app/src/main/java/com/github/libretube/api/StreamsExtractor.kt#L119) I've experimented with using the more general `FeedInfo` first, to check if there are even new videos available, which seems to reduce the chance to be rate-limited, so it might be worthwhile to take a look at ;)