### PR TITLE
feat(Preferences): remove unused hidden quality settings

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -60,7 +60,6 @@ object PreferenceKeys {
     const val DEFAULT_RESOLUTION = "default_res"
     const val DEFAULT_RESOLUTION_MOBILE = "default_res_mobile"
     const val BUFFERING_GOAL = "buffering_goal"
-    const val PLAYER_AUDIO_FORMAT = "player_audio_format"
     const val PLAYER_AUDIO_QUALITY = "player_audio_quality"
     const val PLAYER_AUDIO_QUALITY_MOBILE = "player_audio_quality_mobile"
     const val DEFAULT_SUBTITLE = "default_subtitle"

--- a/app/src/main/res/xml/audio_video_settings.xml
+++ b/app/src/main/res/xml/audio_video_settings.xml
@@ -64,30 +64,6 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/quality">
-
-        <ListPreference
-            android:icon="@drawable/ic_videocam"
-            app:defaultValue="webm"
-            app:entries="@array/playerVideoFormat"
-            app:entryValues="@array/playerVideoFormatValues"
-            app:isPreferenceVisible="false"
-            app:key="player_video_format"
-            app:title="@string/playerVideoFormat"
-            app:useSimpleSummaryProvider="true" />
-
-        <ListPreference
-            android:icon="@drawable/ic_music"
-            app:defaultValue="all"
-            app:entries="@array/playerAudioFormat"
-            app:entryValues="@array/playerAudioFormatValues"
-            app:isPreferenceVisible="false"
-            app:key="player_audio_format"
-            app:title="@string/playerAudioFormat"
-            app:useSimpleSummaryProvider="true" />
-
-    </PreferenceCategory>
-
     <PreferenceCategory app:title="@string/advanced">
 
         <ListPreference


### PR DESCRIPTION
Removes the two hidden quality settings, as the're unused, leading to an empty preference category being displayed.

Closes: https://github.com/libre-tube/LibreTube/issues/7864