### PR TITLE
feat: display sponsorblock video icon on thumbnail for fully sponsored videos

### DIFF
--- a/app/src/main/java/com/github/libretube/api/ExternalApi.kt
+++ b/app/src/main/java/com/github/libretube/api/ExternalApi.kt
@@ -64,6 +64,11 @@ interface ExternalApi {
         @Query("actionType") actionType: List<String>? = null
     ): List<SegmentData>
 
+    @GET("$SB_API_URL/api/videoLabels/{videoId}")
+    suspend fun getVideoLabels(
+        @Path("videoId") videoId: String,
+    ): List<SegmentData>
+
     @POST("$SB_API_URL/api/branding")
     suspend fun submitDeArrow(@Body body: DeArrowBody)
 

--- a/app/src/main/java/com/github/libretube/api/MediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/MediaServiceRepository.kt
@@ -9,6 +9,7 @@ import com.github.libretube.api.obj.SearchResult
 import com.github.libretube.api.obj.SegmentData
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.api.obj.Streams
+import com.github.libretube.extensions.sha256Sum
 import com.github.libretube.helpers.PlayerHelper
 
 interface MediaServiceRepository {
@@ -20,6 +21,13 @@ interface MediaServiceRepository {
         category: List<String>,
         actionType: List<String>? = null
     ): SegmentData
+
+    suspend fun getVideoLabels(videoId: String
+    ): SegmentData? = RetrofitInstance.externalApi.getVideoLabels(
+        // use hashed video id for privacy
+        // https://wiki.sponsor.ajay.app/w/API_Docs/Draft#GET_/api/videoLabels/:sha256HashPrefix
+        videoId.sha256Sum().substring(0, 4),
+    ).firstOrNull { it.videoID == videoId }
 
     suspend fun getDeArrowContent(videoIds: String): Map<String, DeArrowContent>
     suspend fun getCommentsNextPage(videoId: String, nextPage: String): CommentsPage

--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -16,7 +16,7 @@ data class Segment(
     val category: String? = null,
     val description: String? = null,
     val locked: Int? = null,
-    private val segment: List<Float> = listOf(),
+    private val segment: List<Float> = listOf(0f, 0f),
     val userID: String? = null,
     val videoDuration: Double? = null,
     val votes: Int? = null,

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
@@ -4,8 +4,10 @@ import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.ListAdapter
+import com.github.libretube.api.MediaServiceRepository
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.IntentData
 import com.github.libretube.databinding.AllCaughtUpRowBinding
@@ -21,6 +23,10 @@ import com.github.libretube.ui.extensions.setWatchProgressLength
 import com.github.libretube.ui.sheets.VideoOptionsBottomSheet
 import com.github.libretube.ui.viewholders.VideoCardsViewHolder
 import com.github.libretube.util.TextUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
     ListAdapter<StreamItem, VideoCardsViewHolder>(DiffUtilItemCallback()) {
@@ -106,6 +112,14 @@ class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
                 sheet.arguments = bundleOf(IntentData.streamItem to video)
                 sheet.show(fragmentManager, VideoCardsAdapter::class.java.name)
                 true
+            }
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val sponsor = runCatching { MediaServiceRepository.instance.getVideoLabels(videoId) }.getOrNull()
+
+                withContext(Dispatchers.Main) {
+                    sponsorBadge.isVisible = sponsor?.segments?.isNotEmpty() == true
+                }
             }
         }
     }

--- a/app/src/main/res/layout/trending_row.xml
+++ b/app/src/main/res/layout/trending_row.xml
@@ -33,6 +33,32 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
+                android:layout_margin="5dp"
+                app:cardBackgroundColor="@color/duration_background_color"
+                app:cardCornerRadius="8dp"
+                app:cardElevation="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/sponsor_badge"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingHorizontal="6dp"
+                    android:paddingVertical="2dp"
+                    android:src="@drawable/ic_block"
+                    android:visibility="gone"
+                    android:layout_gravity="center"
+                    app:tint="@color/duration_text_color"
+                    tools:ignore="RtlSymmetry"
+                    tools:visibility="visible" />
+
+            </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
                 android:layout_marginEnd="5dp"
                 android:layout_marginBottom="5dp"
                 app:cardBackgroundColor="@color/duration_background_color"


### PR DESCRIPTION
Displays an icon on the thumbnail for fully sponsored videos. This allows users to easily identify and avoid these videos, if they prefer so. This works similarly to how the SponsorBlock extension works for the website.

![SponsorBlock icon on thumbnail](https://github.com/user-attachments/assets/b052a54b-0d69-41ab-9e84-58cc4e841396)

This is still marked as a draft as:
- it always uses the official SponsorBlock server, as Piped does not support the required API (not sure if it is worth fixing, with the current state of the Piped backend?)
- it increases the number of requests made, we should probably cache or store them directly in the DB (though that might lead to outdated data)
- it's only shown for VideoCards (not sure if it even makes sense for the 'normal' video adapter)
- the icon position and size feels suboptimal, due to the difference to the duration
- not sure if that is something that we even want to implement :)