### PR TITLE
fix(Home): hide Trending category

### DIFF
--- a/app/src/main/java/com/github/libretube/api/MediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/MediaServiceRepository.kt
@@ -51,7 +51,6 @@ interface MediaServiceRepository {
 }
 
 enum class TrendingCategory {
-    TRENDING,
     GAMING,
     PODCASTS,
     TRAILERS,

--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -246,14 +246,14 @@ class NewPipeMediaServiceRepository : MediaServiceRepository {
 
     // see https://github.com/TeamNewPipe/NewPipeExtractor/tree/dev/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/kiosk
     private val trendingCategories = mapOf(
-        TrendingCategory.TRENDING to "Trending",
         TrendingCategory.GAMING to "trending_gaming",
         TrendingCategory.TRAILERS to "trending_movies_and_shows",
         TrendingCategory.PODCASTS to "trending_podcasts_episodes",
         TrendingCategory.MUSIC to "trending_music",
         TrendingCategory.LIVE to "live"
     )
-    override fun getTrendingCategories(): List<TrendingCategory> = trendingCategories.keys.toList()
+    override fun getTrendingCategories(): List<TrendingCategory> =
+        trendingCategories.keys.toList()
 
     override suspend fun getTrending(region: String, category: TrendingCategory): List<StreamItem> {
         val kioskList = NewPipeExtractorInstance.extractor.kioskList

--- a/app/src/main/java/com/github/libretube/api/PipedMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/PipedMediaServiceRepository.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.encodeToString
 import retrofit2.HttpException
 
 open class PipedMediaServiceRepository : MediaServiceRepository {
-    override fun getTrendingCategories(): List<TrendingCategory> = listOf(TrendingCategory.TRENDING)
+    override fun getTrendingCategories(): List<TrendingCategory> = emptyList()
 
     override suspend fun getTrending(region: String, category: TrendingCategory): List<StreamItem> =
         api.getTrending(region)

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -7,6 +7,7 @@ import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import com.github.libretube.LibreTubeApp
 import com.github.libretube.R
+import com.github.libretube.api.TrendingCategory
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.enums.SbSkipOptions
 import com.github.libretube.helpers.LocaleHelper.getDetectedCountry
@@ -51,6 +52,10 @@ object PreferenceHelper {
                         putString(key, SbSkipOptions.MANUAL.name.lowercase())
                     }
                 }
+        },
+        PreferenceMigration(1, 2) {
+            // select a random category as the new value
+            putString(PreferenceKeys.TRENDING_CATEGORY, TrendingCategory.LIVE.name)
         },
     )
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/HomeFragment.kt
@@ -141,7 +141,7 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         binding.trendingCategory.setOnClickListener {
             val currentTrendingCategoryPref = PreferenceHelper.getString(
                 PreferenceKeys.TRENDING_CATEGORY,
-                TrendingCategory.TRENDING.name
+                TrendingCategory.LIVE.name
             ).let { TrendingCategory.valueOf(it) }
 
             val categories = trendingCategories.map { category ->
@@ -201,12 +201,13 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
         )
     }
 
-    private fun showTrending(streamItems: List<StreamItem>?) {
-        if (streamItems == null) return
+    private fun showTrending(trends: Pair<TrendingCategory, List<StreamItem>>?) {
+        if (trends == null) return
+        val (category, streamItems) = trends
 
         // cache the loaded trends in the [TrendsViewModel] so that the trends don't need to be
         // reloaded there
-        trendsViewModel.setStreamsForCategory(TrendingCategory.TRENDING, streamItems)
+        trendsViewModel.setStreamsForCategory(category, streamItems)
 
         makeVisible(binding.trendingRV, binding.trendingTV)
         trendingAdapter.submitList(streamItems)

--- a/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/TrendsFragment.kt
@@ -50,7 +50,6 @@ class TrendsFragment : Fragment(R.layout.fragment_trends) {
 
     companion object {
         val categoryNamesToStringRes = mapOf(
-            TrendingCategory.TRENDING to R.string.trends,
             TrendingCategory.GAMING to R.string.gaming,
             TrendingCategory.TRAILERS to R.string.trailers,
             TrendingCategory.PODCASTS to R.string.podcasts,

--- a/app/src/main/java/com/github/libretube/ui/models/HomeViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/HomeViewModel.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.withContext
 class HomeViewModel : ViewModel() {
     private val hideWatched get() = PreferenceHelper.getBoolean(HIDE_WATCHED_FROM_FEED, false)
 
-    val trending: MutableLiveData<List<StreamItem>> = MutableLiveData(null)
+    val trending: MutableLiveData<Pair<TrendingCategory, List<StreamItem>>> = MutableLiveData(null)
     val feed: MutableLiveData<List<StreamItem>> = MutableLiveData(null)
     val bookmarks: MutableLiveData<List<PlaylistBookmark>> = MutableLiveData(null)
     val playlists: MutableLiveData<List<Playlists>> = MutableLiveData(null)
@@ -62,7 +62,7 @@ class HomeViewModel : ViewModel() {
                     async { if (visibleItems.contains(PLAYLISTS)) loadPlaylists() },
                     async { if (visibleItems.contains(WATCHING)) loadVideosToContinueWatching() }
                 )
-                loadedSuccessfully.value = sections.any { !it.value.isNullOrEmpty() }
+                loadedSuccessfully.value = sections.any { it.isInitialized }
                 isLoading.value = false
             }
 
@@ -78,11 +78,13 @@ class HomeViewModel : ViewModel() {
         val region = PreferenceHelper.getTrendingRegion(context)
         val category = PreferenceHelper.getString(
             PreferenceKeys.TRENDING_CATEGORY,
-            TrendingCategory.TRENDING.name
+            TrendingCategory.LIVE.name
         ).let { TrendingCategory.valueOf(it) }
 
         runSafely(
-            onSuccess = { videos -> trending.updateIfChanged(videos) },
+            onSuccess = { videos ->
+                trending.updateIfChanged(Pair(category, videos))
+            },
             ioBlock = {
                 MediaServiceRepository.instance.getTrending(region, category).take(10).deArrow()
             }


### PR DESCRIPTION
As the `Trending` trending category is finally fully shutdown (i.e. the API doesn't work for me for the last few days anymore), hide the category from users and migrate any existing users to another category.

Also fixes an issue, where the wrong category items could be cached from trending.

Happy to also use another choice for the default category value.