### PR TITLE
fix(MarkableTimeBar): align segments to timebar

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/MarkableTimeBar.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/MarkableTimeBar.kt
@@ -38,7 +38,7 @@ class MarkableTimeBar(
         canvas.save()
         val horizontalOffset = (parent as View).marginLeft
         length = canvas.width - horizontalOffset * 2
-        val marginY = canvas.height / 2 - progressBarHeight / 2
+        val marginY =  (canvas.height - progressBarHeight) / 2
         val themeColor = ThemeHelper.getThemeColor(context, R.attr.colorOnSecondary)
 
         segments.forEach {
@@ -49,7 +49,7 @@ class MarkableTimeBar(
                     start.toLength() + horizontalOffset,
                     marginY,
                     end.toLength() + horizontalOffset,
-                    canvas.height - marginY
+                    marginY + progressBarHeight
                 ),
                 Paint().apply {
                     color = if (PreferenceHelper.getBoolean("sb_enable_custom_colors", false)) {


### PR DESCRIPTION
The segments drawn on the timeline seem to be off by one pixel. I'm not quite sure what's causing this, as the calculation is done differently to the timeline itself.
Since the calculation depends on the device, and I haven't been able to test this on multiple devices, further testing should be done before merging.

![Misaligned segment](https://github.com/user-attachments/assets/74f52726-fb7f-4fa8-a937-841dd40651a1)