### PR TITLE
Preserve platform navigation implementation

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -163,7 +163,6 @@ class MainActivity : BaseActivity() {
 
         binding.bottomNav.setOnItemSelectedListener {
             navigateToBottomSelectedItem(it)
-            false
         }
 
         if (binding.bottomNav.menu.children.none { it.itemId == startFragmentId }) deselectBottomBarItems()
@@ -551,21 +550,17 @@ class MainActivity : BaseActivity() {
         }
     }
 
-    private fun navigateToBottomSelectedItem(item: MenuItem) {
+    private fun navigateToBottomSelectedItem(item: MenuItem): Boolean {
         if (item.itemId == R.id.subscriptionsFragment) {
             binding.bottomNav.removeBadge(R.id.subscriptionsFragment)
-        }
-
-        // navigate to the selected fragment, if the fragment already
-        // exists in backstack then pop up to that entry
-        if (!navController.popBackStack(item.itemId, false)) {
-            navController.navigate(item.itemId)
         }
 
         // Remove focus from search view when navigating to bottom view.
         // Call only after navigate to destination, so it can be used in
         // onMenuItemActionCollapse for backstack management
         removeSearchFocus()
+
+        return item.onNavDestinationSelected(navController)
     }
 
     override fun onUserLeaveHint() {

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.onNavDestinationSelected
 import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.github.libretube.BuildConfig

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,6 +41,7 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@+id/bottomNav"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
The intention of the OnItemSelectedListener seems to be adding functionality when a menu item is clicked and not overriding how the navigation is performed. This change switches back to the platform navigation implementation, where a fragment is launched single top among other things by default.