### PR TITLE
fix(Local): encode nextpage data as base64

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -1,5 +1,6 @@
 package com.github.libretube.api
 
+import android.util.Base64
 import com.github.libretube.api.obj.Channel
 import com.github.libretube.api.obj.ChannelTab
 import com.github.libretube.api.obj.ChannelTabResponse
@@ -210,11 +211,11 @@ private data class NextPage(
 )
 
 fun Page.toNextPageString() = JsonHelper.json.encodeToString(
-    NextPage(url, id, ids, cookies, body?.toString())
+    NextPage(url, id, ids, cookies, body?.let { Base64.encodeToString(it, Base64.DEFAULT) })
 )
 
 fun String.toPage(): Page = with(JsonHelper.json.decodeFromString<NextPage>(this)) {
-    return Page(url, id, ids, cookies, body?.toByteArray())
+    return Page(url, id, ids, cookies, body?.let { Base64.decode(it, Base64.DEFAULT) })
 }
 
 @Serializable


### PR DESCRIPTION
Fixes an issue, with local mode enabled, users where unable to continously load channel data.
This was caused by the channel nextpage data being stored as a JVM identifier (the default byte array .toString behaviour), rather than the expected base64 encoded string.

Closes: https://github.com/libre-tube/LibreTube/issues/7240