### PR TITLE
fix(Player): hide sponsorblock skip button on video end

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -273,6 +273,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
 
             // check if video has ended, next video is available and autoplay is enabled/the video is part of a played playlist.
             if (playbackState == Player.STATE_ENDED) {
+                binding.sbSkipBtn.isGone = true
                 if (PlayerHelper.isAutoPlayEnabled(playlistId != null) && autoPlayCountdownEnabled) {
                     showAutoPlayCountdown()
                 } else {


### PR DESCRIPTION
Fixes an issue, where the sponsorblock skip button would remain visible after the video ended.