### PR TITLE
refactor(Preferences): use `MIGRATION` length as version

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -35,16 +35,11 @@ object PreferenceHelper {
      */
     private const val USER_ID_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-
     /**
-     * Current version of the preferences.
+     * Migrations required to migrate the application to a newer preference version.
+     * The version is automatically determined from the number of migrations available.
      */
-    private const val PREFERENCE_VERSION = 1
-
-    /**
-     * Migrations required to migrate the application to a newer [PREFERENCE_VERSION].
-     */
-    private val MIGRATIONS = listOf(
+    private val MIGRATIONS = arrayOf(
         PreferenceMigration(0, 1) {
             LibreTubeApp.instance.resources
                 .getStringArray(R.array.sponsorBlockSegments)
@@ -68,13 +63,11 @@ object PreferenceHelper {
 
     /**
      * Migrate preference to a new version.
-     *
-     * Migrations are run up to [PREFERENCE_VERSION].
      */
     fun migrate() {
         var currentPrefVersion = getInt(PreferenceKeys.PREFERENCE_VERSION, 0)
 
-        while (currentPrefVersion < PREFERENCE_VERSION) {
+        while (currentPrefVersion < MIGRATIONS.count()) {
             val next = currentPrefVersion + 1
 
             val migration =


### PR DESCRIPTION
Uses the `MIGRATION` length to determine the appropriate migrations to be run. This works, as opposed to Room migrations, there is no `AutoMigration`, i.e. no version increase without a corresponding `PreferenceMigration`. By automatically determining the preference version, we avoid issues, where a new migration is created, but never actually run, as the version is not incremented.

Ref: https://github.com/libre-tube/LibreTube/commit/c746647041515ed8e52077753978fb099a53a543