### PR TITLE
feat(Preferences/SponsorBlock): drop `VISIBLE` option 

### DIFF
--- a/app/src/main/java/com/github/libretube/LibreTubeApp.kt
+++ b/app/src/main/java/com/github/libretube/LibreTubeApp.kt
@@ -26,6 +26,7 @@ class LibreTubeApp : Application() {
          * Initialize the [PreferenceHelper]
          */
         PreferenceHelper.initialize(applicationContext)
+        PreferenceHelper.migrate()
 
         /**
          * Set the api and the auth api url

--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -145,6 +145,7 @@ object PreferenceKeys {
     const val SELECTED_CHANNEL_GROUP = "selected_channel_group"
     const val SELECTED_DOWNLOAD_SORT_TYPE = "selected_download_sort_type"
     const val LAST_SHOWN_INFO_MESSAGE_VERSION_CODE = "last_shown_info_message_version"
+    const val PREFERENCE_VERSION = "PREFERENCE_VERSION"
 
     // use the helper methods at PreferenceHelper to access these
     const val LAST_USER_SEEN_FEED_TIME = "last_watched_feed_time"

--- a/app/src/main/java/com/github/libretube/enums/SbSkipOptions.kt
+++ b/app/src/main/java/com/github/libretube/enums/SbSkipOptions.kt
@@ -2,7 +2,6 @@ package com.github.libretube.enums
 
 enum class SbSkipOptions {
     OFF,
-    VISIBLE,
     MANUAL,
     AUTOMATIC,
     AUTOMATIC_ONCE

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -2,11 +2,15 @@ package com.github.libretube.helpers
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
+import com.github.libretube.BuildConfig
 import com.github.libretube.constants.PreferenceKeys
 
 object PreferenceHelper {
+    private val TAG = PreferenceHelper::class.simpleName
+
     /**
      * for normal preferences
      */
@@ -28,6 +32,19 @@ object PreferenceHelper {
     fun initialize(context: Context) {
         settings = getDefaultSharedPreferences(context)
         authSettings = getAuthenticationPreferences(context)
+    }
+
+    /**
+     * Migrate preference to a new version
+     */
+    fun migrate() {
+        val prefVersion = getInt(PreferenceKeys.PREFERENCE_VERSION, -1)
+        // check if there are any prefs to migrate
+        if (prefVersion == BuildConfig.VERSION_CODE)
+            return
+
+        // mark as successfully migrated
+        putInt(PreferenceKeys.PREFERENCE_VERSION, BuildConfig.VERSION_CODE)
     }
 
     fun putString(key: String, value: String) {

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -6,7 +6,10 @@ import android.util.Log
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.github.libretube.BuildConfig
+import com.github.libretube.LibreTubeApp
+import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
+import com.github.libretube.enums.SbSkipOptions
 
 object PreferenceHelper {
     private val TAG = PreferenceHelper::class.simpleName
@@ -42,6 +45,19 @@ object PreferenceHelper {
         // check if there are any prefs to migrate
         if (prefVersion == BuildConfig.VERSION_CODE)
             return
+
+        if (prefVersion < 63) {
+            Log.i(TAG, "Migration to prefs v63")
+            LibreTubeApp.instance.resources
+                .getStringArray(R.array.sponsorBlockSegments)
+                .forEach { category ->
+                    val key = "${category}_category"
+                    val stored = getString(key, "visible")
+                    if (stored == "visible") {
+                        putString(key, SbSkipOptions.MANUAL.name.lowercase())
+                    }
+                }
+        }
 
         // mark as successfully migrated
         putInt(PreferenceKeys.PREFERENCE_VERSION, BuildConfig.VERSION_CODE)

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1014,8 +1014,8 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
         if (segmentData != null && commonPlayerViewModel.isMiniPlayerVisible.value != true) {
             val (segment, sbSkipOption) = segmentData
 
-            val autoSkipTemporarilyDisabled = !binding.player.sponsorBlockAutoSkip &&
-                    sbSkipOption !in arrayOf(SbSkipOptions.OFF, SbSkipOptions.VISIBLE)
+            val autoSkipTemporarilyDisabled =
+                !binding.player.sponsorBlockAutoSkip && sbSkipOption != SbSkipOptions.OFF
 
             if (sbSkipOption in arrayOf(
                     SbSkipOptions.AUTOMATIC_ONCE,

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -422,7 +422,6 @@
 
     <string-array name="sb_skip_options">
         <item>@string/off</item>
-        <item>@string/visible</item>
         <item>@string/manual</item>
         <item>@string/automatic</item>
         <item>@string/automatic_once</item>
@@ -430,7 +429,6 @@
 
     <string-array name="sb_skip_options_values">
         <item>off</item>
-        <item>visible</item>
         <item>manual</item>
         <item>automatic</item>
         <item>automatic_once</item>


### PR DESCRIPTION
Drops the `VISIBLE` option for SponsorBlock, as it provides no additional value and leads to bad UX, as a user is able to see the segment, but able to skip it.
Existing users are migrated to the `MANUAL` option. To achieve this, new supporting code is introduced, that allows us to automatically migrate preferences.

Ref: https://github.com/libre-tube/LibreTube/issues/7384#issuecomment-2860415128
Ref: https://github.com/libre-tube/LibreTube/commit/f5c40157f3e38f019edbbc2568e7c869ffd4f968
Ref: https://github.com/libre-tube/LibreTube/commit/9ceb258881bebb5ee36b6105b491e021930b07bd