### PR TITLE
fix: sorting queue displays wrong current video

### DIFF
--- a/app/src/main/java/com/github/libretube/util/PlayingQueue.kt
+++ b/app/src/main/java/com/github/libretube/util/PlayingQueue.kt
@@ -130,7 +130,7 @@ object PlayingQueue {
     fun getStreams() = queue.toList()
 
     fun setStreams(streams: List<StreamItem>) = synchronized(queue) {
-        clear()
+        queue.clear()
 
         queue.addAll(streams)
     }


### PR DESCRIPTION
closes #7863
