### PR TITLE
fix: thumbnails of videos containing '#' can't be downloaded

### DIFF
--- a/app/src/main/java/com/github/libretube/services/DownloadService.kt
+++ b/app/src/main/java/com/github/libretube/services/DownloadService.kt
@@ -172,7 +172,7 @@ class DownloadService : LifecycleService() {
         try {
             ImageHelper.downloadImage(
                 this@DownloadService,
-                streams.thumbnailUrl,
+                ProxyHelper.rewriteUrlUsingProxyPreference(streams.thumbnailUrl),
                 thumbnailTargetPath
             )
         } catch (e: Exception) {

--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -29,7 +29,7 @@ object TextUtils {
     /**
      * Reserved characters by unix which can not be used for file name.
      */
-    const val RESERVED_CHARS = "?:\"*|/\\<>\u0000"
+    const val RESERVED_CHARS = "#?:\"*|/\\<>\u0000"
 
     /**
      * Date time formatter which uses the [FormatStyle.MEDIUM] format style.


### PR DESCRIPTION
closes #7230
