### PR TITLE
feat: filter members-only videos from channel tab

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -52,6 +52,7 @@ import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExt
 import org.schabi.newpipe.extractor.stream.AudioStream
 import org.schabi.newpipe.extractor.stream.StreamInfo
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
+import org.schabi.newpipe.extractor.stream.StreamInfoItem.ContentAvailability
 import org.schabi.newpipe.extractor.stream.VideoStream
 
 
@@ -449,7 +450,9 @@ class NewPipeMediaServiceRepository : MediaServiceRepository {
         }
 
         return ChannelTabResponse(
-            content = items.mapNotNull { it.toContentItem() },
+            content = items.filterIsInstance<StreamInfoItem>()
+                .filter { it.contentAvailability == ContentAvailability.AVAILABLE || it.contentAvailability == ContentAvailability.UPCOMING }
+                .mapNotNull { it.toContentItem() },
             nextpage = newNextPage?.toNextPageString()
         )
     }


### PR DESCRIPTION
Applies the filtering of members-only videos to the channel page. As some channels upload a lot/mainly members-only content, it can be a hassle to find videos that are watchable in the app, which isn't a great user experience.

Ref: https://github.com/libre-tube/LibreTube/pull/7113