### PR TITLE
fix: always use account subscriptions repository if logged in to Piped

### DIFF
--- a/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
@@ -28,8 +28,8 @@ object SubscriptionHelper {
     private val token get() = PreferenceHelper.getToken()
     private val subscriptionsRepository: SubscriptionsRepository
         get() = when {
-            localFeedExtraction -> LocalSubscriptionsRepository()
             token.isNotEmpty() -> AccountSubscriptionsRepository()
+            localFeedExtraction -> LocalSubscriptionsRepository()
             else -> PipedLocalSubscriptionsRepository()
         }
     private val feedRepository: FeedRepository


### PR DESCRIPTION
closes #7342
