### PR TITLE
chore: don't include encrypted dependency info block blob in builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,13 @@ android {
         buildConfig = true
     }
 
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+
     namespace = "com.github.libretube"
 }
 


### PR DESCRIPTION
see https://github.com/libre-tube/LibreTube/issues/6455#issuecomment-2613437397