### PR TITLE
fix: channel avatar missing in subscriptions list when subbed from search

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchResultsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchResultsAdapter.kt
@@ -162,7 +162,7 @@ class SearchResultsAdapter(
             binding.searchSubButton.setupSubscriptionButton(
                 item.url.toID(),
                 item.name.orEmpty(),
-                item.uploaderAvatar,
+                item.thumbnail,
                 item.uploaderVerified ?: false
             ) {
                 subscribed = it


### PR DESCRIPTION
closes #7359