### PR TITLE
fix(player): clear current stream when closing player

### DIFF
--- a/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
@@ -409,6 +409,8 @@ abstract class AbstractPlayerService : MediaLibraryService(), MediaLibrarySessio
                 mediaLibrarySession = null
             }
 
+            PlayingQueue.clear()
+
             ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
             stopSelf()
 

--- a/app/src/main/java/com/github/libretube/util/PlayingQueue.kt
+++ b/app/src/main/java/com/github/libretube/util/PlayingQueue.kt
@@ -37,6 +37,7 @@ object PlayingQueue {
         }
         queueJobs.clear()
         queue.clear()
+        currentStream = null
     }
 
     /**


### PR DESCRIPTION
Fixes an issue, where the `currentStream` was not cleared when closing the player. This could lead to an issue, where not all video options where displayed, even if the video was no longer playing.

Ref: https://github.com/libre-tube/LibreTube/commit/f262210ef74f268445f8831bd51f54ac0cb1c019