### PR TITLE
Migrate to FragmentContainerView

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -24,7 +24,6 @@ import androidx.core.view.isNotEmpty
 import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import androidx.recyclerview.widget.RecyclerView
@@ -125,7 +124,8 @@ class MainActivity : BaseActivity() {
         // set the action bar for the activity
         setSupportActionBar(binding.toolbar)
 
-        navController = findNavController(R.id.fragment)
+        val navHostFragment = binding.fragment.getFragment<NavHostFragment>()
+        navController = navHostFragment.navController
         binding.bottomNav.setupWithNavController(navController)
 
         // save start tab fragment id and apply navbar style
@@ -152,11 +152,8 @@ class MainActivity : BaseActivity() {
             if (it.itemId != navController.currentDestination?.id) {
                 navigateToBottomSelectedItem(it)
             } else {
-                // get the host fragment containing the current fragment
-                val navHostFragment =
-                    supportFragmentManager.findFragmentById(R.id.fragment) as? NavHostFragment
                 // get the current fragment
-                val fragment = navHostFragment?.childFragmentManager?.fragments?.firstOrNull()
+                val fragment = navHostFragment.childFragmentManager.fragments.firstOrNull()
                 tryScrollToTop(fragment?.requireView())
             }
         }

--- a/app/src/main/java/com/github/libretube/ui/activities/NoInternetActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/NoInternetActivity.kt
@@ -2,8 +2,6 @@ package com.github.libretube.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.navigation.findNavController
-import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.ActivityNointernetBinding
 import com.github.libretube.helpers.NavigationHelper
@@ -15,9 +13,6 @@ class NoInternetActivity : BaseActivity() {
 
         val binding = ActivityNointernetBinding.inflate(layoutInflater)
         setContentView(binding.root)
-
-        val navController = findNavController(R.id.fragment)
-        navController.graph = navController.navInflater.inflate(R.navigation.nav_nointernet)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,7 +36,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:menu="@menu/bottom_menu" />
 
-    <fragment
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_nointernet.xml
+++ b/app/src/main/res/layout/activity_nointernet.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fragment"
+    android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <fragment
-        android:id="@+id/fragment"
-        android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:elevation="20dp"
-        android:paddingTop="10dp" />
-
-    <FrameLayout
-        android:id="@+id/container"
-        android:layout_height="match_parent"
-        android:layout_width="match_parent" />
-
-</FrameLayout>
+    android:layout_height="match_parent"
+    android:elevation="20dp"
+    android:paddingTop="10dp"
+    app:defaultNavHost="true"
+    app:navGraph="@navigation/nav_nointernet" />

--- a/app/src/main/res/layout/activity_nointernet.xml
+++ b/app/src/main/res/layout/activity_nointernet.xml
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/fragment"
-    android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:elevation="20dp"
-    android:paddingTop="10dp"
-    app:defaultNavHost="true"
-    app:navGraph="@navigation/nav_nointernet" />
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:elevation="20dp"
+        android:paddingTop="10dp"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_nointernet" />
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>


### PR DESCRIPTION
Fixes a lint warning:

FragmentContainerView replaces the <fragment> tag as the preferred way of adding fragments via XML. Unlike the <fragment> tag, FragmentContainerView uses a normal FragmentTransaction under the hood to add the initial fragment, allowing further FragmentTransaction operations on the FragmentContainerView and providing a consistent timing for lifecycle events.