### PR TITLE
fix: bound time remaining to mark a video as watched

### DIFF
--- a/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
+++ b/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
@@ -15,6 +15,12 @@ import kotlinx.coroutines.withContext
 object DatabaseHelper {
     private const val MAX_SEARCH_HISTORY_SIZE = 20
 
+    // can only mark as watched if less than 60s remaining
+    private const val ABSOLUTE_WATCHED_THRESHOLD = 60.0f
+
+    // can only mark as watched if at least 75% watched
+    private const val RELATIVE_WATCHED_THRESHOLD = 0.75f
+
     suspend fun addToWatchHistory(watchHistoryItem: WatchHistoryItem) =
         withContext(Dispatchers.IO) {
             Database.watchHistoryDao().insert(watchHistoryItem)
@@ -79,8 +85,8 @@ object DatabaseHelper {
         if (durationSeconds == null) return false
 
         val progress = positionMillis / 1000
-        // show video only in feed when watched less than 90%
-        return progress > 0.9f * durationSeconds
+
+        return durationSeconds - progress <= ABSOLUTE_WATCHED_THRESHOLD && progress >= RELATIVE_WATCHED_THRESHOLD * durationSeconds
     }
 
     suspend fun filterUnwatched(streams: List<StreamItem>): List<StreamItem> {


### PR DESCRIPTION
Right now, videos are always marked as watched if they have less than 90% of the time remaining, which is undesirable for long videos. As an example, for a 5h video, it will mark a video as watched if you've got less than 30min remaining, and for a 10h video, it will allow a full hour remaining. It makes sense to impose a minimum time threshold to mark something as being watched, so that you don't end up with that situation for longer videos.

Note that this not only removes the videos from the "continue watching" area in this case, but it also restarts the video when you try to rewatch it, making it more difficult to find your place in the video.

I only chose to mimic what NewPipe does for the numbers since I wanted to use something that has already been established by another app, but I'm not particularly attached to these numbers and can tweak them as desired. They're intentionally left as named constants so it's easier to find.

Relevant code from NewPipe where these numbers were taken from: https://github.com/TeamNewPipe/NewPipe/blob/ea20ca9e72a22850e3709a14fdd64a51662f07fc/app/src/main/java/org/schabi/newpipe/database/stream/model/StreamStateEntity.java#L82-L96