### PR TITLE
chore: update language name in settings for korean

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -59,7 +59,7 @@
         <item>Bahasa Indonesia</item>
         <item>Italiano</item>
         <item>日本語</item>
-        <item>조선말</item>
+        <item>한국어</item>
         <item>latviešu</item>
         <item>മലയാളം</item>
         <item>मराठी</item>


### PR DESCRIPTION
Fix awkward expression for language array (Korean)