### PR TITLE
refactor: move player related sub-views to its own binding

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/OfflinePlayerActivity.kt
@@ -199,11 +199,7 @@ class OfflinePlayerActivity : BaseActivity() {
             playNextVideo(PlayingQueue.getNext() ?: return@setOnClickListener)
         }
 
-        binding.player.initialize(
-            binding.doubleTapOverlay.binding,
-            binding.playerGestureControlsView.binding,
-            chaptersViewModel
-        )
+        binding.player.initialize(chaptersViewModel)
     }
 
     private suspend fun loadPlayerData() {

--- a/app/src/main/res/layout-land/fragment_player.xml
+++ b/app/src/main/res/layout-land/fragment_player.xml
@@ -207,70 +207,14 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@android:color/black"
+        app:player_layout_id="@layout/custom_exo_player_view"
         app:controller_layout_id="@layout/exo_styled_player_control_view"
         app:layout_constraintBottom_toBottomOf="@id/main_container"
         app:layout_constraintEnd_toEndOf="@id/main_container"
         app:layout_constraintStart_toStartOf="@id/main_container"
         app:layout_constraintTop_toTopOf="@id/main_container"
         app:show_buffering="when_playing"
-        app:surface_type="surface_view">
-
-        <com.github.libretube.ui.views.DoubleTapOverlay
-            android:id="@+id/doubleTapOverlay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-        <com.github.libretube.ui.views.PlayerGestureControlsView
-            android:id="@+id/playerGestureControlsView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-        <com.google.android.material.card.MaterialCardView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center|end"
-            android:layout_marginTop="15dp"
-            android:layout_marginEnd="-10dp"
-            android:paddingEnd="20dp"
-            app:cardBackgroundColor="#88000000"
-            app:strokeWidth="1dp"
-            tools:ignore="RtlSymmetry">
-
-            <com.github.libretube.ui.views.DrawableTextView
-                android:id="@+id/sb_skip_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:drawablePadding="20dp"
-                android:padding="10dp"
-                android:text="@string/skip_segment"
-                android:textColor="@android:color/white"
-                android:textSize="18sp"
-                android:visibility="gone"
-                app:drawableEndCompat="@drawable/ic_next"
-                app:drawableEndDimen="20dp"
-                app:drawableTint="@android:color/white" />
-
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.github.libretube.ui.views.AutoplayCountdownView
-            android:id="@+id/autoplay_countdown"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone" />
-
-        <ProgressBar
-            android:id="@+id/video_transition_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:indeterminate="true"
-            android:visibility="gone" />
-
-    </com.github.libretube.ui.views.OnlinePlayerView>
+        app:surface_type="surface_view" />
 
     <ImageView
         android:id="@+id/close_imageView"

--- a/app/src/main/res/layout/activity_offline_player.xml
+++ b/app/src/main/res/layout/activity_offline_player.xml
@@ -10,23 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/black"
+        app:player_layout_id="@layout/custom_exo_player_view"
         app:controller_layout_id="@layout/exo_styled_player_control_view"
-        app:show_buffering="when_playing">
-
-        <com.github.libretube.ui.views.DoubleTapOverlay
-            android:id="@+id/doubleTapOverlay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-        <com.github.libretube.ui.views.PlayerGestureControlsView
-            android:id="@+id/playerGestureControlsView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-    </com.github.libretube.ui.views.OfflinePlayerView>
+        app:show_buffering="when_playing" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/custom_exo_player_view.xml
+++ b/app/src/main/res/layout/custom_exo_player_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2020 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/custom_exo_player_view_template" />
+
+    <!-- This view is used in ExoPlayer's constructor and will be replaced by the controller on
+    initialization. Thus, this view here can't be inflated using a view binding. You can however bind
+    to the template included above, as a workaround! -->
+    <View android:id="@id/exo_controller_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/custom_exo_player_view_template.xml
+++ b/app/src/main/res/layout/custom_exo_player_view_template.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!--based on https://github.com/androidx/media/blob/release/libraries/ui/src/main/res/layout/exo_player_view.xml -->
+
+    <androidx.media3.ui.AspectRatioFrameLayout android:id="@id/exo_content_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center">
+
+        <View
+            android:id="@id/exo_controls_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/exo_black_opacity_60"
+            android:alpha="0" />
+
+        <View android:id="@id/exo_shutter"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black"/>
+
+        <ImageView android:id="@id/exo_image"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitXY"
+            android:contentDescription="@null"/>
+
+        <ImageView android:id="@id/exo_artwork"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitXY"
+            android:contentDescription="@null"/>
+
+        <androidx.media3.ui.SubtitleView android:id="@id/exo_subtitles"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+        <ProgressBar android:id="@id/exo_buffering"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:layout_gravity="center"/>
+
+        <TextView android:id="@id/exo_error_message"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/exo_error_message_height"
+            android:layout_gravity="center"
+            android:layout_marginBottom="@dimen/exo_error_message_margin_bottom"
+            android:gravity="center"
+            android:textColor="@color/exo_white"
+            android:textSize="@dimen/exo_error_message_text_size"
+            android:background="@drawable/exo_rounded_rectangle"
+            android:paddingLeft="@dimen/exo_error_message_text_padding_horizontal"
+            android:paddingRight="@dimen/exo_error_message_text_padding_horizontal"
+            android:paddingTop="@dimen/exo_error_message_text_padding_vertical"
+            android:paddingBottom="@dimen/exo_error_message_text_padding_vertical"/>
+
+    </androidx.media3.ui.AspectRatioFrameLayout>
+
+    <FrameLayout android:id="@id/exo_ad_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <FrameLayout android:id="@id/exo_overlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+
+    <com.github.libretube.ui.views.DoubleTapOverlay
+        android:id="@+id/doubleTapOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center" />
+
+    <com.github.libretube.ui.views.PlayerGestureControlsView
+        android:id="@+id/playerGestureControlsView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center|end"
+        android:layout_marginTop="15dp"
+        android:layout_marginEnd="-10dp"
+        android:paddingEnd="20dp"
+        app:cardBackgroundColor="#88000000"
+        app:strokeWidth="1dp"
+        tools:ignore="RtlSymmetry">
+
+        <com.github.libretube.ui.views.DrawableTextView
+            android:id="@+id/sb_skip_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:drawablePadding="20dp"
+            android:padding="10dp"
+            android:text="@string/skip_segment"
+            android:textColor="@android:color/white"
+            android:textSize="18sp"
+            android:visibility="gone"
+            app:drawableEndCompat="@drawable/ic_next"
+            app:drawableEndDimen="20dp"
+            app:drawableTint="@android:color/white" />
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <com.github.libretube.ui.views.AutoplayCountdownView
+        android:id="@+id/autoplay_countdown"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
+
+    <ProgressBar
+        android:id="@+id/video_transition_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:visibility="gone" />
+
+</merge>

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -3,12 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <View
-        android:id="@id/exo_controls_background"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@color/exo_black_opacity_60" />
-
     <LinearLayout
         android:id="@+id/top_bar"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -181,68 +181,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/black"
+        app:player_layout_id="@layout/custom_exo_player_view"
         app:controller_layout_id="@layout/exo_styled_player_control_view"
         app:layout_constraintBottom_toBottomOf="@id/main_container"
         app:layout_constraintStart_toStartOf="@id/main_container"
         app:layout_constraintTop_toTopOf="@id/main_container"
         app:show_buffering="when_playing"
-        app:surface_type="surface_view">
-
-        <com.github.libretube.ui.views.DoubleTapOverlay
-            android:id="@+id/doubleTapOverlay"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-        <com.github.libretube.ui.views.PlayerGestureControlsView
-            android:id="@+id/playerGestureControlsView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:gravity="center" />
-
-        <com.google.android.material.card.MaterialCardView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center|end"
-            android:layout_marginTop="15dp"
-            android:layout_marginEnd="-10dp"
-            android:paddingEnd="20dp"
-            app:cardBackgroundColor="#88000000"
-            app:strokeWidth="1dp"
-            tools:ignore="RtlSymmetry">
-
-            <com.github.libretube.ui.views.DrawableTextView
-                android:id="@+id/sb_skip_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:drawablePadding="20dp"
-                android:padding="10dp"
-                android:text="@string/skip_segment"
-                android:textColor="@android:color/white"
-                android:textSize="18sp"
-                android:visibility="gone"
-                app:drawableEndCompat="@drawable/ic_next"
-                app:drawableEndDimen="20dp"
-                app:drawableTint="@android:color/white" />
-
-        </com.google.android.material.card.MaterialCardView>
-
-        <com.github.libretube.ui.views.AutoplayCountdownView
-            android:id="@+id/autoplay_countdown"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone" />
-
-        <ProgressBar
-            android:id="@+id/video_transition_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:indeterminate="true" />
-
-    </com.github.libretube.ui.views.OnlinePlayerView>
+        app:surface_type="surface_view" />
 
     <ImageView
         android:id="@+id/close_imageView"


### PR DESCRIPTION
Motivation:
- We previously duplicated the code to embed the views that are required by the player (e.g. the +10 seek indicator, autoplay countdown, ...) by pasting them everywhere a PlayerView instead is defined in XML
- This way is much cleaner and removes the duplicated code
- The changes also allow us to have more control over the ExoPlayer views inbuild components and use view bindings on it, which hasn't been possible before this PR.

Caveats:
- However, we unfortunately need to create a wrapper `custom_exo_player_view` around the real views, because `PlayerView` replaces `@id/exo_controller_placeholder` with the actual controller view in its constructor, so there's no way that we can prevent that behavior. That causes `custom_exo_player_view` not to be inflatable, because the view with id `@id/exo_controller_placeholder` doesn't exist anymore.
- We have to set the dimmed player controls background manually, because it would otherwise overlap the stuff behind it (i.e. the skip buttons)