### PR TITLE
fix: crash in trends when uploader url is unknown

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -108,7 +108,7 @@ fun StreamInfoItem.toStreamItem(
             ?.toLocalDate()
             ?.toString(),
         uploaderName = uploaderName,
-        uploaderUrl = uploaderUrl.toID(),
+        uploaderUrl = uploaderUrl?.toID(),
         uploaderAvatar = uploaderAvatarUrl ?: uploaderAvatars.maxByOrNull { it.height }?.url,
         thumbnail = thumbnails.maxByOrNull { it.height }?.url,
         duration = duration,


### PR DESCRIPTION
closes #7730
