### PR TITLE
build: use NewPipeExtractor fork

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -118,8 +118,13 @@
 ## Rules for NewPipeExtractor
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
 -keep class org.mozilla.javascript.** { *; }
--keep class org.mozilla.classfile.ClassFileWriter
+-keep class org.mozilla.javascript.engine.** { *; }
+-dontwarn org.mozilla.javascript.JavaToJSONConverters
 -dontwarn org.mozilla.javascript.tools.**
+-keep class javax.script.** { *; }
+-dontwarn javax.script.**
+-keep class jdk.dynalink.** { *; }
+-dontwarn jdk.dynalink.**
 
 # This is generated automatically by the Android Gradle plugin.
 -dontwarn java.beans.BeanDescriptor

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ constraintlayout = "2.2.1"
 loggingInterceptor = "4.12.0"
 material = "1.12.0"
 navigation = "2.8.9"
-newpipeextractor = "v0.24.5"
+newpipeextractor = "bc9a5a220e"
 preference = "1.2.1"
 extJunit = "1.2.1"
 espresso = "3.6.1"
@@ -60,7 +60,7 @@ androidx-media3-exoplayer-hls = { group = "androidx.media3", name="media3-exopla
 androidx-media3-exoplayer-dash = { group = "androidx.media3", name="media3-exoplayer-dash", version.ref="media3" }
 androidx-media3-session = { group="androidx.media3", name="media3-session", version.ref="media3" }
 androidx-media3-ui = { group="androidx.media3", name="media3-ui", version.ref="media3" }
-newpipeextractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version.ref = "newpipeextractor" }
+newpipeextractor = { module = "com.github.libre-tube:NewPipeExtractor", version.ref = "newpipeextractor" }
 square-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 desugaring = { group = "com.android.tools", name = "desugar_jdk_libs_nio", version.ref = "desugaring" }


### PR DESCRIPTION
Switches from the official NewPipeExtractor versions to a [soft fork](https://github.com/libre-tube/NewPipeExtractor), allowing fixes and other improvements that have not yet been merged upstream.
For now, it just contains a fix for working with newer YT player versions and checks if a video is available.

Ref: https://github.com/TeamNewPipe/NewPipeExtractor/pull/1290
Ref: https://github.com/libre-tube/LibreTube/pull/7113