### PR TITLE
feat: increase corner-radius of watch-progressbar

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/extensions/SetWatchProgressLength.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetWatchProgressLength.kt
@@ -1,7 +1,9 @@
 package com.github.libretube.ui.extensions
 
 import android.graphics.Color
+import android.graphics.Outline
 import android.view.View
+import android.view.ViewOutlineProvider
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.graphics.ColorUtils
 import androidx.core.view.isGone
@@ -35,6 +37,15 @@ fun View.setWatchProgressLength(videoId: String, duration: Long) {
         backgroundColor = ColorUtils.blendARGB(backgroundColor, Color.WHITE, 0.4f)
     }
     setBackgroundColor(backgroundColor)
+
+    // set corner-radius
+    clipToOutline = true
+    outlineProvider = object : ViewOutlineProvider() {
+        override fun getOutline(view: View, outline: Outline) {
+            outline.setRoundRect(0, 0, view.width, view.height, 16f)
+        }
+    }
+
 
     isVisible = true
 }


### PR DESCRIPTION
Adds a rounded corner to the watch-progressbar, making it more inline with the general design of the app, as well as how other progressbars are styled.

| Before                                                                                                               	| After                                                                                                                 	|
|----------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------	|
| ![Watchprogress with straight edge](https://github.com/user-attachments/assets/0987e90e-5881-45cf-a632-6934fc4ed475) 	| ![Watchprogress with rounded corner](https://github.com/user-attachments/assets/5a74fef3-eb4c-4cdf-9ccc-d6d3c55bed11) 	|