### PR TITLE
feat(SponsorBlock): add Hook/Greetings category

### DIFF
--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -366,6 +366,7 @@
         <item>music_offtopic</item>
         <item>preview</item>
         <item>exclusive_access</item>
+        <item>hook</item>
     </string-array>
 
     <string-array name="sponsorBlockSegmentNames">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="category_highlight">Show video highlight</string>
     <string name="category_highlight_summary">Could either be the advertised title, the thumbnail or the most interesting part of the video. You can skip to it by tapping on it in the chapters section</string>
     <string name="category_exclusive_access">Exclusive Access</string>
+    <string name="category_hook">Hook/Greetings</string>
+    <string name="category_hook_summary">For narrative hooks that grab the viewer\'s attention (often as the first scene) by teasing or describing events from later in the same video or future episodes in a series</string>
     <string name="license">License</string>
     <string name="color_accent">Accents</string>
     <string name="color_red">Resting red</string>

--- a/app/src/main/res/xml/sponsorblock_settings.xml
+++ b/app/src/main/res/xml/sponsorblock_settings.xml
@@ -149,6 +149,12 @@
             app:summary="@string/category_preview_summary"
             app:title="@string/category_preview" />
 
+        <com.github.libretube.ui.views.SbSpinnerPreference
+            app:defaultValue="off"
+            app:key="hook_category"
+            app:summary="@string/category_hook_summary"
+            app:title="@string/category_hook" />
+
         <com.github.libretube.ui.views.ColorPreference
             android:dependency="sb_enable_custom_colors"
             app:defaultValue="#008fd6"


### PR DESCRIPTION
Adds support for the newly introduced hook category. By default, the category will neither be skipped, not displayed in the seek bar.

Ref: https://wiki.sponsor.ajay.app/w/Hook/Greetings