### PR TITLE
Fix crash when streams size > 1MB

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/SetMetadata.kt
+++ b/app/src/main/java/com/github/libretube/extensions/SetMetadata.kt
@@ -16,12 +16,13 @@ import kotlinx.serialization.encodeToString
 
 @OptIn(UnstableApi::class)
 fun MediaItem.Builder.setMetadata(streams: Streams, videoId: String) = apply {
+    val clearedStreams = streams.copy(audioStreams = emptyList(), videoStreams = emptyList())
     val extras = bundleOf(
         MediaMetadataCompat.METADATA_KEY_TITLE to streams.title,
         MediaMetadataCompat.METADATA_KEY_ARTIST to streams.uploader,
         IntentData.videoId to videoId,
         // JSON-encode as work-around for https://github.com/androidx/media/issues/564
-        IntentData.streams to JsonHelper.json.encodeToString(streams),
+        IntentData.streams to JsonHelper.json.encodeToString(clearedStreams),
         IntentData.chapters to JsonHelper.json.encodeToString(streams.chapters)
     )
     setMediaMetadata(


### PR DESCRIPTION
The maximum parcelable size is 1MB. When this limit is reached, a crash will occur. The metadata is set with a `Streams` parcelable object and is sent over IPC to a place in the Android system where it will make Bluetooth crash. 

This PR reduces the `Streams` object size by setting `audioStreams` and `videoStreams` to empty lists as these lists can grow substantially, reaching over the 1MB size limit.

Fixes https://github.com/libre-tube/LibreTube/issues/7023