### PR TITLE
fix: image loading issues when scrolling too fast on a list

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -3,14 +3,13 @@ package com.github.libretube.helpers
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.widget.ImageView
 import androidx.core.net.toUri
 import coil3.ImageLoader
-import coil3.asDrawable
 import coil3.disk.DiskCache
 import coil3.disk.directory
+import coil3.load
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
@@ -107,11 +106,13 @@ object ImageHelper {
             if (urlToLoad.startsWith(HTTP_SCHEME) && !isCached(urlToLoad)) return
         }
 
-        getImageWithCallback(target.context, urlToLoad) { result ->
-            // set the background to white for transparent images
-            if (whiteBackground) target.setBackgroundColor(Color.WHITE)
-
-            target.setImageDrawable(result)
+        target.load(urlToLoad) {
+            listener(
+                onSuccess = { _, _ ->
+                    // set the background to white for transparent images
+                    if (whiteBackground) target.setBackgroundColor(Color.WHITE)
+                }
+            )
         }
     }
 
@@ -134,17 +135,6 @@ object ImageHelper {
             .build()
 
         return imageLoader.execute(request).image?.toBitmap()
-    }
-
-    private fun getImageWithCallback(context: Context, url: String?, onSuccess: (Drawable) -> Unit) {
-        val request = ImageRequest.Builder(context)
-            .data(url)
-            .target { drawable ->
-                onSuccess(drawable.asDrawable(context.resources))
-            }
-            .build()
-
-        imageLoader.enqueue(request)
     }
 
     /**


### PR DESCRIPTION
Load images using coil's extension, by passing the `target` image directly. The nice thing about this is they automatically cancel the requests for you somehow. 

Their website says coil automatically cancel/pause requests for you, but doesnt say 'when' it does that. The only answer I got was from google's ai result, which says that it cancels the requests when the view gets detached.