### PR TITLE
feat(Feed): update local feed data when watching video

### DIFF
--- a/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
@@ -3,6 +3,7 @@ package com.github.libretube.api
 import android.content.Context
 import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
+import com.github.libretube.db.obj.SubscriptionsFeedItem
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.repo.AccountSubscriptionsRepository
 import com.github.libretube.repo.FeedProgress
@@ -49,6 +50,7 @@ object SubscriptionHelper {
     suspend fun getSubscriptionChannelIds() = subscriptionsRepository.getSubscriptionChannelIds()
     suspend fun getFeed(forceRefresh: Boolean, onProgressUpdate: (FeedProgress) -> Unit = {}) =
         feedRepository.getFeed(forceRefresh, onProgressUpdate)
+    suspend fun submitFeedItemChange(feedItem: SubscriptionsFeedItem) = feedRepository.submitFeedItemChange(feedItem)
 
     fun handleUnsubscribe(
         context: Context,

--- a/app/src/main/java/com/github/libretube/db/dao/SubscriptionsFeedDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/SubscriptionsFeedDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.github.libretube.db.obj.SubscriptionsFeedItem
 
 @Dao
@@ -13,6 +14,9 @@ interface SubscriptionsFeedDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(feedItems: List<SubscriptionsFeedItem>)
+
+    @Update
+    suspend fun update(feedItem: SubscriptionsFeedItem)
 
     @Query("SELECT EXISTS (SELECT * FROM feedItem WHERE videoId = :videoId)")
     suspend fun contains(videoId: String): Boolean

--- a/app/src/main/java/com/github/libretube/repo/FeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/FeedRepository.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.repo
 
 import com.github.libretube.api.obj.StreamItem
+import com.github.libretube.db.obj.SubscriptionsFeedItem
 
 data class FeedProgress(
     val currentProgress: Int,
@@ -12,4 +13,5 @@ interface FeedRepository {
         forceRefresh: Boolean,
         onProgressUpdate: (FeedProgress) -> Unit
     ): List<StreamItem>
+    suspend fun submitFeedItemChange(feedItem: SubscriptionsFeedItem) {}
 }

--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -35,6 +35,10 @@ class LocalFeedRepository : FeedRepository {
             if (filter.isEnabled) tab else null
         }.toTypedArray()
 
+    override suspend fun submitFeedItemChange(feedItem: SubscriptionsFeedItem) {
+        DatabaseHolder.Database.feedDao().update(feedItem)
+    }
+
     override suspend fun getFeed(
         forceRefresh: Boolean,
         onProgressUpdate: (FeedProgress) -> Unit

--- a/app/src/main/java/com/github/libretube/services/OnlinePlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/OnlinePlayerService.kt
@@ -14,11 +14,13 @@ import com.github.libretube.R
 import com.github.libretube.api.JsonHelper
 import com.github.libretube.api.RetrofitInstance
 import com.github.libretube.api.StreamsExtractor
+import com.github.libretube.api.SubscriptionHelper
 import com.github.libretube.api.obj.Segment
 import com.github.libretube.api.obj.Streams
 import com.github.libretube.constants.IntentData
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.db.DatabaseHelper
+import com.github.libretube.db.DatabaseHolder
 import com.github.libretube.enums.PlayerCommand
 import com.github.libretube.extensions.parcelable
 import com.github.libretube.extensions.setMetadata
@@ -138,9 +140,14 @@ open class OnlinePlayerService : AbstractPlayerService() {
             PlayingQueue.insertRelatedStreams(streams!!.relatedStreams)
         }
 
-        // save the current stream to the queue
         streams?.toStreamItem(videoId)?.let {
+            // save the current stream to the queue
             PlayingQueue.updateCurrent(it)
+
+            // update feed item with newer information, e.g. more up-to-date views
+            SubscriptionHelper.submitFeedItemChange(
+                it.toFeedItem()
+            )
         }
 
         withContext(Dispatchers.Main) {


### PR DESCRIPTION
As local feed videos are only fetched once, this can lead to outdated data being displayed in the feed. As we already fetch the metadata when the video is being played, use this data to update the locally stored feed data.