### PR TITLE
fix: audio player autoplay doesn't work if autoplay countdown enabled

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -784,6 +784,14 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
             AbstractPlayerService.runPlayerActionCommand,
             bundleOf(PlayerCommand.TOGGLE_AUDIO_ONLY_MODE.name to true)
         )
+        // disable autoplay countdown while the audio player is running
+        // otherwise playback of the next video wouldn't start automatically because
+        // it awaits the start of the autoplay countdown
+        playerController.sendCustomCommand(
+            AbstractPlayerService.runPlayerActionCommand, bundleOf(
+                PlayerCommand.SET_AUTOPLAY_COUNTDOWN_ENABLED.name to false
+            )
+        )
 
         binding.player.player = null
 


### PR DESCRIPTION
closes  #7453
