### PR TITLE
fix(Feed): extract shorts uploadDate from feedInfo

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -87,25 +87,31 @@ private fun AudioStream.toPipedStream() = PipedStream(
 )
 
 fun StreamInfoItem.toStreamItem(
-    uploaderAvatarUrl: String? = null
-) = StreamItem(
-    type = TYPE_STREAM,
-    url = url.toID(),
-    title = name,
-    uploaded = uploadDate?.offsetDateTime()?.toEpochSecond()?.times(1000) ?: -1,
-    uploadedDate = textualUploadDate ?: uploadDate?.offsetDateTime()?.toLocalDateTime()
-        ?.toLocalDate()
-        ?.toString(),
-    uploaderName = uploaderName,
-    uploaderUrl = uploaderUrl.toID(),
-    uploaderAvatar = uploaderAvatarUrl ?: uploaderAvatars.maxByOrNull { it.height }?.url,
-    thumbnail = thumbnails.maxByOrNull { it.height }?.url,
-    duration = duration,
-    views = viewCount,
-    uploaderVerified = isUploaderVerified,
-    shortDescription = shortDescription,
-    isShort = isShortFormContent
-)
+    uploaderAvatarUrl: String? = null,
+    feedInfo: StreamInfoItem? = null,
+): StreamItem {
+    val uploadDate = uploadDate ?: feedInfo?.uploadDate
+    val textualUploadDate = textualUploadDate ?: feedInfo?.textualUploadDate
+
+    return StreamItem(
+        type = TYPE_STREAM,
+        url = url.toID(),
+        title = name,
+        uploaded = uploadDate?.offsetDateTime()?.toEpochSecond()?.times(1000) ?: -1,
+        uploadedDate = textualUploadDate ?: uploadDate?.offsetDateTime()?.toLocalDateTime()
+            ?.toLocalDate()
+            ?.toString(),
+        uploaderName = uploaderName,
+        uploaderUrl = uploaderUrl.toID(),
+        uploaderAvatar = uploaderAvatarUrl ?: uploaderAvatars.maxByOrNull { it.height }?.url,
+        thumbnail = thumbnails.maxByOrNull { it.height }?.url,
+        duration = duration,
+        views = viewCount,
+        uploaderVerified = isUploaderVerified,
+        shortDescription = shortDescription,
+        isShort = isShortFormContent
+    )
+}
 
 fun InfoItem.toContentItem() = when (this) {
     is StreamInfoItem -> ContentItem(


### PR DESCRIPTION
Shorts extracted from the Shorts tab do not have an uploadDate. They are currently saved with their uploadDate set to -1, leading in them to appear at the end of the feed. To fix this, we can use the generic FeedInfo that contains the uploadDate, which also fixes an issue, where old shorts were fetched on every refresh.

Ref: https://github.com/libre-tube/LibreTube/pull/7111