### PR TITLE
fix(sponsorblock): segment time not properly parsed if exceeds 1 hour

### DIFF
--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -58,7 +58,7 @@ object TextUtils {
     fun String.parseDurationString(): Float? = parseTimeString(this)
 
     private fun parseTimeString(timeString: String): Float? {
-        if (timeString.isDigitsOnly()) return timeString.toLongOrNull()?.toFloat()
+        if (timeString.all { it.isDigit() }) return timeString.toLongOrNull()?.toFloat()
 
         if (timeString.all { it.isDigit() || ",.:".contains(it) }) {
             var secondsTotal = 0
@@ -79,7 +79,8 @@ object TextUtils {
                     secondsScoped *= 10
                     secondsScoped += char.digitToInt()
                 } else if (char == ':') {
-                    secondsTotal += secondsScoped * 60
+                    secondsTotal += secondsScoped
+                    secondsTotal *= 60
                     secondsScoped = 0
                 } else if (",.".contains(char)) {
                     secondsTotal += secondsScoped

--- a/app/src/test/java/com/github/libretube/TextParserTest.kt
+++ b/app/src/test/java/com/github/libretube/TextParserTest.kt
@@ -14,5 +14,6 @@ class TextParserTest {
         assertEquals(15f * 60 + 20 + 0.25f, "15:20.25".parseDurationString())
         assertEquals(20f, "00:20".parseDurationString())
         assertEquals(60.02503f, "1:00.02503".parseDurationString())
+        assertEquals((1 * 60 * 60) + (3 * 60) + 40 + .251f, "1:03:40.251".parseDurationString())
     }
 }


### PR DESCRIPTION
Previously when trying to submit a sponsorblock segment, if the time exceed 1 hour, the time conversion resulted in a wrong value and caused the segment to be submitted in the wrong place of the video