### PR TITLE
build: keep NewPipeExtractor auto-generated proto classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -116,6 +116,7 @@
 -keep class com.github.libretube.ui.preferences.** { *; }
 
 ## Rules for NewPipeExtractor
+-keep class org.schabi.newpipe.extractor.services.youtube.protos.** { *; }
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
 -keep class org.mozilla.javascript.** { *; }
 -keep class org.mozilla.javascript.engine.** { *; }


### PR DESCRIPTION
Fixes a regression, where in release mode the auto-generated protobuf classes would be removed, leading to a runtime error.
This could lead to indefinite loading when trying to interact with online playlist.

Ref: https://github.com/libre-tube/LibreTube/pull/7568