### PR TITLE
fix(SubscriptionsFragment): skip upcoming videos when adding caught-up

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -378,7 +378,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         if (selectedSortOrder == 0) {
             val lastCheckedFeedTime = PreferenceHelper.getLastCheckedFeedTime()
             val caughtUpIndex = feed.indexOfFirst { it.uploaded <= lastCheckedFeedTime && !it.isUpcoming }
-            if (caughtUpIndex > 0) {
+            if (caughtUpIndex > 0 && !feed[caughtUpIndex-1].isUpcoming) {
                 sorted.add(
                     caughtUpIndex,
                     StreamItem(type = VideosAdapter.CAUGHT_UP_STREAM_TYPE)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,7 +358,7 @@
     <string name="captions_size">Captions size</string>
     <string name="double_tap_seek">Double tap to seek</string>
     <string name="double_tap_seek_summary">Tap twice at the left or right to rewind or forward the player position</string>
-    <string name="all_caught_up">You\'re all caught up</string>
+    <string name="all_caught_up">All caught up</string>
     <string name="all_caught_up_summary">You\'ve seen all new videos</string>
     <string name="import_playlists">Import playlists</string>
     <string name="export_playlists">Export playlists</string>


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/libre-tube/LibreTube/commit/d34d34e9e6bad1e9e2f32da8bb9ea9aeebb63589, which caused the original fix (https://github.com/libre-tube/LibreTube/commit/111cd1b3507da4240cb339382b63aef622e3bfff) to no longer function correctly.

I also used to opportunity to rename the title of the caught-up item to `All caught up`, in order to avoid having both the title and the subtitle starting with `You`.