### PR TITLE
fix: remove HLS message

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -620,9 +620,7 @@ class MainActivity : BaseActivity() {
             PreferenceHelper.getInt(PreferenceKeys.LAST_SHOWN_INFO_MESSAGE_VERSION_CODE, -1)
 
         // mapping of version code to info message
-        val infoMessages = listOf(
-            60 to "If you use Local Streams Extraction, please disable \"Use HLS\" in the instance settings."
-        )
+        val infoMessages = emptyList<Pair<Int, String>>()
 
         val message =
             infoMessages.lastOrNull { (versionCode, _) -> versionCode > lastShownVersionCode }?.second


### PR DESCRIPTION
Removes the HLS message as it is no longer relevant, since HLS has been removed. This is confusing to new users, as the message will still be shown on first startup.

Ref: https://github.com/libre-tube/LibreTube/pull/7508