### PR TITLE
fix(Feed): only update `LastFeedWatchedTime` when update time is newer

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -104,8 +104,12 @@ object PreferenceHelper {
         return getString(PreferenceKeys.LAST_STREAM_VIDEO_ID, "")
     }
 
-    fun setLastFeedWatchedTime(time: Long) {
-        putLong(PreferenceKeys.LAST_WATCHED_FEED_TIME, time)
+    fun updateLastFeedWatchedTime(time: Long) {
+        // only update the time if the time is newer
+        // this avoids cases, where the user last saw an older video, which had already been seen,
+        // causing all following video to be incorrectly marked as unseen again
+        if (getLastCheckedFeedTime() < time)
+            putLong(PreferenceKeys.LAST_WATCHED_FEED_TIME, time)
     }
 
     fun getLastCheckedFeedTime(): Long {

--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -398,7 +398,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         binding.toggleSubs.text = getString(R.string.subscriptions)
 
         feed.firstOrNull { !it.isUpcoming }?.uploaded?.let {
-            PreferenceHelper.setLastFeedWatchedTime(it)
+            PreferenceHelper.updateLastFeedWatchedTime(it)
         }
 
         binding.subRefresh.isRefreshing = false


### PR DESCRIPTION
Fixes an issue, where if the user switches between channel group, already seen videos could be marked as new. This was caused by the channel group having only older videos, which resetted the last watched time to an older timepoint.
To fix this, the last watched time is only updated, when the new watched time is newer than the previous watched time.