### PR TITLE
feat(LocalFeedRepository): filter members only videos

### DIFF
--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -21,6 +21,7 @@ import org.schabi.newpipe.extractor.channel.tabs.ChannelTabInfo
 import org.schabi.newpipe.extractor.channel.tabs.ChannelTabs
 import org.schabi.newpipe.extractor.feed.FeedInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamInfoItem.ContentAvailability
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -146,6 +147,7 @@ class LocalFeedRepository : FeedRepository {
                 ChannelTabInfo.getInfo(NewPipeExtractorInstance.extractor, tab).relatedItems
             }.getOrElse { emptyList() }
         }.flatten().filterIsInstance<StreamInfoItem>()
+            .filter { it.contentAvailability == ContentAvailability.AVAILABLE || it.contentAvailability == ContentAvailability.UPCOMING }
 
         val channelAvatar = channelInfo.avatars.maxByOrNull { it.height }?.url
         return related.map { item ->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
         maven { setUrl("https://jitpack.io") }


### PR DESCRIPTION
YouTube has started to insert Members only videos into the normal video feed. As there not watchable without signing in, they only clutter the subscription feed.
This filters them out before they're displayed.

Requires https://github.com/TeamNewPipe/NewPipeExtractor/pull/1280

This is still a draft as extractor PR is not yet merged. It might also make sense to still store the videos, so they can be used when deciding if a full channel fetch is needed?