### PR TITLE
fix: display `ContentItem`s with `UNKNOWN` availability

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -120,7 +120,12 @@ fun StreamInfoItem.toStreamItem(
 }
 
 fun InfoItem.toContentItem() = when (this) {
-    is StreamInfoItem -> if (contentAvailability == ContentAvailability.AVAILABLE || contentAvailability == ContentAvailability.UPCOMING) ContentItem(
+    is StreamInfoItem -> if (contentAvailability in arrayOf(
+            ContentAvailability.AVAILABLE,
+            ContentAvailability.UPCOMING,
+            ContentAvailability.UNKNOWN
+        )
+    ) ContentItem(
         url = url.toID(),
         type = TYPE_STREAM,
         thumbnail = thumbnails.maxByOrNull { it.height }?.url.orEmpty(),

--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -148,7 +148,13 @@ class LocalFeedRepository : FeedRepository {
                 ChannelTabInfo.getInfo(NewPipeExtractorInstance.extractor, tab).relatedItems
             }.getOrElse { emptyList() }
         }.flatten().filterIsInstance<StreamInfoItem>()
-            .filter { it.contentAvailability == ContentAvailability.AVAILABLE || it.contentAvailability == ContentAvailability.UPCOMING }
+            .filter {
+                it.contentAvailability in arrayOf(
+                    ContentAvailability.AVAILABLE,
+                    ContentAvailability.UPCOMING,
+                    ContentAvailability.UNKNOWN
+                )
+            }
 
         val channelAvatar = channelInfo.avatars.maxByOrNull { it.height }?.url
         return related.map { item ->


### PR DESCRIPTION
Fixes an regression in the recent extractor updated, where shorts would no longer be displayed, as they had a `UNKNOWN` availability.

Ref: 338cd57e0a73bfa8290cf146c04179a319016bfa
Closes: https://github.com/libre-tube/LibreTube/issues/7794