### PR TITLE
fix: home screen error not shown if homepage fails to load

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/models/HomeViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/HomeViewModel.kt
@@ -61,7 +61,7 @@ class HomeViewModel : ViewModel() {
                     async { if (visibleItems.contains(PLAYLISTS)) loadPlaylists() },
                     async { if (visibleItems.contains(WATCHING)) loadVideosToContinueWatching() }
                 )
-                loadedSuccessfully.value = sections.any { it.isInitialized }
+                loadedSuccessfully.value = sections.any { it.value != null }
                 isLoading.value = false
             }
 


### PR DESCRIPTION
That's a revert of changes you made @FineFindus.

On the current master branch, I can't seem to trigger the "Change instance" page when it fails to load.

If you have a better idea, we'll take that :)