### PR TITLE
Rework view binding

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/base/DynamicLayoutManagerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/base/DynamicLayoutManagerFragment.kt
@@ -3,12 +3,13 @@ package com.github.libretube.ui.base
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.helpers.PreferenceHelper
 
-abstract class DynamicLayoutManagerFragment : Fragment() {
+abstract class DynamicLayoutManagerFragment(@LayoutRes layoutResId: Int) : Fragment(layoutResId) {
     abstract fun setLayoutManagers(gridItems: Int)
 
     private fun getGridItemsCount(orientation: Int): Int {

--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -7,9 +7,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.text.format.DateUtils
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.BackEventCompat
 import androidx.activity.OnBackPressedCallback
 import androidx.constraintlayout.motion.widget.MotionLayout
@@ -65,7 +63,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 @UnstableApi
-class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
+class AudioPlayerFragment : Fragment(R.layout.fragment_audio_player), AudioPlayerOptions {
     private var _binding: FragmentAudioPlayerBinding? = null
     val binding get() = _binding!!
 
@@ -109,17 +107,9 @@ class AudioPlayerFragment : Fragment(), AudioPlayerOptions {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentAudioPlayerBinding.inflate(inflater)
-        return binding.root
-    }
-
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentAudioPlayerBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         mainActivity?.getBottomNavColor()?.let { color ->

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelContentFragment.kt
@@ -4,14 +4,13 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.github.libretube.R
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.api.obj.ChannelTab
 import com.github.libretube.api.obj.StreamItem
@@ -29,7 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class ChannelContentFragment : DynamicLayoutManagerFragment() {
+class ChannelContentFragment : DynamicLayoutManagerFragment(R.layout.fragment_channel_content) {
     private var _binding: FragmentChannelContentBinding? = null
     private val binding get() = _binding!!
     private var channelId: String? = null
@@ -38,15 +37,6 @@ class ChannelContentFragment : DynamicLayoutManagerFragment() {
     private var recyclerViewState: Parcelable? = null
     private var nextPage: String? = null
     private var isLoading: Boolean = false
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentChannelContentBinding.inflate(inflater, container, false)
-        return _binding!!.root
-    }
 
     override fun setLayoutManagers(gridItems: Int) {
         binding.channelRecView.layoutManager = GridLayoutManager(
@@ -125,6 +115,7 @@ class ChannelContentFragment : DynamicLayoutManagerFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentChannelContentBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         val arguments = requireArguments()

--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.fragments
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -42,7 +40,7 @@ import kotlinx.coroutines.withContext
 import retrofit2.HttpException
 import java.io.IOException
 
-class ChannelFragment : DynamicLayoutManagerFragment() {
+class ChannelFragment : DynamicLayoutManagerFragment(R.layout.fragment_channel) {
     private var _binding: FragmentChannelBinding? = null
     private val binding get() = _binding!!
     private val args by navArgs<ChannelFragmentArgs>()
@@ -74,18 +72,10 @@ class ChannelFragment : DynamicLayoutManagerFragment() {
         channelId = args.channelId
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentChannelBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {}
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentChannelBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
         // Check if the AppBarLayout is fully expanded
         binding.channelAppBar.addOnOffsetChangedListener { _, verticalOffset ->

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsMainFragment.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.fragments
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -26,24 +24,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class CommentsMainFragment : Fragment() {
+class CommentsMainFragment : Fragment(R.layout.fragment_comments) {
     private var _binding: FragmentCommentsBinding? = null
     private val binding get() = _binding!!
     private val viewModel: CommentsViewModel by activityViewModels()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentCommentsBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentCommentsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
-        val binding = binding
         val layoutManager = LinearLayoutManager(requireContext())
         binding.commentsRV.layoutManager = layoutManager
         binding.commentsRV.setItemViewCacheSize(20)

--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.fragments
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -31,28 +29,18 @@ import com.github.libretube.ui.models.sources.CommentRepliesPagingSource
 import com.github.libretube.ui.sheets.CommentsSheet
 import kotlinx.coroutines.launch
 
-class CommentsRepliesFragment : Fragment() {
+class CommentsRepliesFragment : Fragment(R.layout.fragment_comments) {
     private var _binding: FragmentCommentsBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: CommentsViewModel by activityViewModels()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentCommentsBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentCommentsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
         val arguments = requireArguments()
         val videoId = arguments.getString(IntentData.videoId, "")
         val comment = arguments.parcelable<Comment>(IntentData.comment)!!
-
-        val binding = binding
 
         val commentsSheet = parentFragment as? CommentsSheet
         commentsSheet?.binding?.btnScrollToTop?.isGone = true

--- a/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
@@ -7,9 +7,7 @@ import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.os.Bundle
 import android.os.IBinder
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isGone
@@ -59,20 +57,12 @@ enum class DownloadTab {
     AUDIO
 }
 
-class DownloadsFragment : Fragment() {
+class DownloadsFragment : Fragment(R.layout.fragment_downloads) {
     private var _binding: FragmentDownloadsBinding? = null
     private val binding get() = _binding!!
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentDownloadsBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentDownloadsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         binding.downloadsPager.adapter = DownloadsFragmentAdapter(this)
@@ -112,7 +102,7 @@ class DownloadsFragmentAdapter(fragment: Fragment) : FragmentStateAdapter(fragme
     }
 }
 
-class DownloadsFragmentPage : DynamicLayoutManagerFragment() {
+class DownloadsFragmentPage : DynamicLayoutManagerFragment(R.layout.fragment_download_content) {
     private lateinit var adapter: DownloadsAdapter
     private var _binding: FragmentDownloadContentBinding? = null
     private val binding get() = _binding!!
@@ -149,20 +139,12 @@ class DownloadsFragmentPage : DynamicLayoutManagerFragment() {
         this.downloadTab = requireArguments().serializable(IntentData.currentPosition)!!
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentDownloadContentBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.downloadsRecView?.layoutManager = GridLayoutManager(context, gridItems.ceilHalf())
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentDownloadContentBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         var selectedSortType =

--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.fragments
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -35,23 +33,15 @@ import com.github.libretube.ui.models.HomeViewModel
 import com.github.libretube.ui.models.SubscriptionsViewModel
 import com.google.android.material.snackbar.Snackbar
 
-class HomeFragment : Fragment() {
+class HomeFragment : Fragment(R.layout.fragment_home) {
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!
 
     private val subscriptionsViewModel: SubscriptionsViewModel by activityViewModels()
     private val homeViewModel: HomeViewModel by activityViewModels()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentHomeBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         with(homeViewModel) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/LibraryFragment.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.fragments
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.widget.Toast
 import androidx.core.view.isGone
@@ -41,20 +39,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class LibraryFragment : DynamicLayoutManagerFragment() {
+class LibraryFragment : DynamicLayoutManagerFragment(R.layout.fragment_library) {
     private var _binding: FragmentLibraryBinding? = null
     private val binding get() = _binding!!
 
     private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentLibraryBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.bookmarksRecView?.layoutManager = GridLayoutManager(context, gridItems.ceilHalf())
@@ -62,6 +51,7 @@ class LibraryFragment : DynamicLayoutManagerFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentLibraryBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         // listen for the mini player state changing

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -17,7 +17,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
 import android.view.KeyEvent
-import android.view.LayoutInflater
 import android.view.PixelCopy
 import android.view.SurfaceView
 import android.view.View
@@ -121,7 +120,7 @@ import kotlin.math.ceil
 
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-class PlayerFragment : Fragment(), OnlinePlayerOptions {
+class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
     private var _binding: FragmentPlayerBinding? = null
     val binding get() = _binding!!
 
@@ -385,16 +384,8 @@ class PlayerFragment : Fragment(), OnlinePlayerOptions {
         noFullscreenResolution = PlayerHelper.getDefaultResolution(requireContext(), false)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentPlayerBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentPlayerBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
         SoftwareKeyboardControllerCompat(view).hide()
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -6,9 +6,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.text.format.DateUtils
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
@@ -51,7 +49,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-class PlaylistFragment : DynamicLayoutManagerFragment() {
+class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist) {
     private var _binding: FragmentPlaylistBinding? = null
     private val binding get() = _binding!!
     private val args by navArgs<PlaylistFragmentArgs>()
@@ -84,20 +82,12 @@ class PlaylistFragment : DynamicLayoutManagerFragment() {
         playlistType = args.playlistType
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentPlaylistBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.playlistRecView?.layoutManager = GridLayoutManager(context, gridItems.ceilHalf())
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentPlaylistBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         binding.playlistProgress.isVisible = true

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchResultFragment.kt
@@ -3,9 +3,7 @@ package com.github.libretube.ui.fragments
 import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -35,7 +33,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
-class SearchResultFragment : DynamicLayoutManagerFragment() {
+class SearchResultFragment : DynamicLayoutManagerFragment(R.layout.fragment_search_result) {
     private var _binding: FragmentSearchResultBinding? = null
     private val binding get() = _binding!!
     private val args by navArgs<SearchResultFragmentArgs>()
@@ -43,20 +41,12 @@ class SearchResultFragment : DynamicLayoutManagerFragment() {
 
     private var recyclerViewState: Parcelable? = null
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentSearchResultBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.searchRecycler?.layoutManager = GridLayoutManager(context, gridItems.ceilHalf())
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentSearchResultBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         // fixes a bug that the search query will stay the old one when searching for multiple

--- a/app/src/main/java/com/github/libretube/ui/fragments/SearchSuggestionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SearchSuggestionsFragment.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.fragments
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -12,6 +10,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.constants.IntentData
 import com.github.libretube.constants.PreferenceKeys
@@ -29,7 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class SearchSuggestionsFragment : Fragment() {
+class SearchSuggestionsFragment : Fragment(R.layout.fragment_search_suggestions) {
     private var _binding: FragmentSearchSuggestionsBinding? = null
     private val binding get() = _binding!!
     private val viewModel: SearchViewModel by activityViewModels()
@@ -40,16 +39,8 @@ class SearchSuggestionsFragment : Fragment() {
         viewModel.searchQuery.value = arguments?.getString(IntentData.query)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentSearchSuggestionsBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentSearchSuggestionsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         binding.suggestionsRecycler.layoutManager = LinearLayoutManager(requireContext()).apply {

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -4,9 +4,7 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.core.os.bundleOf
 import androidx.core.view.children
@@ -52,7 +50,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class SubscriptionsFragment : DynamicLayoutManagerFragment() {
+class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_subscriptions) {
     private var _binding: FragmentSubscriptionsBinding? = null
     private val binding get() = _binding!!
 
@@ -86,20 +84,12 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment() {
     private var subChannelsRecyclerViewState: Parcelable? = null
     private var subFeedRecyclerViewState: Parcelable? = null
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentSubscriptionsBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.subFeed?.layoutManager = VideosAdapter.getLayout(requireContext(), gridItems)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentSubscriptionsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         setupSortAndFilter()

--- a/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
@@ -3,9 +3,7 @@ package com.github.libretube.ui.fragments
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.RecyclerView
@@ -19,25 +17,17 @@ import com.github.libretube.ui.extensions.setupFragmentAnimation
 import com.github.libretube.ui.models.TrendsViewModel
 import com.google.android.material.snackbar.Snackbar
 
-class TrendsFragment : DynamicLayoutManagerFragment() {
+class TrendsFragment : DynamicLayoutManagerFragment(R.layout.fragment_trends) {
     private var _binding: FragmentTrendsBinding? = null
     private val binding get() = _binding!!
     private val viewModel: TrendsViewModel by activityViewModels()
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentTrendsBinding.inflate(inflater, container, false)
-        return binding.root
-    }
 
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.recview?.layoutManager = VideosAdapter.getLayout(requireContext(), gridItems)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentTrendsBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.trendingVideos.observe(viewLifecycleOwner) { videos ->

--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -5,9 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.Parcelable
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.postDelayed
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -43,7 +41,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.math.ceil
 
-class WatchHistoryFragment : DynamicLayoutManagerFragment() {
+class WatchHistoryFragment : DynamicLayoutManagerFragment(R.layout.fragment_watch_history) {
     private var _binding: FragmentWatchHistoryBinding? = null
     private val binding get() = _binding!!
 
@@ -69,21 +67,13 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment() {
             field = value
         }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FragmentWatchHistoryBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
     override fun setLayoutManagers(gridItems: Int) {
         _binding?.watchHistoryRecView?.layoutManager =
             GridLayoutManager(context, gridItems.ceilHalf())
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FragmentWatchHistoryBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         commonPlayerViewModel.isMiniPlayerVisible.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
@@ -1,11 +1,10 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.DialogAddChannelToGroupBinding
 import com.github.libretube.db.DatabaseHolder
@@ -14,7 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class AddChannelToGroupSheet : ExpandedBottomSheet() {
+class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_to_group) {
     private lateinit var channelId: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,12 +22,9 @@ class AddChannelToGroupSheet : ExpandedBottomSheet() {
         channelId = arguments?.getString(IntentData.channelId)!!
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val binding = DialogAddChannelToGroupBinding.inflate(layoutInflater)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = DialogAddChannelToGroupBinding.bind(view)
 
         binding.groupsRV.layoutManager = LinearLayoutManager(context)
         binding.cancel.setOnClickListener {
@@ -55,7 +51,5 @@ class AddChannelToGroupSheet : ExpandedBottomSheet() {
                 }
             }
         }
-
-        return binding.root
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
@@ -2,40 +2,29 @@ package com.github.libretube.ui.sheets
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import androidx.annotation.LayoutRes
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.databinding.BottomSheetBinding
 import com.github.libretube.extensions.dpToPx
 import com.github.libretube.obj.BottomSheetItem
 import com.github.libretube.ui.adapters.BottomSheetAdapter
 import kotlinx.coroutines.launch
 
-open class BaseBottomSheet : ExpandedBottomSheet() {
-    private var _binding: BottomSheetBinding? = null
-    private val binding get() = _binding!!
+open class BaseBottomSheet(@LayoutRes layoutResId: Int = R.layout.bottom_sheet) : ExpandedBottomSheet(layoutResId) {
 
     private var title: String? = null
     private var preselectedItem: String? = null
     private lateinit var items: List<BottomSheetItem>
     private lateinit var listener: (index: Int) -> Unit
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = BottomSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
+        val binding = BottomSheetBinding.bind(view)
 
         if (title != null) {
             binding.bottomSheetTitleLayout.isVisible = true
@@ -57,11 +46,6 @@ open class BaseBottomSheet : ExpandedBottomSheet() {
         }
         binding.optionsRecycler.layoutManager = LinearLayoutManager(requireContext())
         binding.optionsRecycler.adapter = BottomSheetAdapter(items, listener)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     fun setItems(items: List<BottomSheetItem>, listener: (suspend (index: Int) -> Unit)?) = apply {

--- a/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ChannelGroupsSheet.kt
@@ -2,12 +2,11 @@ package com.github.libretube.ui.sheets
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.databinding.DialogSubscriptionGroupsBinding
 import com.github.libretube.db.DatabaseHolder
 import com.github.libretube.db.obj.SubscriptionGroup
@@ -19,17 +18,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class ChannelGroupsSheet : ExpandedBottomSheet() {
+class ChannelGroupsSheet : ExpandedBottomSheet(R.layout.dialog_subscription_groups) {
     private val channelGroupsModel: EditChannelGroupsModel by activityViewModels()
 
     @SuppressLint("NotifyDataSetChanged")
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val binding = DialogSubscriptionGroupsBinding.inflate(layoutInflater)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
+        val binding = DialogSubscriptionGroupsBinding.inflate(layoutInflater)
         binding.groupsRV.layoutManager = LinearLayoutManager(context)
         val groups = channelGroupsModel.groups.value.orEmpty().toMutableList()
         val adapter = SubscriptionGroupsAdapter(groups, channelGroupsModel, parentFragmentManager)
@@ -59,7 +55,5 @@ class ChannelGroupsSheet : ExpandedBottomSheet() {
             adapter.groups.move(from, to)
             adapter.notifyItemMoved(from, to)
         }
-
-        return binding.root
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/ChaptersBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ChaptersBottomSheet.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.sheets
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
@@ -17,7 +15,7 @@ import com.github.libretube.databinding.BottomSheetBinding
 import com.github.libretube.ui.adapters.ChaptersAdapter
 import com.github.libretube.ui.models.ChaptersViewModel
 
-class ChaptersBottomSheet : ExpandablePlayerSheet() {
+class ChaptersBottomSheet : ExpandablePlayerSheet(R.layout.bottom_sheet) {
     private var _binding: BottomSheetBinding? = null
     private val binding get() = _binding!!
 
@@ -29,17 +27,9 @@ class ChaptersBottomSheet : ExpandablePlayerSheet() {
         duration = requireArguments().getLong(IntentData.duration, 0L)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = BottomSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     @SuppressLint("NotifyDataSetChanged")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = BottomSheetBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         binding.optionsRecycler.layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/CommentsSheet.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.ComponentDialog
 import androidx.activity.addCallback
 import androidx.core.view.isVisible
@@ -16,7 +14,7 @@ import com.github.libretube.databinding.CommentsSheetBinding
 import com.github.libretube.ui.fragments.CommentsMainFragment
 import com.github.libretube.ui.models.CommonPlayerViewModel
 
-class CommentsSheet : ExpandablePlayerSheet() {
+class CommentsSheet : ExpandablePlayerSheet(R.layout.comments_sheet) {
     private var _binding: CommentsSheetBinding? = null
     val binding get() = _binding!!
 
@@ -30,19 +28,9 @@ class CommentsSheet : ExpandablePlayerSheet() {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = CommentsSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = CommentsSheetBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
-
-        val binding = binding
 
         childFragmentManager.setFragmentResultListener(DISMISS_SHEET_REQUEST_KEY, viewLifecycleOwner) { _, _ ->
             dismiss()

--- a/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/EditChannelGroupSheet.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.activityViewModels
@@ -24,7 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
-class EditChannelGroupSheet : ExpandedBottomSheet() {
+class EditChannelGroupSheet : ExpandedBottomSheet(R.layout.dialog_edit_channel_group) {
     private var _binding: DialogEditChannelGroupBinding? = null
     private val binding get() = _binding!!
 
@@ -32,18 +30,8 @@ class EditChannelGroupSheet : ExpandedBottomSheet() {
     private val channelGroupsModel: EditChannelGroupsModel by activityViewModels()
     private var channels = listOf<Subscription>()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = DialogEditChannelGroupBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
-
+        _binding = DialogEditChannelGroupBinding.bind(view)
         binding.groupName.setText(channelGroupsModel.groupToEdit?.name)
         val oldGroupName = channelGroupsModel.groupToEdit?.name.orEmpty()
 
@@ -109,7 +97,6 @@ class EditChannelGroupSheet : ExpandedBottomSheet() {
     }
 
     private fun showChannels(channels: List<Subscription>, query: String?) {
-        val binding = binding
         binding.channelsRV.adapter = SubscriptionGroupChannelsAdapter(
             channels.filter { query == null || it.name.lowercase().contains(query.lowercase()) },
             channelGroupsModel.groupToEdit!!

--- a/app/src/main/java/com/github/libretube/ui/sheets/ExpandablePlayerSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ExpandablePlayerSheet.kt
@@ -2,10 +2,12 @@ package com.github.libretube.ui.sheets
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.activityViewModels
 import com.github.libretube.ui.models.CommonPlayerViewModel
 
-abstract class ExpandablePlayerSheet: UndimmedBottomSheet() {
+abstract class ExpandablePlayerSheet(@LayoutRes layoutResId: Int) :
+    UndimmedBottomSheet(layoutResId) {
     private val commonPlayerViewModel: CommonPlayerViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/github/libretube/ui/sheets/ExpandedBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/ExpandedBottomSheet.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.content.res.Configuration
 import android.os.Bundle
 import android.widget.FrameLayout
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -11,7 +12,8 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.PEEK_HEIGHT_A
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-open class ExpandedBottomSheet : BottomSheetDialogFragment() {
+open class ExpandedBottomSheet(@LayoutRes layoutResId: Int) :
+    BottomSheetDialogFragment(layoutResId) {
     private val bottomSheet: FrameLayout? get() = dialog?.findViewById(R.id.design_bottom_sheet)
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog

--- a/app/src/main/java/com/github/libretube/ui/sheets/FilterSortBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/FilterSortBottomSheet.kt
@@ -1,19 +1,18 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.RadioButton
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
+import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.FilterSortSheetBinding
 import com.github.libretube.enums.ContentFilter
 import com.github.libretube.extensions.parcelableArrayList
 import com.github.libretube.obj.SelectableOption
 
-class FilterSortBottomSheet : ExpandedBottomSheet() {
+class FilterSortBottomSheet : ExpandedBottomSheet(R.layout.filter_sort_sheet) {
     private var _binding: FilterSortSheetBinding? = null
     private val binding get() = _binding!!
 
@@ -29,16 +28,8 @@ class FilterSortBottomSheet : ExpandedBottomSheet() {
         super.onCreate(savedInstanceState)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = FilterSortSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = FilterSortSheetBinding.bind(view)
         addSortOptions()
         setInitialFiltersState()
 

--- a/app/src/main/java/com/github/libretube/ui/sheets/IconsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IconsBottomSheet.kt
@@ -1,34 +1,17 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
+import com.github.libretube.R
 import com.github.libretube.databinding.BottomSheetBinding
 import com.github.libretube.ui.adapters.IconsSheetAdapter
 
-class IconsBottomSheet : ExpandedBottomSheet() {
-    private var _binding: BottomSheetBinding? = null
-    private val binding get() = _binding!!
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = BottomSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
+class IconsBottomSheet : ExpandedBottomSheet(R.layout.bottom_sheet) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
+        val binding = BottomSheetBinding.bind(view)
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IconsSheetAdapter()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/IntentChooserSheet.kt
@@ -1,9 +1,7 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.recyclerview.widget.GridLayoutManager
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.BottomSheetBinding
@@ -11,8 +9,6 @@ import com.github.libretube.helpers.IntentHelper
 import com.github.libretube.ui.adapters.IntentChooserAdapter
 
 class IntentChooserSheet : BaseBottomSheet() {
-    private var _binding: BottomSheetBinding? = null
-    private val binding get() = _binding!!
     private lateinit var url: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,24 +17,10 @@ class IntentChooserSheet : BaseBottomSheet() {
         url = arguments?.getString(IntentData.url)!!
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = BottomSheetBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
+        val binding = BottomSheetBinding.bind(view)
         val packages = IntentHelper.getResolveInfo(requireContext(), url)
         binding.optionsRecycler.layoutManager = GridLayoutManager(context, 3)
         binding.optionsRecycler.adapter = IntentChooserAdapter(packages, url)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
@@ -1,13 +1,12 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.session.MediaController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.databinding.PlaybackBottomSheetBinding
 import com.github.libretube.enums.PlayerCommand
@@ -18,22 +17,13 @@ import com.github.libretube.ui.adapters.SliderLabelsAdapter
 
 class PlaybackOptionsSheet(
     private val player: MediaController
-) : ExpandedBottomSheet() {
+) : ExpandedBottomSheet(R.layout.playback_bottom_sheet) {
     private var _binding: PlaybackBottomSheetBinding? = null
     private val binding get() = _binding!!
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = PlaybackBottomSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
+        _binding = PlaybackBottomSheetBinding.bind(view)
 
         binding.speedShortcuts.layoutManager =
             LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlayingQueueSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlayingQueueSheet.kt
@@ -2,9 +2,7 @@ package com.github.libretube.ui.sheets
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
 import androidx.media3.common.Player
@@ -26,21 +24,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class PlayingQueueSheet : ExpandedBottomSheet() {
+class PlayingQueueSheet : ExpandedBottomSheet(R.layout.queue_bottom_sheet) {
     private var _binding: QueueBottomSheetBinding? = null
     private val binding get() = _binding!!
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = QueueBottomSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     @SuppressLint("NotifyDataSetChanged")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = QueueBottomSheetBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         binding.optionsRecycler.layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/com/github/libretube/ui/sheets/SleepTimerSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/SleepTimerSheet.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.text.format.DateUtils
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.os.postDelayed
 import androidx.core.view.isGone
@@ -15,21 +13,13 @@ import com.github.libretube.R
 import com.github.libretube.databinding.SleepTimerSheetBinding
 import com.github.libretube.ui.tools.SleepTimer
 
-class SleepTimerSheet : ExpandedBottomSheet() {
+class SleepTimerSheet : ExpandedBottomSheet(R.layout.sleep_timer_sheet) {
     private var _binding: SleepTimerSheetBinding? = null
     private val binding get() = _binding!!
     private val handler = Handler(Looper.getMainLooper())
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = SleepTimerSheetBinding.inflate(layoutInflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        _binding = SleepTimerSheetBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
         updateTimeLeftText()

--- a/app/src/main/java/com/github/libretube/ui/sheets/StatsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/StatsSheet.kt
@@ -1,28 +1,16 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import com.github.libretube.R
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.DialogStatsBinding
 import com.github.libretube.extensions.parcelable
 import com.github.libretube.helpers.ClipboardHelper
 import com.github.libretube.obj.VideoStats
 
-class StatsSheet : ExpandedBottomSheet() {
-    private var _binding: DialogStatsBinding? = null
-    private val binding get() = _binding!!
+class StatsSheet : ExpandedBottomSheet(R.layout.dialog_stats) {
     private lateinit var stats: VideoStats
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        _binding = DialogStatsBinding.inflate(layoutInflater)
-        return binding.root
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,8 +18,7 @@ class StatsSheet : ExpandedBottomSheet() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val binding = binding
-
+        val binding = DialogStatsBinding.bind(view)
         binding.videoId.setText(stats.videoId)
         binding.videoIdCopy.setEndIconOnClickListener {
             ClipboardHelper.save(requireContext(), "text", stats.videoId)
@@ -39,10 +26,5 @@ class StatsSheet : ExpandedBottomSheet() {
         binding.videoInfo.setText(stats.videoInfo)
         binding.audioInfo.setText(stats.audioInfo)
         binding.videoQuality.setText(stats.videoQuality)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/sheets/UndimmedBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/UndimmedBottomSheet.kt
@@ -8,12 +8,13 @@ import android.view.View
 import android.view.ViewTreeObserver
 import android.view.WindowManager
 import android.widget.FrameLayout
+import androidx.annotation.LayoutRes
 import androidx.core.view.updateLayoutParams
 
 /**
  * A bottom sheet that allows touches on its top/background
  */
-abstract class UndimmedBottomSheet : ExpandedBottomSheet() {
+abstract class UndimmedBottomSheet(@LayoutRes layoutResId: Int) : ExpandedBottomSheet(layoutResId) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 


### PR DESCRIPTION
This PR reworks viewbinding in fragments. 
- The layout is now set in the constructor, making the code a little more concise. 
- val binding = binding entries are now removed
- Global viewbinding references are converted to local where possible