### PR TITLE
fix: copying reply text to clipboard copies comment text

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/CommentsRepliesFragment.kt
@@ -48,8 +48,8 @@ class CommentsRepliesFragment : Fragment(R.layout.fragment_comments) {
                     bundleOf(IntentData.url to it),
                 )
             },
-            saveToClipboard = {
-                viewModel.saveToClipboard(view.context)
+            saveToClipboard = { replyComment ->
+                viewModel.saveToClipboard(view.context, replyComment)
             },
             navigateToChannel = { comment ->
                 NavigationHelper.navigateChannel(view.context, comment.commentorUrl)

--- a/app/src/main/java/com/github/libretube/ui/models/CommentRepliesViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentRepliesViewModel.kt
@@ -30,10 +30,10 @@ class CommentRepliesViewModel(
         .liveData
         .cachedIn(viewModelScope)
 
-    fun saveToClipboard(context: Context) {
+    fun saveToClipboard(context: Context, reply: Comment) {
         ClipboardHelper.save(
             context,
-            text = comment.commentText.orEmpty().parseAsHtml().toString(),
+            text = reply.commentText.orEmpty().parseAsHtml().toString(),
             notify = true
         )
     }


### PR DESCRIPTION
closes #7883
