### PR TITLE
feat(Player): remove external player button

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/IntentHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/IntentHelper.kt
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Build
-import android.widget.Toast
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
@@ -49,23 +48,6 @@ object IntentHelper {
             IntentChooserSheet()
                 .apply { arguments = bundleOf(IntentData.url to link) }
                 .show(fragmentManager)
-        }
-    }
-
-    fun openWithExternalPlayer(context: Context, uri: Uri, title: String?, uploader: String?) {
-        // start an intent with video as mimetype using the hls stream
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, "video/*")
-            putExtra(Intent.EXTRA_TITLE, title)
-            putExtra("title", title)
-            putExtra("artist", uploader)
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-
-        try {
-            context.startActivity(intent)
-        } catch (e: Exception) {
-            Toast.makeText(context, R.string.no_player_found, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -744,23 +744,6 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
             newShareDialog.show(childFragmentManager, ShareDialog::class.java.name)
         }
 
-        binding.relPlayerExternalPlayer.setOnClickListener {
-            if (!this::streams.isInitialized || streams.hls == null) return@setOnClickListener
-
-            val context = requireContext()
-            lifecycleScope.launch {
-                val hlsStream = withContext(Dispatchers.IO) {
-                    ProxyHelper.rewriteUrlUsingProxyPreference(streams.hls!!).toUri()
-                }
-                IntentHelper.openWithExternalPlayer(
-                    context,
-                    hlsStream,
-                    streams.title,
-                    streams.uploader
-                )
-            }
-        }
-
         binding.relPlayerBackground.setOnClickListener {
             // start the background mode
             switchToAudioMode()

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -68,12 +68,6 @@
                         app:icon="@drawable/ic_headphones" />
 
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/relPlayer_external_player"
-                        style="@style/PlayerActionsButton"
-                        android:text="@string/external_player"
-                        app:icon="@drawable/ic_video" />
-
-                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/relPlayer_pip"
                         style="@style/PlayerActionsButton"
                         android:text="@string/pip"


### PR DESCRIPTION
Removes the option to use an external video player to play a stream, as it relied on the HLS media URL, which is no longer served by any of the clients we currently use. This is consistent with the previous removal of other HLS preferences.

Ref: https://github.com/libre-tube/LibreTube/pull/7508
Ref: https://github.com/libre-tube/LibreTube/issues/7482