### PR TITLE
feat(player ui): better control overlays visibility

### DIFF
--- a/app/src/main/res/layout/custom_exo_player_view_template.xml
+++ b/app/src/main/res/layout/custom_exo_player_view_template.xml
@@ -10,13 +10,6 @@
         android:layout_height="match_parent"
         android:layout_gravity="center">
 
-        <View
-            android:id="@id/exo_controls_background"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/exo_black_opacity_60"
-            android:alpha="0" />
-
         <View android:id="@id/exo_shutter"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -57,6 +50,13 @@
             android:paddingRight="@dimen/exo_error_message_text_padding_horizontal"
             android:paddingTop="@dimen/exo_error_message_text_padding_vertical"
             android:paddingBottom="@dimen/exo_error_message_text_padding_vertical"/>
+
+        <View
+            android:id="@id/exo_controls_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/exo_black_opacity_60"
+            android:alpha="0" />
 
     </androidx.media3.ui.AspectRatioFrameLayout>
 


### PR DESCRIPTION
This changes move `exo_controls_background` to the top, so that the controls have better contrast than the other overlays like subtitle.

|Before|After|
|----------|-------|
|<img width="280" height=auto alt="sub-visibility-before" src="https://github.com/user-attachments/assets/18b568d1-0ad3-4cfa-981b-3e4e4e863718" />| <img width="280" height=auto alt="sub-visibility-after" src="https://github.com/user-attachments/assets/1f25c5d9-aabe-4625-851f-4189d5252054" />|
|<img width="280" height="auto" alt="sub-visibility-bottom-before" src="https://github.com/user-attachments/assets/b6e7eaee-668b-4c94-b38d-aec0fd5e1fd8" />|<img width="280" height="auto" alt="sub-visibility-bottom-after" src="https://github.com/user-attachments/assets/93913187-7793-41c0-90bc-d6b323d53e23" />|




