### PR TITLE
feat: separate 'clone' and 'create' when creating a new playist

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/CreatePlaylistDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/CreatePlaylistDialog.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.os.Bundle
 import android.widget.Toast
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.lifecycleScope
@@ -21,6 +22,15 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 class CreatePlaylistDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val binding = DialogCreatePlaylistBinding.inflate(layoutInflater)
+
+        binding.createPlaylistSpinner.items = listOf(
+            getString(R.string.createNewPlaylist),
+            getString(R.string.clonePlaylist)
+        )
+        binding.createPlaylistSpinner.setOnSelectionChangeListener { position ->
+            binding.createPlayistContainerView.isVisible = position == 0
+            binding.clonePlaylistContainerView.isVisible = position == 1
+        }
 
         binding.clonePlaylist.setOnClickListener {
             val playlistUrl = binding.playlistUrl.text.toString().toHttpUrlOrNull()

--- a/app/src/main/java/com/github/libretube/ui/views/DropdownMenu.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DropdownMenu.kt
@@ -52,6 +52,12 @@ class DropdownMenu(
 
     override fun isEnabled() = binding.textInputLayout.isEnabled
 
+    private var onSelectionChangeListener: ((Int) -> Unit)? = null
+
+    fun setOnSelectionChangeListener(listener: ((Int) -> Unit)?) {
+        onSelectionChangeListener = listener
+    }
+
     fun setSelection(item: String) {
         val itemIndex = items.indexOf(item)
         if (itemIndex != -1) selectedItemPosition = itemIndex
@@ -69,5 +75,9 @@ class DropdownMenu(
         }
 
         adapter = ArrayAdapter(context, R.layout.dropdown_item)
+
+        binding.autoCompleteTextView.setOnItemClickListener {_, _, position, _ ->
+            onSelectionChangeListener?.invoke(position)
+        }
     }
 }

--- a/app/src/main/res/layout/dialog_create_playlist.xml
+++ b/app/src/main/res/layout/dialog_create_playlist.xml
@@ -1,49 +1,75 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingTop="8dp">
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/CustomDialogTextInputLayout"
-        android:hint="@string/playlistUrl">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/playlist_url"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/clone_playlist"
-        android:layout_width="wrap_content"
+    <com.github.libretube.ui.views.DropdownMenu
+        android:id="@+id/create_playlist_spinner"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="10dp"
-        android:drawableStart="@drawable/ic_copy"
-        android:text="@string/clonePlaylist" />
+        android:layout_marginHorizontal="15dp"
+        app:hint="@string/tooltip_options" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        style="@style/CustomDialogTextInputLayout"
-        android:hint="@string/playlistName">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/playlist_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:inputType="text" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/create_new_playlist"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/clone_playlist_container_view"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="end"
-        android:layout_marginEnd="20dp"
-        android:drawableStart="@drawable/ic_copy"
-        android:text="@string/createPlaylist" />
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/CustomDialogTextInputLayout"
+            android:hint="@string/playlistUrl">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/playlist_url"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/clone_playlist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginEnd="20dp"
+            android:drawableStart="@drawable/ic_copy"
+            android:text="@string/clonePlaylist" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/create_playist_container_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/CustomDialogTextInputLayout"
+            android:layout_marginHorizontal="0dp"
+            android:hint="@string/playlistName">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/playlist_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/create_new_playlist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginEnd="20dp"
+            android:drawableStart="@drawable/ic_copy"
+            android:text="@string/createNewPlaylist" />
+    </LinearLayout>
+
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="deletePlaylist">Delete playlist</string>
     <string name="areYouSure">Delete the playlist?</string>
     <string name="createPlaylist">Create playlist</string>
+    <string name="createNewPlaylist">Create new playlist</string>
     <string name="playlistCreated">Playlist created.</string>
     <string name="playlistName">Playlist name</string>
     <string name="emptyPlaylistName">The playlist name can\'t be empty</string>

--- a/app/src/main/res/values/style.xml
+++ b/app/src/main/res/values/style.xml
@@ -43,7 +43,7 @@
         <item name="android:paddingBottom">15dp</item>
     </style>
 
-    <style name="CustomDialogTextInputLayout" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <style name="CustomDialogTextInputLayout" parent="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
This PR separate `clone playlist` and `create playlist` into  separate view via spinner.

Having 2 options in the same UI while the user only able to proceed with just one of them is kind of bad UX, I think?  

Before changes:
<img width="220" height=auto alt="before-pl-dialog-Screenshot_20250803-065659_LibreTube Debug" src="https://github.com/user-attachments/assets/dcb451fb-1954-401b-9c02-8285ee735e95" />

After changes:
<img width="220" height=auto alt="After-pl-dialog-Screenshot_20250803-064904_LibreTube Debug" src="https://github.com/user-attachments/assets/1390f93f-0da7-4595-aca6-fde83dc5c491" />

