### PR TITLE
fix: multiple recyclerview adapter regressions in SubscriptionsFragment

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionChannelAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SubscriptionChannelAdapter.kt
@@ -18,9 +18,6 @@ import com.github.libretube.ui.viewholders.SubscriptionChannelViewHolder
 
 class SubscriptionChannelAdapter :
     ListAdapter<Subscription, SubscriptionChannelViewHolder>(DiffUtilItemCallback()) {
-    private var visibleCount = 20
-
-    override fun getItemCount() = minOf(visibleCount, currentList.size)
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -29,13 +26,6 @@ class SubscriptionChannelAdapter :
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = ChannelSubscriptionRowBinding.inflate(layoutInflater, parent, false)
         return SubscriptionChannelViewHolder(binding)
-    }
-
-    fun updateItems() {
-        val oldSize = visibleCount
-        visibleCount += minOf(10, currentList.size - oldSize)
-        if (visibleCount == oldSize) return
-        notifyItemRangeInserted(oldSize, visibleCount)
     }
 
     override fun onBindViewHolder(holder: SubscriptionChannelViewHolder, position: Int) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -175,7 +175,6 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
 
             if (viewModel.subscriptions.value != null && isCurrentTabSubChannels) {
                 binding.subRefresh.isRefreshing = true
-                channelsAdapter.updateItems()
                 binding.subRefresh.isRefreshing = false
             }
         }

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -237,7 +237,9 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
                     }
                 }
 
-                feedAdapter.submitList(streamItemsToInsert)
+                feedAdapter.submitList(streamItemsToInsert) {
+                    binding.subFeed.scrollToPosition(0)
+                }
                 binding.subRefresh.isRefreshing = false
             }
         }
@@ -409,9 +411,13 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         )
 
         if (legacySubscriptions) {
-            legacySubscriptionsAdapter.submitList(subscriptions)
+            legacySubscriptionsAdapter.submitList(subscriptions) {
+                binding.subFeed.scrollToPosition(0)
+            }
         } else {
-            channelsAdapter.submitList(subscriptions)
+            channelsAdapter.submitList(subscriptions) {
+                binding.subFeed.scrollToPosition(0)
+            }
         }
 
         binding.subRefresh.isRefreshing = false


### PR DESCRIPTION
Fixes https://github.com/libre-tube/LibreTube/issues/7072

Fixes a crash when selecting a different subscription group and going back to the 'all' group

Be aware that this PR removes the local pagination. I think more performance improvements can be gained by making changes to the videos adapter compared to what the local pagination can achieve.