### PR TITLE
fix(player ui): seek and skip buttons appear at opposite side in rtl mode

### DIFF
--- a/app/src/main/res/layout/double_tap_overlay.xml
+++ b/app/src/main/res/layout/double_tap_overlay.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:baselineAligned="false">
+    android:baselineAligned="false"
+    android:layoutDirection="ltr">
 
     <!-- double tap rewind btn -->
     <FrameLayout

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -129,7 +129,8 @@
         android:layout_gravity="center"
         android:background="@android:color/transparent"
         android:gravity="center"
-        android:padding="20dp">
+        android:padding="20dp"
+        android:layoutDirection="ltr">
 
         <include
             android:id="@+id/seek_button_rewind"


### PR DESCRIPTION
I also notice the skip segment button appears at the left side in rtl mode. The video is progressing from left to right so the skip segment button on the left side seems kind of unintuitive,  I think? I wanted to hardcode it on the right side but realized it's been there for quite some time so it might make some people unhappy if it's moved so I just left it untouched.