### PR TITLE
fix: shared url not being retrieved properly

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/dialogs/ShareDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/ShareDialog.kt
@@ -122,7 +122,7 @@ class ShareDialog : DialogFragment() {
             .setView(binding.root)
             .setPositiveButton(R.string.share) { _, _ ->
                 val intent = Intent(Intent.ACTION_SEND)
-                    .putExtra(Intent.EXTRA_TEXT, binding.linkPreview.text)
+                    .putExtra(Intent.EXTRA_TEXT, binding.linkPreview.text.toString())
                     .putExtra(Intent.EXTRA_SUBJECT, shareableTitle)
                     .setType("text/plain")
                 val shareIntent = Intent.createChooser(intent, getString(R.string.shareTo))


### PR DESCRIPTION
In my case it fixes the issue described here #7828, but I'm still not sure why it's fixed. Cant find any documentation or any forum regarding this though.

Before the change, opening the shared url in Cromite crash that app, the log doesnt seem much of a help either. And some other apps just doesnt retrieve the url at all.

The documentation on [Intent.EXTRA_TEXT](https://developer.android.com/reference/android/content/Intent#EXTRA_TEXT) says that if you send `CharSequence`, the recipient must use `getCharSequence` to retrieve it, and so I thought "well, maybe that's the reason".
But then I tried to hardcode an url using a char sequence like:
```kotlin
val url: CharSequence = "https://youtu.be/something"
```
The recipient received that text just fine....

Any clue on this?