### PR TITLE
feat: display title of downloading video

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/DownloadDialog.kt
@@ -76,6 +76,8 @@ class DownloadDialog : DialogFragment() {
     }
 
     private fun initDownloadOptions(binding: DialogDownloadBinding, streams: Streams) {
+        binding.videoTitle.text = streams.title
+
         val videoStreams = streams.videoStreams.filter {
             !it.url.isNullOrEmpty()
         }.filter { !it.format.orEmpty().contains("HLS") }.sortedByDescending {

--- a/app/src/main/res/layout/dialog_download.xml
+++ b/app/src/main/res/layout/dialog_download.xml
@@ -6,6 +6,15 @@
     android:orientation="vertical"
     android:paddingHorizontal="20dp">
 
+    <TextView
+        android:id="@+id/video_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dp"
+        android:ellipsize="end"
+        android:maxLines="2"
+        android:textSize="16sp" />
+
     <com.github.libretube.ui.views.DropdownMenu
         android:id="@+id/video_spinner"
         android:layout_width="match_parent"


### PR DESCRIPTION
Displays the title of the video that should be downloaded in the download dialog, to indicate, which video is being downloaded.\

![Download dialog with title](https://github.com/user-attachments/assets/53222ad8-a603-48d3-a7ac-3a6178a7aa37)