### PR TITLE
fix: shuffling downloads leaves queue empty if insertRelatedStreams disabled

### DIFF
--- a/app/src/main/java/com/github/libretube/services/OfflinePlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/OfflinePlayerService.kt
@@ -200,7 +200,7 @@ open class OfflinePlayerService : AbstractPlayerService() {
 
         if (shuffle) downloads.shuffle()
 
-        PlayingQueue.insertRelatedStreams(downloads.map { it.download.toStreamItem() })
+        PlayingQueue.add(*downloads.map { it.download.toStreamItem() }.toTypedArray())
     }
 
     private fun playNextVideo(videoId: String? = null) {


### PR DESCRIPTION
closes #7541
