### PR TITLE
Fix initial video player margin issue in PlayerFragment 

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -882,7 +882,6 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
         windowInsetsControllerCompat.isAppearanceLightStatusBars = false
 
         commonPlayerViewModel.isFullscreen.value = true
-
         updateFullscreenOrientation()
 
         commonPlayerViewModel.setSheetExpand(null)

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -713,6 +713,18 @@ abstract class CustomExoPlayerView(
                 marginEnd = horizontalMargin
             }
         }
+
+        binding.fullscreen.layoutParams = (binding.fullscreen.layoutParams as MarginLayoutParams).apply {
+            if (isFullscreen()) {
+                // Add extra bottom margin in fullscreen mode
+                bottomMargin = resources.getDimensionPixelSize(R.dimen.fullscreen_button_margin_bottom)
+                marginEnd = resources.getDimensionPixelSize(R.dimen.fullscreen_button_margin_end)
+            } else {
+                // Reset to default margin
+                bottomMargin = resources.getDimensionPixelSize(R.dimen.normal_button_margin_bottom)
+                marginEnd = resources.getDimensionPixelSize(R.dimen.normal_button_margin_end)
+            }
+        }
     }
 
     /**
@@ -843,6 +855,8 @@ abstract class CustomExoPlayerView(
             )
             subtitleView?.setBottomPaddingFraction(SubtitleView.DEFAULT_BOTTOM_PADDING_FRACTION)
         }
+
+        updateMarginsByFullscreenMode()
     }
 
     /**

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,9 @@
 <resources>
     <integer name="grid_items">1</integer>
     <integer name="grid_items_landscape">2</integer>
-
+    <dimen name="normal_button_margin_bottom">0dp</dimen>
+    <dimen name="normal_button_margin_end">0dp</dimen>
+    <dimen name="fullscreen_button_margin_bottom">5dp</dimen>
+    <dimen name="fullscreen_button_margin_end">3dp</dimen>
     <item name="landscape_player_constraint_width_percentage" type="dimen" format="float">0.55</item>
 </resources>


### PR DESCRIPTION
Hey there ! Thanks for the feedback

This is a follow-up to my previous PR #7743 . 

I’ve updated the implementation so that the margin change for the fullscreen button now occurs only when entering fullscreen mode. In normal mode, the margins remain untouched to keep the layout consistent.
Added a small tooltip for the fullscreen button as a friendly hint.
I’ve also reverted the unintended changes in app/src/main/res/values/languages.xml.
These updates should make the fullscreen layout behave smoothly and keep the UI consistent in both modes.