### PR TITLE
fix(video player): preview frame jumping around the screen when seeking

### DIFF
--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -195,6 +195,16 @@
                 android:scaleType="fitCenter"
                 app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Small" />
 
+            <com.google.android.material.progressindicator.LinearProgressIndicator
+                android:id="@+id/previewProgressIndicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="?shapeCornerSizeSmall"
+                android:layout_gravity="bottom"
+                android:indeterminate="true"
+                android:visibility="invisible"
+                app:trackThickness="2.5dp" />
+
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Fix seekbar preview frame jumping around the screen due to previous coroutines are not being canceled when scrubbing the timebar.

UI changes:
The preview frame now moves as soon as the finger moves (without waiting for the frame image to finish fetching) and a little progress indicator is added below the preview frame to serve as a ui feedback when the frame is being loaded

https://github.com/user-attachments/assets/936395ab-3960-400f-aa94-912ae591f0f0



