### PR TITLE
fix(SubscriptionsFragment): reset scroll position when switching Chan…

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -146,7 +146,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
             selectedFilterGroup = group.children.indexOfFirst { it.id == group.checkedChipId }
 
             lifecycleScope.launch {
-                showFeed()
+                showFeed(restoreScrollState = false)
             }
         }
 


### PR DESCRIPTION
…nelGroups

Resets the scroll position to the top, when switching channel groups. This fixes an issue, where the user could end up in an unpredictable scroll position, simply due to switching channel groups, not allowing them to see later videos.