### PR TITLE
fix(player): save watch position on playback end

### DIFF
--- a/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
+++ b/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
@@ -68,9 +68,6 @@ object DatabaseHelper {
         getWatchPosition(videoId)
     }
 
-    fun isVideoWatchedBlocking(videoId: String, duration: Long) =
-        runBlocking { isVideoWatched(videoId, duration) }
-
     suspend fun isVideoWatched(videoId: String, duration: Long): Boolean =
         withContext(Dispatchers.IO) {
             val position = getWatchPosition(videoId) ?: return@withContext false

--- a/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
@@ -94,8 +94,13 @@ abstract class AbstractPlayerService : MediaLibraryService(), MediaLibrarySessio
         override fun onPlaybackStateChanged(playbackState: Int) {
             super.onPlaybackStateChanged(playbackState)
 
-            if (playbackState == Player.STATE_READY) {
-                isTransitioning = false
+            when (playbackState) {
+                Player.STATE_ENDED -> {
+                    exoPlayer?.let { PlayerHelper.saveWatchPosition(it, videoId) }
+                }
+                Player.STATE_READY -> {
+                 isTransitioning = false
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes an issue, where the watch position would not correctly be saved as the fully watched video. This could occur when the last part of a video was skipped by a SponsorBlock segment.