### PR TITLE
fix(LocalFeedRepository): update subscribed channels

### DIFF
--- a/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SubscriptionHelper.kt
@@ -1,5 +1,6 @@
 package com.github.libretube.api
 
+import com.github.libretube.api.obj.Subscription
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.db.obj.SubscriptionsFeedItem
 import com.github.libretube.helpers.PreferenceHelper
@@ -57,4 +58,7 @@ object SubscriptionHelper {
 
     suspend fun submitFeedItemChange(feedItem: SubscriptionsFeedItem) =
         feedRepository.submitFeedItemChange(feedItem)
+
+    suspend fun submitSubscriptionChannelInfosChanged(subscriptions: List<Subscription>) =
+        subscriptionsRepository.submitSubscriptionChannelInfosChanged(subscriptions)
 }

--- a/app/src/main/java/com/github/libretube/db/dao/LocalSubscriptionDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/LocalSubscriptionDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.github.libretube.db.obj.LocalSubscription
 
 @Dao
@@ -16,6 +17,9 @@ interface LocalSubscriptionDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(localSubscriptions: List<LocalSubscription>)
+
+    @Update
+    suspend fun updateAll(localSubscriptions: List<LocalSubscription>)
 
     @Query("DELETE FROM localSubscription WHERE channelId = :channelId")
     suspend fun deleteById(channelId: String)

--- a/app/src/main/java/com/github/libretube/repo/LocalSubscriptionsRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalSubscriptionsRepository.kt
@@ -92,4 +92,15 @@ class LocalSubscriptionsRepository : SubscriptionsRepository {
     override suspend fun getSubscriptionChannelIds(): List<String> {
         return Database.localSubscriptionDao().getAll().map { it.channelId }
     }
+
+    override suspend fun submitSubscriptionChannelInfosChanged(subscriptions: List<Subscription>) {
+        Database.localSubscriptionDao().updateAll(subscriptions.map {
+            LocalSubscription(
+                it.url,
+                it.name,
+                it.avatar,
+                it.verified
+            )
+        })
+    }
 }

--- a/app/src/main/java/com/github/libretube/repo/SubscriptionsRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/SubscriptionsRepository.kt
@@ -9,4 +9,5 @@ interface SubscriptionsRepository {
     suspend fun importSubscriptions(newChannels: List<String>)
     suspend fun getSubscriptions(): List<Subscription>
     suspend fun getSubscriptionChannelIds(): List<String>
+    suspend fun submitSubscriptionChannelInfosChanged(subscriptions: List<Subscription>) {}
 }


### PR DESCRIPTION
Fixes an issue, where local subscriptions could display outdated information (i.e. having the wrong avatar/name), as the where never updated after being inserted into the database.
To avoid this, we use the channel info, which is fetched when refreshing the local feed to also update the local subscriptions.