### PR TITLE
feat: show toolbar when scrolling up in subscriptions feed for better accessibility

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -91,7 +91,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
 
         // Determine if the child can scroll up
         binding.subRefresh.setOnChildScrollUpCallback { _, _ ->
-            !isAppBarFullyExpanded
+            !isAppBarFullyExpanded || binding.subFeed.canScrollVertically(-1)
         }
 
         binding.subRefresh.isEnabled = true
@@ -328,7 +328,6 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
             if (restoreScrollState) {
                 // manually restore the previous feed state
                 binding.subFeed.layoutManager?.onRestoreInstanceState(viewModel.subFeedRecyclerViewState)
-                binding.subscriptionsAppBar.setExpanded(viewModel.subFeedRecyclerViewState == null)
             } else {
                 binding.subFeed.scrollToPosition(0)
             }

--- a/app/src/main/res/layout/fragment_subscriptions.xml
+++ b/app/src/main/res/layout/fragment_subscriptions.xml
@@ -53,13 +53,14 @@
             <com.google.android.material.appbar.AppBarLayout
                 android:id="@+id/subscriptions_app_bar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                app:liftOnScroll="false">
 
                 <com.google.android.material.appbar.CollapsingToolbarLayout
                     android:id="@+id/subscriptions_collapsing_tb"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_scrollFlags="scroll"
+                    app:layout_scrollFlags="scroll|enterAlways"
                     app:titleCollapseMode="scale">
 
                     <LinearLayout


### PR DESCRIPTION
Now we dont need to scroll all the way up just to filter the list.

~~Other changes:~~
~~- Toolbar stays expanded when the subscription list is opened. The reason I made it like this is because I think the subscription list is still part/menu of the toolbar, not an actual content of this fragment, so the toolbar should stay open with the list ( I think?)~~

~~- Added collapse icon:~~
