### PR TITLE
Observe comment count outside of lifecycle aware block

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -116,18 +116,16 @@ class CommentsMainFragment : Fragment() {
                         commentPagingAdapter.submitData(it)
                     }
                 }
-
-                launch {
-                    viewModel.commentCountLiveData.observe(viewLifecycleOwner) { commentCount ->
-                        if (commentCount == null) return@observe
-
-                        commentsSheet?.updateFragmentInfo(
-                            false,
-                            getString(R.string.comments_count, commentCount.formatShort())
-                        )
-                    }
-                }
             }
+        }
+
+        viewModel.commentCountLiveData.observe(viewLifecycleOwner) { commentCount ->
+            if (commentCount == null) return@observe
+
+            commentsSheet?.updateFragmentInfo(
+                false,
+                getString(R.string.comments_count, commentCount.formatShort())
+            )
         }
     }
 


### PR DESCRIPTION
The repeatOnLifecycle block is meant for flows to be collected. Livedata can be observed outside this block.