### PR TITLE
chore: revert "Improve landscape UI"

### DIFF
--- a/app/src/main/res/layout-land/fragment_player.xml
+++ b/app/src/main/res/layout-land/fragment_player.xml
@@ -177,7 +177,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintWidth_default="percent"
-        app:layout_constraintWidth_percent=".7" />
+        app:layout_constraintWidth_percent=".55" />
 
     <RelativeLayout
         android:id="@+id/related_container"


### PR DESCRIPTION
Reverts libre-tube/LibreTube#7475

Breaks mobile landscape UI, for reference:
![screen](https://github.com/user-attachments/assets/46b54662-40c0-4bf1-b5ac-deb325ba8051)
