### PR TITLE
feat: Implement splash screen for older Android versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.navigation.fragment)

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.allViews
 import androidx.core.view.children
 import androidx.core.view.isNotEmpty
@@ -95,6 +96,7 @@ class MainActivity : BaseActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         // enable auto rotation if turned on

--- a/app/src/main/res/drawable/splash_anim.xml
+++ b/app/src/main/res/drawable/splash_anim.xml
@@ -1,27 +1,6 @@
 <animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aapt="http://schemas.android.com/aapt">
-    <aapt:attr name="android:drawable">
-        <vector
-            android:width="64dp"
-            android:height="64dp"
-            android:tint="?attr/colorSecondary"
-            android:viewportWidth="1280"
-            android:viewportHeight="1280">
-            <group
-                android:name="scaleGroup"
-                android:pivotX="640"
-                android:pivotY="640">
-                <path
-                    android:fillColor="#000"
-                    android:pathData="M1130.145 639.54c0-6.202-3.236-11.865-8.358-14.831L225.77 93.247c-15.64-9.168-35.324 2.157-35.324 20.493v229.194c0 8.629 4.584 16.449 11.864 20.762l446.525 255.619c15.91 9.169 15.91 32.358 0 41.525L202.31 916.46c-7.28 4.315-11.864 12.135-11.864 20.763v228.925c0 18.336 19.684 29.93 35.324 20.493l895.747-532.271c5.122-3.236 8.359-8.898 8.359-14.83h0.269Z"
-                    android:strokeWidth="30"
-                    android:strokeColor="#000" />
-                <path
-                    android:fillColor="#000"
-                    android:pathData="M373.802 625.518c11.325 6.471 11.325 22.92 0 29.391L174.807 769.507c-11.055 6.47-24.807-1.619-24.807-14.561V525.482c0-12.944 13.752-21.033 24.807-14.562l198.995 114.598Z" />
-            </group>
-        </vector>
-    </aapt:attr>
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:drawable="@drawable/splash_icon">
 
     <target android:name="scaleGroup">
         <aapt:attr name="android:animation">

--- a/app/src/main/res/drawable/splash_icon.xml
+++ b/app/src/main/res/drawable/splash_icon.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:tint="@color/splash_screen_icon_color"
+    android:viewportWidth="1280"
+    android:viewportHeight="1280">
+
+    <group
+        android:name="scaleGroup"
+        android:scaleX="0.55"
+        android:scaleY="0.55"
+        android:pivotX="640"
+        android:pivotY="640">
+        <path
+            android:fillColor="#000"
+            android:pathData="M1130.145 639.54c0-6.202-3.236-11.865-8.358-14.831L225.77 93.247c-15.64-9.168-35.324 2.157-35.324 20.493v229.194c0 8.629 4.584 16.449 11.864 20.762l446.525 255.619c15.91 9.169 15.91 32.358 0 41.525L202.31 916.46c-7.28 4.315-11.864 12.135-11.864 20.763v228.925c0 18.336 19.684 29.93 35.324 20.493l895.747-532.271c5.122-3.236 8.359-8.898 8.359-14.83h0.269Z"
+            android:strokeWidth="30"
+            android:strokeColor="#000" />
+        <path
+            android:fillColor="#000"
+            android:pathData="M373.802 625.518c11.325 6.471 11.325 22.92 0 29.391L174.807 769.507c-11.055 6.47-24.807-1.619-24.807-14.561V525.482c0-12.944 13.752-21.033 24.807-14.562l198.995 114.598Z" />
+    </group>
+
+</vector>

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="StartupTheme" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_anim</item>
+        <item name="postSplashScreenTheme">@style/BaseTheme</item>
+    </style>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splash_screen_icon_color">#ccc</color>
+</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -2,8 +2,8 @@
 
     <style name="BaseTheme" parent="Theme.Material3.Dark.NoActionBar">
 
-        <item name="android:statusBarColor" tools:targetApi="m">@android:color/transparent</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">false</item>
 
@@ -13,16 +13,12 @@
 
         <item name="snackbarStyle">@style/snackBarStyle</item>
 
-        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">
-            @drawable/splash_anim
-        </item>
-
     </style>
 
-    <style name="StartupTheme" parent="BaseTheme">
+    <style name="StartupTheme" parent="Theme.SplashScreen">
 
-        <item name="android:colorBackground">@android:color/black</item>
-        <item name="colorSurface">@android:color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
+        <item name="postSplashScreenTheme">@style/BaseTheme</item>
 
     </style>
 

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="StartupTheme" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_anim</item>
+        <item name="postSplashScreenTheme">@style/BaseTheme</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="duration_background_color">#AA000000</color>
     <color name="duration_text_color">#EEFFFFFF</color>
     <color name="shortcut_color">#0061A6</color>
+    <color name="splash_screen_icon_color">#222</color>
 
     <color name="blue_md_theme_light_primary">#0058CB</color>
     <color name="blue_md_theme_light_onPrimary">#FFFFFF</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,8 +2,8 @@
 
     <style name="BaseTheme" parent="Theme.Material3.Light.NoActionBar">
 
-        <item name="android:statusBarColor" tools:targetApi="m">@android:color/transparent</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar" tools:ignore="NewApi">true</item>
 
@@ -13,16 +13,12 @@
 
         <item name="snackbarStyle">@style/snackBarStyle</item>
 
-        <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">
-            @drawable/splash_anim
-        </item>
-
     </style>
 
-    <style name="StartupTheme" parent="BaseTheme">
+    <style name="StartupTheme" parent="Theme.SplashScreen">
 
-        <item name="android:colorBackground">@android:color/white</item>
-        <item name="colorSurface">@android:color/white</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
+        <item name="postSplashScreenTheme">@style/BaseTheme</item>
 
     </style>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,11 +32,13 @@ profileinstaller = "1.4.1"
 paging = "3.3.6"
 collection = "1.5.0"
 swiperefreshlayout = "1.1.0"
+splashscreen = "1.0.1"
 
 [libraries]
 androidx-activity = { group = "androidx.activity", name = "activity-ktx", version.ref = "activity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-core = { group = "androidx.core", name = "core", version.ref = "core" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }


### PR DESCRIPTION
Implement a splash screen similar to the one on Android 12+ for older versions of Android using the Core Splashscreen library.

[This guide](https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen) has more information on its features and limitations.

* Before (Android 8.1)

https://github.com/user-attachments/assets/0c88c965-99de-4e5b-a094-4f56c26abbf5

* After (Android 8.1)

https://github.com/user-attachments/assets/8efb1e38-7a79-4f53-918c-58c2c181783e
