### PR TITLE
Update DownloadHelper.kt

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
@@ -52,7 +52,7 @@ object DownloadHelper {
         return PreferenceHelper.getString(
             PreferenceKeys.MAX_CONCURRENT_DOWNLOADS,
             "6"
-        ).toFloat().toInt()
+        ).toIntOrNull() ?: 6
     }
 
     fun startDownloadService(context: Context, downloadData: DownloadData? = null) {


### PR DESCRIPTION
Replaces unsafe toFloat().toInt() with safe toIntOrNull() to prevent crashes on invalid input while maintaining the same behavior for valid values.