### PR TITLE
fix(StreamItem): correctly determine upcoming videos

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
@@ -29,7 +29,7 @@ data class StreamItem(
     val isShort: Boolean = false
 ) : Parcelable {
     val isLive get() = (duration == null) || (duration <= 0L)
-    val isUpcoming get() = uploaded < System.currentTimeMillis()
+    val isUpcoming get() = uploaded > System.currentTimeMillis()
 
     fun toLocalPlaylistItem(playlistId: String): LocalPlaylistItem {
         return LocalPlaylistItem(


### PR DESCRIPTION
Fixes a bug, where the check for upcoming videos was inverted, i.e. checking if the video had already been published. This caused the all-caught-up indicator to appear incorrectly.

Ref: https://github.com/libre-tube/LibreTube/pull/7008/commits/c3be28e23bdc5a13d9c1ce0beb9bd9c599f195d9