### PR TITLE
Refactor Comments

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/models/CommentRepliesViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentRepliesViewModel.kt
@@ -1,0 +1,50 @@
+package com.github.libretube.ui.models
+
+import android.content.Context
+import androidx.core.text.parseAsHtml
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
+import androidx.paging.liveData
+import com.github.libretube.api.obj.Comment
+import com.github.libretube.constants.IntentData
+import com.github.libretube.helpers.ClipboardHelper
+import com.github.libretube.ui.models.sources.CommentRepliesPagingSource
+
+class CommentRepliesViewModel(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val videoId = savedStateHandle.get<String>(IntentData.videoId)!!
+    private val comment = savedStateHandle.get<Comment>(IntentData.comment)!!
+
+    val commentRepliesLiveData = Pager(PagingConfig(20, enablePlaceholders = false)) {
+        CommentRepliesPagingSource(videoId, comment)
+    }
+        .liveData
+        .cachedIn(viewModelScope)
+
+    fun saveToClipboard(context: Context) {
+        ClipboardHelper.save(
+            context,
+            text = comment.commentText.orEmpty().parseAsHtml().toString(),
+            notify = true
+        )
+    }
+
+    companion object {
+        val Factory = viewModelFactory {
+            initializer {
+                CommentRepliesViewModel(
+                    savedStateHandle = createSavedStateHandle()
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
@@ -1,30 +1,33 @@
 package com.github.libretube.ui.models
 
+import android.content.Context
+import androidx.core.text.parseAsHtml
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asFlow
+import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
+import androidx.paging.liveData
+import com.github.libretube.api.obj.Comment
 import com.github.libretube.extensions.updateIfChanged
+import com.github.libretube.helpers.ClipboardHelper
 import com.github.libretube.ui.models.sources.CommentPagingSource
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flatMapLatest
 
 class CommentsViewModel : ViewModel() {
+
+    private var lastOpenedCommentRepliesId: String? = null
     val videoIdLiveData = MutableLiveData<String>()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val commentsFlow = videoIdLiveData.asFlow()
-        .flatMapLatest {
-            Pager(PagingConfig(pageSize = 20, enablePlaceholders = false)) {
-                CommentPagingSource(it) {
-                    _commentCountLiveData.updateIfChanged(it)
-                }
-            }.flow
-        }
+    val commentsLiveData = videoIdLiveData.switchMap {
+        Pager(PagingConfig(pageSize = 20, enablePlaceholders = false)) {
+            CommentPagingSource(it) {
+                _commentCountLiveData.updateIfChanged(it)
+            }
+        }.liveData
+    }
         .cachedIn(viewModelScope)
 
     private val _commentCountLiveData = MutableLiveData<Long>()
@@ -42,13 +45,28 @@ class CommentsViewModel : ViewModel() {
 
     fun setCommentsPosition(position: Int) {
         if (position != currentCommentsPosition.value) {
-            _currentCommentsPosition.postValue(position)
+            _currentCommentsPosition.value = position
         }
     }
 
     fun setRepliesPosition(position: Int) {
         if (position != currentRepliesPosition.value) {
-            _currentRepliesPosition.postValue(position)
+            _currentRepliesPosition.value = position
         }
+    }
+
+    fun setLastOpenedCommentRepliesId(id: String) {
+        if (lastOpenedCommentRepliesId != id) {
+            _currentRepliesPosition.value = 0
+            lastOpenedCommentRepliesId = id
+        }
+    }
+
+    fun saveToClipboard(context: Context, comment: Comment) {
+        ClipboardHelper.save(
+            context,
+            text = comment.commentText.orEmpty().parseAsHtml().toString(),
+            notify = true
+        )
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/viewholders/CommentViewHolder.kt
+++ b/app/src/main/java/com/github/libretube/ui/viewholders/CommentViewHolder.kt
@@ -3,6 +3,6 @@ package com.github.libretube.ui.viewholders
 import androidx.recyclerview.widget.RecyclerView
 import com.github.libretube.databinding.CommentsRowBinding
 
-class CommentsViewHolder(
+class CommentViewHolder(
     val binding: CommentsRowBinding
 ) : RecyclerView.ViewHolder(binding.root)


### PR DESCRIPTION
This PR does several things to improve the code quality:

- Perform navigation in the Fragment instead of the RV adapter
- Pager now lives in the ViewModel and is emitted as LiveData. LiveData makes more sense because of the free lifecycle benefits you get compared to using Flow (by not having to use `repeatOnLifecycle(Lifecycle.State.STARTED)`)

Other:
- Smooth scrolling now works when pressing the scroll up button