### PR TITLE
feat: disable 'Add to playlist' button and spinner when there is no playlist available

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/AddToPlaylistDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/AddToPlaylistDialog.kt
@@ -44,11 +44,30 @@ class AddToPlaylistDialog : DialogFragment() {
         }
 
         val binding = DialogAddToPlaylistBinding.inflate(layoutInflater)
+        binding.createPlaylist.setOnClickListener {
+            CreatePlaylistDialog().show(childFragmentManager, null)
+        }
+        binding.addToPlaylist.setOnClickListener {
+            val selectedItemPosition = binding.playlistsSpinner.selectedItemPosition
+            viewModel.onAddToPlaylist(selectedItemPosition)
+        }
+
         viewModel.uiState.observe(this) { (lastSelectedPlaylistId, playlists, msg, saved) ->
-            binding.playlistsSpinner.items = playlists.mapNotNull { it.name }
+            binding.playlistsSpinner.items =
+                playlists
+                    .mapNotNull { it.name }
+                    .ifEmpty { listOf("") }
+
+            // disable the spinner and the 'Add' button when there is no available playlist
+            binding.playlistsSpinner.isEnabled = playlists.isNotEmpty()
+            binding.addToPlaylist.isEnabled = playlists.isNotEmpty()
 
             // select the last used playlist
             lastSelectedPlaylistId?.let { id ->
+                // check if the list is empty, it's possible that the user just deleted
+                // all playlists and 'lastSelectedPlaylist' still has value
+                if (playlists.isEmpty()) return@let
+
                 binding.playlistsSpinner.selectedItemPosition = playlists
                     .indexOfFirst { it.id == id }
                     .takeIf { it >= 0 } ?: 0
@@ -56,7 +75,8 @@ class AddToPlaylistDialog : DialogFragment() {
 
             msg?.let {
                 with(binding.root.context) {
-                    Toast.makeText(this, getString(it.resId, it.formatArgs), Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this, getString(it.resId, it.formatArgs), Toast.LENGTH_SHORT)
+                        .show()
                 }
                 viewModel.onMessageShown()
             }
@@ -69,20 +89,8 @@ class AddToPlaylistDialog : DialogFragment() {
 
         return MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.addToPlaylist)
-            .setNegativeButton(R.string.createPlaylist, null)
-            .setPositiveButton(R.string.addToPlaylist, null)
             .setView(binding.root)
             .show()
-            .apply {
-                // Click listeners without closing the dialog
-                getButton(DialogInterface.BUTTON_NEGATIVE).setOnClickListener {
-                    CreatePlaylistDialog().show(childFragmentManager, null)
-                }
-                getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener {
-                    val selectedItemPosition = binding.playlistsSpinner.selectedItemPosition
-                    viewModel.onAddToPlaylist(selectedItemPosition)
-                }
-            }
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/res/layout/dialog_add_to_playlist.xml
+++ b/app/src/main/res/layout/dialog_add_to_playlist.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -12,7 +11,29 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="24dp"
         android:layout_marginTop="8dp"
-        app:icon="@drawable/ic_playlist_add"
-        tools:ignore="RtlSymmetry" />
+        app:icon="@drawable/ic_playlist_add" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:padding="8dp"
+        android:gravity="end|center_vertical"
+        android:orientation="horizontal">
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.Material3.Button.TextButton.Dialog"
+            android:id="@+id/create_playlist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/createPlaylist" />
+
+        <com.google.android.material.button.MaterialButton
+            style="@style/Widget.Material3.Button.TextButton.Dialog"
+            android:id="@+id/add_to_playlist"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/addToPlaylist" />
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Slight UI impovement to avoid confusion.

Dialog before:
<img width="200" height=auto alt="beforeAddPlScreenshot_20250803-181107_LibreTube Debug" src="https://github.com/user-attachments/assets/e112544c-f612-407c-8603-7e1c744d71c6" />

Dialog after:
<img width="200" height=auto alt="afterAddPlScreenshot_20250803-183242_LibreTube Debug" src="https://github.com/user-attachments/assets/90368f54-ae23-4898-9d53-197ca4093b6f" />

This PR also includes **fix**:
-After the user deleted all playlists, if they try to add a video to a playlist by triggering this dialog, the app crashes.
