### PR TITLE
fix: downloads adapter empty

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
@@ -172,6 +172,7 @@ class DownloadsFragmentPage : DynamicLayoutManagerFragment(R.layout.fragment_dow
             return@DownloadsAdapter isDownloading.not()
         }
         binding.downloadsRecView.adapter = adapter
+        adapter.submitList(downloads)
 
         var selectedSortType =
             PreferenceHelper.getInt(PreferenceKeys.SELECTED_DOWNLOAD_SORT_TYPE, 0)


### PR DESCRIPTION
This fixes a regression from https://github.com/libre-tube/LibreTube/pull/6971