### PR TITLE
fix(SubscriptionsFragment): skip all-caught-up check for upcoming videos

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
@@ -29,6 +29,7 @@ data class StreamItem(
     val isShort: Boolean = false
 ) : Parcelable {
     val isLive get() = (duration == null) || (duration <= 0L)
+    val isUpcoming get() = uploaded < System.currentTimeMillis()
 
     fun toLocalPlaylistItem(playlistId: String): LocalPlaylistItem {
         return LocalPlaylistItem(

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -358,7 +358,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         // add an "all caught up item"
         if (selectedSortOrder == 0) {
             val lastCheckedFeedTime = PreferenceHelper.getLastCheckedFeedTime()
-            val caughtUpIndex = feed.indexOfFirst { it.uploaded / 1000 < lastCheckedFeedTime }
+            val caughtUpIndex = feed.indexOfFirst { it.uploaded / 1000 < lastCheckedFeedTime && !it.isUpcoming }
             if (caughtUpIndex > 0) {
                 sortedFeed.add(
                     caughtUpIndex,


### PR DESCRIPTION
Skips the check if a video has been already seen (caught up on) for videos which have not been released yet, such as premieres. Doing the check could lead to the all caught up continously displayed for upcoming videos.