### PR TITLE
fix(UI/Comments): only show creator reply indicator for the initial comment

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/CommentPagingAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/CommentPagingAdapter.kt
@@ -86,6 +86,8 @@ class CommentPagingAdapter(
             ImageHelper.loadImage(comment.thumbnail, commentorImage, true)
             likesTextView.text = comment.likeCount.formatShort()
 
+            // clear the image view, to avoid it still being shown when android recycles the view
+            creatorReplyImageView.isGone = true
             if (comment.creatorReplied && !channelAvatar.isNullOrBlank()) {
                 ImageHelper.loadImage(channelAvatar, creatorReplyImageView, true)
                 creatorReplyImageView.isVisible = true


### PR DESCRIPTION
Fixes an issue, where the creator reply indicator would be displayed multiple times in the reply page. This is caused by android re-using the view in the recyclerview, but not resetting the visibility of the imageview.