### PR TITLE
feat(LocalFeed): prefer untranslated video title if available

### DIFF
--- a/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/NewPipeMediaServiceRepository.kt
@@ -102,7 +102,8 @@ fun StreamInfoItem.toStreamItem(
     return StreamItem(
         type = TYPE_STREAM,
         url = url.toID(),
-        title = name,
+        // if available prefer the RSS feed title, since it's untranslated
+        title = feedInfo?.name ?: name,
         uploaded = uploadDate?.offsetDateTime()?.toEpochSecond()?.times(1000) ?: -1,
         uploadedDate = textualUploadDate ?: uploadDate?.offsetDateTime()?.toLocalDateTime()
             ?.toLocalDate()


### PR DESCRIPTION
Fixes an issue, where the local subscription feed could show automatically translated video titles. As the RSS feed seems to contain the untranslated title, prefer that over the translated Innertube title.

Note that this only affects the (local) subscription feed, where we already fetch the RSS feed, and not the individual channel pages. 

Closes: https://github.com/libre-tube/LibreTube/issues/7832