### PR TITLE
fix: collapse description when loading new video

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1101,6 +1101,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
     }
 
     private fun toggleVideoInfoVisibility(show: Boolean){
+        binding.descriptionLayout.collapseDescription()
         binding.descriptionLayout.isInvisible = !show
         binding.relatedRecView.isInvisible = !show
         binding.playerChannel.isInvisible = !show

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -113,6 +113,16 @@ class DescriptionLayout(
     }
 
     /**
+     * Collapses the description, if it is currently expanded.
+     */
+    fun collapseDescription() {
+        val isCollapsed = binding.descLinLayout.isGone
+        if (!isCollapsed) {
+            toggleDescription()
+        }
+    }
+
+    /**
      * Set up the description text with video links and timestamps
      */
     private fun setupDescription(description: String) {


### PR DESCRIPTION
Fixes a regression, where the description layout could still be expanded, when loading a new video, leading to only a blank layout being displayed.

Ref: https://github.com/libre-tube/LibreTube/pull/7526

![Blank screen when loading new video with expanded description](https://github.com/user-attachments/assets/6c9241f5-ca45-43eb-8685-425979d1d61c)
