### PR TITLE
fix: missing playlist name in search results using local extraction

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -143,6 +143,7 @@ fun InfoItem.toContentItem() = when (this) {
         url = url.toID(),
         type = TYPE_PLAYLIST,
         title = name,
+        name = name,
         shortDescription = description.content,
         thumbnail = thumbnails.maxByOrNull { it.height }?.url.orEmpty(),
         videos = streamCount,


### PR DESCRIPTION
closes #7197