### PR TITLE
feat(DASH): remove unsatisfiable filter

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/DashHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DashHelper.kt
@@ -41,11 +41,6 @@ object DashHelper {
         val adapSetInfos = ArrayList<AdapSetInfo>()
 
         for (stream in streams.videoStreams) {
-            // used to avoid including LBRY HLS inside the streams in the manifest
-            if (stream.format.orEmpty().contains("HLS")) {
-                continue
-            }
-
             // HDR is only supported by some new devices
             if (!supportsHdr && stream.quality.orEmpty().uppercase().contains("HDR")) {
                 continue


### PR DESCRIPTION
Removes the filter, that removes LBRY streams from appearing the dash manifest, as it could never be satisfied, due to checking the `format` property, which is always set to `video/mp4`. The correct check would've been to check the quality, however, considering there haven't been any issues with the false check, that doesn't appear to be necessary.

Ref: https://github.com/libre-tube/LibreTube/pull/7844
Ref: https://github.com/TeamPiped/Piped-Backend/blob/c5921f6b70762e78fed2cd0af8078c376b500228/src/main/java/me/kavin/piped/server/handlers/StreamHandlers.java#L216