### PR TITLE
Rework RecyclerViews to set adapter once

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/VideoTagsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/VideoTagsAdapter.kt
@@ -2,21 +2,29 @@ package com.github.libretube.ui.activities
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.databinding.VideoTagRowBinding
 import com.github.libretube.ui.viewholders.VideoTagsViewHolder
 
-class VideoTagsAdapter(private val tags: List<String>) :
-    RecyclerView.Adapter<VideoTagsViewHolder>() {
+class VideoTagsAdapter :
+    ListAdapter<String, VideoTagsViewHolder>(object : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+    }) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoTagsViewHolder {
         val binding = VideoTagRowBinding.inflate(LayoutInflater.from(parent.context))
         return VideoTagsViewHolder(binding)
     }
 
-    override fun getItemCount() = tags.size
-
     override fun onBindViewHolder(holder: VideoTagsViewHolder, position: Int) {
-        val tag = tags[position]
+        val tag = getItem(holder.bindingAdapterPosition)
         holder.binding.apply {
             tagText.text = tag
             root.setOnClickListener {

--- a/app/src/main/java/com/github/libretube/ui/activities/WelcomeActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/WelcomeActivity.kt
@@ -47,13 +47,16 @@ class WelcomeActivity : BaseActivity() {
         val binding = ActivityWelcomeBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        binding.instancesRecycler.layoutManager = LinearLayoutManager(this@WelcomeActivity)
+        val adapter = InstancesAdapter(viewModel.selectedInstanceIndex.value) { index ->
+            viewModel.selectedInstanceIndex.value = index
+            binding.okay.alpha = 1f
+        }
+        binding.instancesRecycler.adapter = adapter
+
         // ALl the binding values are optional due to two different possible layouts (normal, landscape)
         viewModel.instances.observe(this) { instances ->
-            binding.instancesRecycler.layoutManager = LinearLayoutManager(this@WelcomeActivity)
-            binding.instancesRecycler.adapter = InstancesAdapter(ImmutableList.copyOf(instances), viewModel.selectedInstanceIndex.value) { index ->
-                viewModel.selectedInstanceIndex.value = index
-                binding.okay.alpha = 1f
-            }
+            adapter.submitList(ImmutableList.copyOf(instances))
             binding.progress.isGone = true
         }
         viewModel.fetchInstances()

--- a/app/src/main/java/com/github/libretube/ui/adapters/AddChannelToGroupAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/AddChannelToGroupAdapter.kt
@@ -2,25 +2,35 @@ package com.github.libretube.ui.adapters
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.databinding.AddChannelToGroupRowBinding
 import com.github.libretube.db.obj.SubscriptionGroup
 import com.github.libretube.ui.viewholders.AddChannelToGroupViewHolder
 
 class AddChannelToGroupAdapter(
-    private val channelGroups: MutableList<SubscriptionGroup>,
     private val channelId: String
-) : RecyclerView.Adapter<AddChannelToGroupViewHolder>() {
+) : ListAdapter<SubscriptionGroup, AddChannelToGroupViewHolder>(object: DiffUtil.ItemCallback<SubscriptionGroup>() {
+    override fun areItemsTheSame(oldItem: SubscriptionGroup, newItem: SubscriptionGroup): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(
+        oldItem: SubscriptionGroup,
+        newItem: SubscriptionGroup
+    ): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AddChannelToGroupViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = AddChannelToGroupRowBinding.inflate(layoutInflater, parent, false)
         return AddChannelToGroupViewHolder(binding)
     }
 
-    override fun getItemCount() = channelGroups.size
-
     override fun onBindViewHolder(holder: AddChannelToGroupViewHolder, position: Int) {
-        val channelGroup = channelGroups[position]
+        val channelGroup = getItem(holder.bindingAdapterPosition)
 
         holder.binding.apply {
             groupName.text = channelGroup.name

--- a/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/InstancesAdapter.kt
@@ -3,18 +3,26 @@ package com.github.libretube.ui.adapters
 import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.R
 import com.github.libretube.api.obj.PipedInstance
 import com.github.libretube.databinding.InstanceRowBinding
 import com.github.libretube.ui.viewholders.InstancesViewHolder
-import com.google.common.collect.ImmutableList
 
 class InstancesAdapter(
-    private val instances: ImmutableList<PipedInstance>,
     initialSelectionApiIndex: Int?,
     private val onSelectInstance: (index: Int) -> Unit
-) : RecyclerView.Adapter<InstancesViewHolder>() {
+) : ListAdapter<PipedInstance, InstancesViewHolder>(object: DiffUtil.ItemCallback<PipedInstance>() {
+    override fun areItemsTheSame(oldItem: PipedInstance, newItem: PipedInstance): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: PipedInstance, newItem: PipedInstance): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
     private var selectedInstanceIndex = initialSelectionApiIndex?.takeIf { it >= 0 }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InstancesViewHolder {
@@ -23,11 +31,9 @@ class InstancesAdapter(
         return InstancesViewHolder(binding)
     }
 
-    override fun getItemCount() = instances.size
-
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: InstancesViewHolder, position: Int) {
-        val instance = instances[position]
+        val instance = getItem(holder.bindingAdapterPosition)
 
         holder.binding.apply {
             var instanceText = "${instance.name} ${instance.locations}"

--- a/app/src/main/java/com/github/libretube/ui/adapters/LegacySubscriptionAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/LegacySubscriptionAdapter.kt
@@ -3,7 +3,9 @@ package com.github.libretube.ui.adapters
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.github.libretube.api.obj.Subscription
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.LegacySubscriptionChannelBinding
 import com.github.libretube.extensions.toID
@@ -13,9 +15,17 @@ import com.github.libretube.ui.base.BaseActivity
 import com.github.libretube.ui.sheets.ChannelOptionsBottomSheet
 import com.github.libretube.ui.viewholders.LegacySubscriptionViewHolder
 
-class LegacySubscriptionAdapter(
-    private val subscriptions: List<com.github.libretube.api.obj.Subscription>
-) : RecyclerView.Adapter<LegacySubscriptionViewHolder>() {
+class LegacySubscriptionAdapter : ListAdapter<Subscription, LegacySubscriptionViewHolder>(object :
+    DiffUtil.ItemCallback<Subscription>() {
+    override fun areItemsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -27,7 +37,7 @@ class LegacySubscriptionAdapter(
     }
 
     override fun onBindViewHolder(holder: LegacySubscriptionViewHolder, position: Int) {
-        val subscription = subscriptions[position]
+        val subscription = getItem(holder.bindingAdapterPosition)
         holder.binding.apply {
             channelName.text = subscription.name
             ImageHelper.loadImage(
@@ -51,6 +61,4 @@ class LegacySubscriptionAdapter(
             }
         }
     }
-
-    override fun getItemCount() = subscriptions.size
 }

--- a/app/src/main/java/com/github/libretube/ui/adapters/PlaylistBookmarkAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/PlaylistBookmarkAdapter.kt
@@ -5,7 +5,8 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.PlaylistBookmarkRowBinding
@@ -23,9 +24,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class PlaylistBookmarkAdapter(
-    private val bookmarks: List<PlaylistBookmark>,
     private val bookmarkMode: BookmarkMode = BookmarkMode.FRAGMENT
-) : RecyclerView.Adapter<PlaylistBookmarkViewHolder>() {
+) : ListAdapter<PlaylistBookmark, PlaylistBookmarkViewHolder>(object: DiffUtil.ItemCallback<PlaylistBookmark>() {
+    override fun areItemsTheSame(oldItem: PlaylistBookmark, newItem: PlaylistBookmark): Boolean {
+        return oldItem.playlistId == newItem.playlistId
+    }
+
+    override fun areContentsTheSame(oldItem: PlaylistBookmark, newItem: PlaylistBookmark): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlaylistBookmarkViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
         return when (bookmarkMode) {
@@ -38,8 +47,6 @@ class PlaylistBookmarkAdapter(
             )
         }
     }
-
-    override fun getItemCount() = bookmarks.size
 
     private fun showPlaylistOptions(context: Context, bookmark: PlaylistBookmark) {
         val sheet = PlaylistOptionsBottomSheet()
@@ -54,7 +61,7 @@ class PlaylistBookmarkAdapter(
     }
 
     override fun onBindViewHolder(holder: PlaylistBookmarkViewHolder, position: Int) {
-        val bookmark = bookmarks[position]
+        val bookmark = getItem(holder.bindingAdapterPosition)
         holder.playlistBookmarkBinding?.apply {
             ImageHelper.loadImage(bookmark.thumbnailUrl, thumbnail)
             playlistName.text = bookmark.playlistName

--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchSuggestionsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchSuggestionsAdapter.kt
@@ -2,18 +2,24 @@ package com.github.libretube.ui.adapters
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.appcompat.widget.SearchView
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.databinding.SuggestionRowBinding
 import com.github.libretube.ui.viewholders.SuggestionsViewHolder
 
 class SearchSuggestionsAdapter(
-    private var suggestionsList: List<String>,
-    private val searchView: SearchView
-) :
-    RecyclerView.Adapter<SuggestionsViewHolder>() {
+    private val onRootClickListener: (String) -> Unit,
+    private val onArrowClickListener: (String) -> Unit,
+) : ListAdapter<String, SuggestionsViewHolder>(object: DiffUtil.ItemCallback<String>() {
+    override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
 
-    override fun getItemCount() = suggestionsList.size
+    override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SuggestionsViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
@@ -22,14 +28,14 @@ class SearchSuggestionsAdapter(
     }
 
     override fun onBindViewHolder(holder: SuggestionsViewHolder, position: Int) {
-        val suggestion = suggestionsList[position]
+        val suggestion = getItem(holder.bindingAdapterPosition)
         holder.binding.apply {
             suggestionText.text = suggestion
             root.setOnClickListener {
-                searchView.setQuery(suggestion, true)
+                onRootClickListener(suggestion)
             }
             arrow.setOnClickListener {
-                searchView.setQuery(suggestion, false)
+                onArrowClickListener(suggestion)
             }
         }
     }

--- a/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionChannelAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionChannelAdapter.kt
@@ -3,7 +3,8 @@ package com.github.libretube.ui.adapters
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.api.obj.Subscription
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.ChannelSubscriptionRowBinding
@@ -15,12 +16,20 @@ import com.github.libretube.ui.extensions.setupSubscriptionButton
 import com.github.libretube.ui.sheets.ChannelOptionsBottomSheet
 import com.github.libretube.ui.viewholders.SubscriptionChannelViewHolder
 
-class SubscriptionChannelAdapter(
-    private val subscriptions: MutableList<Subscription>
-) : RecyclerView.Adapter<SubscriptionChannelViewHolder>() {
+class SubscriptionChannelAdapter : ListAdapter<Subscription, SubscriptionChannelViewHolder>(object :
+    DiffUtil.ItemCallback<Subscription>() {
+    override fun areItemsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
     private var visibleCount = 20
 
-    override fun getItemCount() = minOf(visibleCount, subscriptions.size)
+    override fun getItemCount() = minOf(visibleCount, currentList.size)
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -33,13 +42,13 @@ class SubscriptionChannelAdapter(
 
     fun updateItems() {
         val oldSize = visibleCount
-        visibleCount += minOf(10, subscriptions.size - oldSize)
+        visibleCount += minOf(10, currentList.size - oldSize)
         if (visibleCount == oldSize) return
         notifyItemRangeInserted(oldSize, visibleCount)
     }
 
     override fun onBindViewHolder(holder: SubscriptionChannelViewHolder, position: Int) {
-        val subscription = subscriptions[position]
+        val subscription = getItem(holder.bindingAdapterPosition)
 
         holder.binding.apply {
             subscriptionChannelName.text = subscription.name

--- a/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionGroupChannelsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionGroupChannelsAdapter.kt
@@ -2,7 +2,8 @@ package com.github.libretube.ui.adapters
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.github.libretube.api.obj.Subscription
 import com.github.libretube.databinding.SubscriptionGroupChannelRowBinding
 import com.github.libretube.db.obj.SubscriptionGroup
@@ -12,10 +13,18 @@ import com.github.libretube.helpers.NavigationHelper
 import com.github.libretube.ui.viewholders.SubscriptionGroupChannelRowViewHolder
 
 class SubscriptionGroupChannelsAdapter(
-    private val channels: List<Subscription>,
     private val group: SubscriptionGroup,
     private val onGroupChanged: (SubscriptionGroup) -> Unit
-) : RecyclerView.Adapter<SubscriptionGroupChannelRowViewHolder>() {
+) : ListAdapter<Subscription, SubscriptionGroupChannelRowViewHolder>(object: DiffUtil.ItemCallback<Subscription>() {
+    override fun areItemsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: Subscription, newItem: Subscription): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
@@ -25,10 +34,8 @@ class SubscriptionGroupChannelsAdapter(
         return SubscriptionGroupChannelRowViewHolder(binding)
     }
 
-    override fun getItemCount() = channels.size
-
     override fun onBindViewHolder(holder: SubscriptionGroupChannelRowViewHolder, position: Int) {
-        val channel = channels[position]
+        val channel = getItem(holder.bindingAdapterPosition)
         holder.binding.apply {
             root.setOnClickListener {
                 NavigationHelper.navigateChannel(root.context, channel.url)

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
@@ -87,10 +87,8 @@ class ChannelContentFragment : DynamicLayoutManagerFragment(R.layout.fragment_ch
         }
         nextPage = response.nextpage
 
-        val binding = _binding ?: return@launch
-        searchChannelAdapter = SearchChannelAdapter()
-        binding.channelRecView.adapter = searchChannelAdapter
         searchChannelAdapter?.submitList(response.content)
+        val binding = _binding ?: return@launch
         binding.progressBar.isGone = true
 
         isLoading = false
@@ -122,6 +120,9 @@ class ChannelContentFragment : DynamicLayoutManagerFragment(R.layout.fragment_ch
         val tabData = arguments.parcelable<ChannelTab>(IntentData.tabData)
         channelId = arguments.getString(IntentData.channelId)
         nextPage = arguments.getString(IntentData.nextPage)
+
+        searchChannelAdapter = SearchChannelAdapter()
+        binding.channelRecView.adapter = searchChannelAdapter
 
         binding.channelRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
@@ -156,9 +156,10 @@ class ChannelContentFragment : DynamicLayoutManagerFragment() {
 
         if (tabData?.data.isNullOrEmpty()) {
             channelAdapter = VideosAdapter(
-                arguments.parcelableArrayList<StreamItem>(IntentData.videoList)!!,
                 forceMode = VideosAdapter.Companion.LayoutMode.CHANNEL_ROW
-            )
+            ).also {
+                it.submitList(arguments.parcelableArrayList<StreamItem>(IntentData.videoList)!!)
+            }
             binding.channelRecView.adapter = channelAdapter
             binding.progressBar.isGone = true
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -246,9 +246,10 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
         }.attach()
 
         channelAdapter = VideosAdapter(
-            response.relatedStreams.toMutableList(),
             forceMode = VideosAdapter.Companion.LayoutMode.CHANNEL_ROW
-        )
+        ).also {
+            it.submitList(response.relatedStreams)
+        }
         tabList.clear()
 
         val tabs = listOf(ChannelTab(VIDEOS_TAB_KEY, "")) + response.tabs

--- a/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
@@ -45,7 +45,8 @@ class LibraryFragment : DynamicLayoutManagerFragment(R.layout.fragment_library) 
 
     private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
 
-    val playlistsAdapter = PlaylistsAdapter(PlaylistsHelper.getPrivatePlaylistType())
+    private val playlistsAdapter = PlaylistsAdapter(PlaylistsHelper.getPrivatePlaylistType())
+    private val playlistBookmarkAdapter = PlaylistBookmarkAdapter()
 
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.bookmarksRecView?.layoutManager = GridLayoutManager(context, gridItems.ceilHalf())
@@ -56,6 +57,7 @@ class LibraryFragment : DynamicLayoutManagerFragment(R.layout.fragment_library) 
         _binding = FragmentLibraryBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
+        binding.bookmarksRecView.adapter = playlistBookmarkAdapter
         // listen for playlists to become deleted
         playlistsAdapter.registerAdapterDataObserver(object :
             RecyclerView.AdapterDataObserver() {
@@ -155,9 +157,7 @@ class LibraryFragment : DynamicLayoutManagerFragment(R.layout.fragment_library) 
 
             binding.bookmarksCV.isVisible = bookmarks.isNotEmpty()
             if (bookmarks.isNotEmpty()) {
-                binding.bookmarksRecView.adapter = PlaylistBookmarkAdapter().also {
-                    it.submitList(bookmarks)
-                }
+                playlistBookmarkAdapter.submitList(bookmarks)
             }
         }
     }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1136,13 +1136,14 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         if (PlayerHelper.relatedStreamsEnabled) {
             val relatedLayoutManager = binding.relatedRecView.layoutManager as LinearLayoutManager
             binding.relatedRecView.adapter = VideosAdapter(
-                streams.relatedStreams.filter { !it.title.isNullOrBlank() }.toMutableList(),
                 forceMode = if (relatedLayoutManager.orientation == LinearLayoutManager.HORIZONTAL) {
                     VideosAdapter.Companion.LayoutMode.RELATED_COLUMN
                 } else {
                     VideosAdapter.Companion.LayoutMode.TRENDING_ROW
                 }
-            )
+            ).also { adapter ->
+                adapter.submitList(streams.relatedStreams.filter { !it.title.isNullOrBlank() })
+            }
         }
 
         // update the subscribed state

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -335,6 +335,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
             playlistId,
             playlistType
         )
+        // TODO make sure the adapter is set once in onViewCreated
         binding.playlistRecView.adapter = playlistAdapter
 
         // listen for playlist items to become deleted

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchSuggestionsFragment.kt
@@ -9,9 +9,10 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.map
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.constants.IntentData
 import com.github.libretube.constants.PreferenceKeys
@@ -35,6 +36,27 @@ class SearchSuggestionsFragment : Fragment() {
     private val viewModel: SearchViewModel by activityViewModels()
     private val mainActivity get() = activity as MainActivity
 
+    private val historyAdapter = SearchHistoryAdapter(
+        onRootClickListener = { historyQuery ->
+            runCatching {
+                (activity as MainActivity?)?.searchView
+            }.getOrNull()?.setQuery(historyQuery, true)
+        },
+        onArrowClickListener = { historyQuery ->
+            runCatching {
+                (activity as MainActivity?)?.searchView
+            }.getOrNull()?.setQuery(historyQuery, false)
+        }
+    )
+    private val suggestionsAdapter = SearchSuggestionsAdapter(
+        onRootClickListener = { suggestion ->
+            (activity as MainActivity?)?.searchView?.setQuery(suggestion, true)
+        },
+        onArrowClickListener = { suggestion ->
+            (activity as MainActivity?)?.searchView?.setQuery(suggestion, false)
+        },
+    )
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.searchQuery.value = arguments?.getString(IntentData.query)
@@ -52,9 +74,15 @@ class SearchSuggestionsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.suggestionsRecycler.layoutManager = LinearLayoutManager(requireContext()).apply {
-            reverseLayout = true
-            stackFromEnd = true
+        viewModel.searchQuery
+            .map { it.isNullOrEmpty() }
+            .distinctUntilChanged()
+            .observe(viewLifecycleOwner) { isQueryEmpty ->
+                if (isQueryEmpty) {
+                    binding.suggestionsRecycler.adapter = historyAdapter
+                } else if (PreferenceHelper.getBoolean(PreferenceKeys.SEARCH_SUGGESTIONS, true)) {
+                    binding.suggestionsRecycler.adapter = suggestionsAdapter
+                }
         }
 
         // waiting for the query to change
@@ -90,30 +118,19 @@ class SearchSuggestionsFragment : Fragment() {
                 return@launch
             }
             // only load the suggestions if the input field didn't get cleared yet
-            val suggestionsAdapter = SearchSuggestionsAdapter(
-                response.reversed(),
-                (activity as MainActivity).searchView
-            )
-            if (isAdded && !viewModel.searchQuery.value.isNullOrEmpty()) {
-                binding.suggestionsRecycler.adapter = suggestionsAdapter
+            if (!viewModel.searchQuery.value.isNullOrEmpty()) {
+                suggestionsAdapter.submitList(response.reversed())
             }
         }
     }
 
     private fun showHistory() {
-        val searchView = runCatching {
-            (activity as MainActivity).searchView
-        }.getOrNull()
-
         lifecycleScope.launch {
             val historyList = withContext(Dispatchers.IO) {
                 Database.searchHistoryDao().getAll().map { it.query }
             }
-            if (historyList.isNotEmpty() && searchView != null) {
-                binding.suggestionsRecycler.adapter = SearchHistoryAdapter(
-                    historyList,
-                    searchView
-                )
+            if (historyList.isNotEmpty()) {
+                historyAdapter.submitList(historyList)
             } else {
                 binding.suggestionsRecycler.isGone = true
                 binding.historyEmpty.isVisible = true

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -66,10 +66,9 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
     private var isCurrentTabSubChannels = false
     private var isAppBarFullyExpanded = true
 
-    private var feedAdapter: VideosAdapter? = null
+    private var feedAdapter = VideosAdapter()
     private val sortedFeed: MutableList<StreamItem> = mutableListOf()
 
-    private var channelsAdapter: SubscriptionChannelAdapter? = null
     private var selectedSortOrder = PreferenceHelper.getInt(PreferenceKeys.FEED_SORT_ORDER, 0)
         set(value) {
             PreferenceHelper.putInt(PreferenceKeys.FEED_SORT_ORDER, value)
@@ -85,6 +84,9 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
 
     private var subChannelsRecyclerViewState: Parcelable? = null
     private var subFeedRecyclerViewState: Parcelable? = null
+
+    private val legacySubscriptionsAdapter = LegacySubscriptionAdapter()
+    private val channelsAdapter = SubscriptionChannelAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -103,6 +105,27 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupSortAndFilter()
+
+        binding.subFeed.adapter = feedAdapter
+
+        val legacySubscriptions = PreferenceHelper.getBoolean(
+            PreferenceKeys.LEGACY_SUBSCRIPTIONS,
+            false
+        )
+
+        if (legacySubscriptions) {
+            binding.subChannels.layoutManager = GridLayoutManager(
+                context,
+                PreferenceHelper.getString(
+                    PreferenceKeys.LEGACY_SUBSCRIPTIONS_COLUMNS,
+                    "4"
+                ).toInt()
+            )
+            binding.subChannels.adapter = legacySubscriptionsAdapter
+        } else {
+            binding.subChannels.layoutManager = LinearLayoutManager(context)
+            binding.subChannels.adapter = channelsAdapter
+        }
 
         // Check if the AppBarLayout is fully expanded
         binding.subscriptionsAppBar.addOnOffsetChangedListener { _, verticalOffset ->
@@ -155,7 +178,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
 
             if (viewModel.subscriptions.value != null && isCurrentTabSubChannels) {
                 binding.subRefresh.isRefreshing = true
-                channelsAdapter?.updateItems()
+                channelsAdapter.updateItems()
                 binding.subRefresh.isRefreshing = false
             }
         }
@@ -213,8 +236,6 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
 
     private fun loadNextFeedItems() {
         val binding = _binding ?: return
-
-        val feedAdapter = feedAdapter ?: return
 
         val hasMore = sortedFeed.size > feedAdapter.itemCount
         if (viewModel.videoFeed.value != null && !isCurrentTabSubChannels && !binding.subRefresh.isRefreshing && hasMore) {
@@ -383,11 +404,8 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
         val notLoaded = viewModel.videoFeed.value.isNullOrEmpty()
         binding.subFeed.isGone = notLoaded
         binding.emptyFeed.isVisible = notLoaded
-
-        feedAdapter = VideosAdapter(mutableListOf())
         loadNextFeedItems()
 
-        binding.subFeed.adapter = feedAdapter
         binding.toggleSubs.text = getString(R.string.subscriptions)
 
         PreferenceHelper.updateLastFeedWatchedTime()
@@ -403,18 +421,9 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
         )
 
         if (legacySubscriptions) {
-            binding.subChannels.layoutManager = GridLayoutManager(
-                context,
-                PreferenceHelper.getString(
-                    PreferenceKeys.LEGACY_SUBSCRIPTIONS_COLUMNS,
-                    "4"
-                ).toInt()
-            )
-            binding.subChannels.adapter = LegacySubscriptionAdapter(subscriptions)
+            legacySubscriptionsAdapter.submitList(subscriptions)
         } else {
-            binding.subChannels.layoutManager = LinearLayoutManager(context)
-            channelsAdapter = SubscriptionChannelAdapter(subscriptions.toMutableList())
-            binding.subChannels.adapter = channelsAdapter
+            channelsAdapter.submitList(subscriptions)
         }
 
         binding.subRefresh.isRefreshing = false
@@ -430,7 +439,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
     }
 
     fun removeItem(videoId: String) {
-        feedAdapter?.removeItemById(videoId)
+        feedAdapter.removeItemById(videoId)
         sortedFeed.removeAll { it.url?.toID() != videoId }
     }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
@@ -40,14 +40,17 @@ class TrendsFragment : DynamicLayoutManagerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val adapter = VideosAdapter()
+        binding.recview.adapter = adapter
+        binding.recview.layoutManager?.onRestoreInstanceState(viewModel.recyclerViewState)
+
         viewModel.trendingVideos.observe(viewLifecycleOwner) { videos ->
             if (videos == null) return@observe
 
-            binding.recview.adapter = VideosAdapter(videos.toMutableList())
-            binding.recview.layoutManager?.onRestoreInstanceState(viewModel.recyclerViewState)
-
             binding.homeRefresh.isRefreshing = false
             binding.progressBar.isGone = true
+
+            adapter.submitList(videos)
 
             if (videos.isEmpty()) {
                 Snackbar.make(binding.root, R.string.change_region, Snackbar.LENGTH_LONG)

--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -52,6 +52,8 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
     private var isLoading = false
     private var recyclerViewState: Parcelable? = null
 
+    private val watchHistoryAdapter = WatchHistoryAdapter()
+
     private var selectedStatusFilter = PreferenceHelper.getInt(
         PreferenceKeys.SELECTED_HISTORY_STATUS_FILTER,
         0
@@ -89,6 +91,31 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
         commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {
             _binding?.watchHistoryRecView?.updatePadding(bottom = if (it) 64f.dpToPx() else 0)
         }
+
+        binding.watchHistoryRecView.setOnDismissListener { position ->
+            watchHistoryAdapter.removeFromWatchHistory(position)
+        }
+
+        // observe changes to indicate if the history is empty
+        watchHistoryAdapter.registerAdapterDataObserver(object :
+            RecyclerView.AdapterDataObserver() {
+            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+                if (watchHistoryAdapter.itemCount == 0) {
+                    binding.historyContainer.isGone = true
+                    binding.historyEmpty.isVisible = true
+                }
+            }
+        })
+
+        binding.watchHistoryRecView.adapter = watchHistoryAdapter
+
+        // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
+        binding.watchHistoryRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                super.onScrollStateChanged(recyclerView, newState)
+                recyclerViewState = binding.watchHistoryRecView.layoutManager?.onSaveInstanceState()
+            }
+        })
 
         lifecycleScope.launch {
             val history = withContext(Dispatchers.IO) {
@@ -149,14 +176,6 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
                 }.show(childFragmentManager)
             }
 
-            // manually restore the recyclerview state due to https://github.com/material-components/material-components-android/issues/3473
-            binding.watchHistoryRecView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
-                    super.onScrollStateChanged(recyclerView, newState)
-                    recyclerViewState = binding.watchHistoryRecView.layoutManager?.onSaveInstanceState()
-                }
-            })
-
             showWatchHistory(history)
         }
 
@@ -167,7 +186,6 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
 
     private fun showWatchHistory(history: List<WatchHistoryItem>) {
         val watchHistory = history.filterByStatusAndWatchPosition()
-        val watchHistoryAdapter = WatchHistoryAdapter(watchHistory.toMutableList())
 
         binding.playAll.setOnClickListener {
             PlayingQueue.resetToDefaults()
@@ -180,25 +198,9 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
                 keepQueue = true
             )
         }
-
-        binding.watchHistoryRecView.adapter = watchHistoryAdapter
+        watchHistoryAdapter.submitList(history)
         binding.historyEmpty.isGone = true
         binding.historyContainer.isVisible = true
-
-        binding.watchHistoryRecView.setOnDismissListener { position ->
-            watchHistoryAdapter.removeFromWatchHistory(position)
-        }
-
-        // observe changes to indicate if the history is empty
-        watchHistoryAdapter.registerAdapterDataObserver(object :
-            RecyclerView.AdapterDataObserver() {
-            override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
-                if (watchHistoryAdapter.itemCount == 0) {
-                    binding.historyContainer.isGone = true
-                    binding.historyEmpty.isVisible = true
-                }
-            }
-        })
 
         // add a listener for scroll end, delay needed to prevent loading new ones the first time
         handler.postDelayed(200) {

--- a/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
@@ -187,8 +187,10 @@ class InstanceSettings : BasePreferenceFragment() {
         binding.optionsRecycler.layoutManager = LinearLayoutManager(context)
 
         val instances = ImmutableList.copyOf(this.instances)
-        binding.optionsRecycler.adapter = InstancesAdapter(instances, selectedIndex) {
+        binding.optionsRecycler.adapter = InstancesAdapter(selectedIndex) {
             selectedInstance = instances[it].apiUrl
+        }.also {
+            it.submitList(instances)
         }
 
         MaterialAlertDialogBuilder(requireContext())

--- a/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
@@ -3,7 +3,6 @@ package com.github.libretube.ui.sheets
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.DialogAddChannelToGroupBinding
@@ -16,6 +15,10 @@ import kotlinx.coroutines.withContext
 class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_to_group) {
     private lateinit var channelId: String
 
+    private val addToGroupAdapter by lazy(LazyThreadSafetyMode.NONE) {
+        AddChannelToGroupAdapter(channelId)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -26,7 +29,8 @@ class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_t
         super.onViewCreated(view, savedInstanceState)
         val binding = DialogAddChannelToGroupBinding.bind(view)
 
-        binding.groupsRV.layoutManager = LinearLayoutManager(context)
+        binding.groupsRV.adapter = addToGroupAdapter
+
         binding.cancel.setOnClickListener {
             requireDialog().dismiss()
         }
@@ -36,7 +40,7 @@ class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_t
             val subscriptionGroups = subGroupsDao.getAll().sortedBy { it.index }.toMutableList()
 
             withContext(Dispatchers.Main) {
-                binding.groupsRV.adapter = AddChannelToGroupAdapter(subscriptionGroups, channelId)
+                addToGroupAdapter.submitList(subscriptionGroups)
 
                 binding.okay.setOnClickListener {
                     requireDialog().hide()

--- a/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
@@ -32,6 +32,13 @@ class EditChannelGroupSheet : ExpandedBottomSheet() {
     private val channelGroupsModel: EditChannelGroupsModel by activityViewModels()
     private var channels = listOf<Subscription>()
 
+    private val channelsAdapter = SubscriptionGroupChannelsAdapter(
+        channelGroupsModel.groupToEdit!!
+    ) {
+        channelGroupsModel.groupToEdit = it
+        updateConfirmStatus()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -43,6 +50,7 @@ class EditChannelGroupSheet : ExpandedBottomSheet() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val binding = binding
+        binding.channelsRV.adapter = channelsAdapter
 
         binding.groupName.setText(channelGroupsModel.groupToEdit?.name)
         val oldGroupName = channelGroupsModel.groupToEdit?.name.orEmpty()
@@ -110,15 +118,12 @@ class EditChannelGroupSheet : ExpandedBottomSheet() {
 
     private fun showChannels(channels: List<Subscription>, query: String?) {
         val binding = binding
-        binding.channelsRV.adapter = SubscriptionGroupChannelsAdapter(
-            channels.filter { query == null || it.name.lowercase().contains(query.lowercase()) },
-            channelGroupsModel.groupToEdit!!
-        ) {
-            channelGroupsModel.groupToEdit = it
-            updateConfirmStatus()
-        }
         binding.subscriptionsContainer.isVisible = true
         binding.progress.isVisible = false
+
+        channelsAdapter.submitList(
+            channels.filter { query == null || it.name.lowercase().contains(query.lowercase()) }
+        )
     }
 
     private fun updateConfirmStatus() {

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -10,7 +10,6 @@ import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.libretube.R
 import com.github.libretube.api.obj.Segment
 import com.github.libretube.api.obj.Streams
@@ -33,6 +32,8 @@ class DescriptionLayout(
     private var streams: Streams? = null
     var handleLink: (link: String) -> Unit = {}
 
+    private val videoTagsAdapter = VideoTagsAdapter()
+
     init {
         binding.playerTitleLayout.setOnClickListener {
             toggleDescription()
@@ -41,6 +42,8 @@ class DescriptionLayout(
             streams?.title?.let { ClipboardHelper.save(context, text = it) }
             true
         }
+
+        binding.tagsRecycler.adapter = videoTagsAdapter
     }
 
     fun setSegments(segments: List<Segment>) {
@@ -101,9 +104,7 @@ class DescriptionLayout(
                 "${context?.getString(R.string.visibility)}: $visibility"
 
             if (streams.tags.isNotEmpty()) {
-                binding.tagsRecycler.layoutManager =
-                    LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
-                binding.tagsRecycler.adapter = VideoTagsAdapter(streams.tags)
+                videoTagsAdapter.submitList(streams.tags)
             }
             binding.tagsRecycler.isVisible = streams.tags.isNotEmpty()
 

--- a/app/src/main/res/layout/description_layout.xml
+++ b/app/src/main/res/layout/description_layout.xml
@@ -20,8 +20,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"
-            android:visibility="gone"
-            android:text="Sponsor"/>
+            android:text="Sponsor"
+            android:visibility="gone" />
 
     </LinearLayout>
 
@@ -133,7 +133,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/tags_recycler"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/dialog_add_channel_to_group.xml
+++ b/app/src/main/res/layout/dialog_add_channel_to_group.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -48,7 +49,9 @@
                 android:id="@+id/groupsRV"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1" />
+                android:layout_weight="1"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/add_channel_to_group_row" />
 
             <LinearLayout
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -35,10 +36,12 @@
                     android:id="@+id/featuredRV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingHorizontal="10dp"
                     android:clipToPadding="false"
                     android:nestedScrollingEnabled="false"
-                    android:visibility="gone" />
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="10dp"
+                    android:visibility="gone"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
                 <TextView
                     android:id="@+id/watchingTV"
@@ -49,10 +52,12 @@
                     android:id="@+id/watchingRV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingHorizontal="10dp"
                     android:clipToPadding="false"
                     android:nestedScrollingEnabled="false"
-                    android:visibility="gone" />
+                    android:orientation="horizontal"
+                    android:paddingHorizontal="10dp"
+                    android:visibility="gone"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
                 <TextView
                     android:id="@+id/trendingTV"
@@ -70,7 +75,9 @@
                         android:layout_height="wrap_content"
                         android:layout_marginHorizontal="10dp"
                         android:nestedScrollingEnabled="false"
-                        android:visibility="gone" />
+                        android:visibility="gone"
+                        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                        app:spanCount="2" />
 
                 </RelativeLayout>
 
@@ -84,7 +91,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false"
-                    android:visibility="gone" />
+                    android:orientation="horizontal"
+                    android:visibility="gone"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
                 <TextView
                     android:id="@+id/playlistsTV"
@@ -96,7 +105,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
             </LinearLayout>
 
@@ -134,8 +144,8 @@
             android:layout_height="50dp"
             android:layout_gravity="center"
             android:layout_marginTop="30dp"
-            android:textSize="12sp"
-            android:text="@string/retry"/>
+            android:text="@string/retry"
+            android:textSize="12sp" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/change_instance"
@@ -144,8 +154,8 @@
             android:layout_height="50dp"
             android:layout_gravity="center"
             android:layout_marginTop="5dp"
-            android:textSize="12sp"
-            android:text="@string/change_instance"/>
+            android:text="@string/change_instance"
+            android:textSize="12sp" />
     </LinearLayout>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_search_suggestions.xml
+++ b/app/src/main/res/layout/fragment_search_suggestions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -9,7 +10,10 @@
         android:id="@+id/suggestions_recycler"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginVertical="10dp" />
+        android:layout_marginVertical="10dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:reverseLayout="true"
+        app:stackFromEnd="true" />
 
     <LinearLayout
         android:id="@+id/history_empty"


### PR DESCRIPTION
On most pages, the recyclerview adapter is set on every refresh. By doing this, you basically loose all benefits of a recyclerview. Examples are animations and efficiency in adding items.
By refreshing the subscriptions page, the list will no longer flicker as items that are still the same will no longer be updated.

There are still one or two cases left, but the fragments they live in need some changes outside the scope of this PR before they can be fixed.