### PR TITLE
fix(Local): set channelOwner for Comments

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -195,7 +195,8 @@ fun CommentsInfoItem.toComment() = Comment(
     verified = isUploaderVerified,
     replyCount = replyCount.toLong(),
     repliesPage = replies?.toNextPageString(),
-    thumbnail = thumbnails.maxByOrNull { it.height }?.url.orEmpty()
+    thumbnail = thumbnails.maxByOrNull { it.height }?.url.orEmpty(),
+    channelOwner = isChannelOwner
 )
 
 // the following classes are necessary because kotlinx can't deserialize


### PR DESCRIPTION
Fixes a parity issue, between Piped and the local mode, where the local mode would now mark the channelOwner's comments, due the `channelOwner` not being set.