### PR TITLE
Chore: Remove context parameter from InstanceRepository

### DIFF
--- a/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
@@ -1,7 +1,5 @@
 package com.github.libretube.api
 
-import android.content.Context
-import com.github.libretube.R
 import com.github.libretube.api.RetrofitInstance.PIPED_API_URL
 import com.github.libretube.api.obj.PipedInstance
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
-class InstanceRepository(private val context: Context) {
+class InstanceRepository {
 
     /**
      * Fetch official public instances from kavin.rocks

--- a/app/src/main/java/com/github/libretube/ui/models/WelcomeViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/WelcomeViewModel.kt
@@ -116,7 +116,7 @@ class WelcomeViewModel(
         val Factory: ViewModelProvider.Factory = viewModelFactory {
             initializer {
                 WelcomeViewModel(
-                    instanceRepository = InstanceRepository(this[APPLICATION_KEY]!!),
+                    instanceRepository = InstanceRepository(),
                     savedStateHandle = createSavedStateHandle(),
                 )
             }

--- a/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/InstanceSettings.kt
@@ -55,10 +55,10 @@ class InstanceSettings : BasePreferenceFragment() {
 
         lifecycleScope.launch {
             // update the instances to also show custom ones
-            initInstancesPref(instancePrefs, InstanceRepository(appContext).getInstancesFallback())
+            initInstancesPref(instancePrefs, InstanceRepository().getInstancesFallback())
 
             // try to fetch the public list of instances async
-            val instanceRepo = InstanceRepository(appContext)
+            val instanceRepo = InstanceRepository()
             val instances = instanceRepo.getInstances()
                 .onFailure {
                     appContext.toastFromMainDispatcher(it.message.orEmpty())


### PR DESCRIPTION
The `Context` parameter was unused in the `InstanceRepository` constructor and has been removed. This simplifies the class and its instantiation.