### PR TITLE
feat(Preferences): remove codec preferences

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -73,8 +73,6 @@ object PreferenceKeys {
     const val DOUBLE_TAP_TO_SEEK = "double_tap_seek"
     const val ALTERNATIVE_PIP_CONTROLS = "alternative_pip_controls"
     const val SKIP_SILENCE = "skip_silence"
-    const val ENABLED_VIDEO_CODECS = "video_codecs"
-    const val ENABLED_AUDIO_CODECS = "audio_codecs"
     const val AUTOPLAY_COUNTDOWN = "autoplay_countdown"
     const val AUTO_FULLSCREEN_SHORTS = "auto_fullscreen_shorts"
     const val PLAY_AUTOMATICALLY = "play_automatically"

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -331,18 +331,6 @@ object PlayerHelper {
             false
         )
 
-    private val enabledVideoCodecs: String
-        get() = PreferenceHelper.getString(
-            PreferenceKeys.ENABLED_VIDEO_CODECS,
-            "all"
-        )
-
-    private val enabledAudioCodecs: String
-        get() = PreferenceHelper.getString(
-            PreferenceKeys.ENABLED_AUDIO_CODECS,
-            "all"
-        )
-
     val playAutomatically: Boolean
         get() = PreferenceHelper.getBoolean(
             PreferenceKeys.PLAY_AUTOMATICALLY,
@@ -886,32 +874,6 @@ object PlayerHelper {
             }
 
             else -> false
-        }
-    }
-
-    @OptIn(UnstableApi::class)
-    fun setPreferredCodecs(trackSelector: DefaultTrackSelector) {
-        trackSelector.updateParameters {
-            val enabledVideoCodecs = PlayerHelper.enabledVideoCodecs
-            if (enabledVideoCodecs != "all") {
-                // map the codecs to their corresponding mimetypes
-                val mimeType = when (enabledVideoCodecs) {
-                    "vp9" -> arrayOf("video/webm", "video/x-vnd.on2.vp9")
-                    "avc" -> arrayOf("video/mp4", "video/avc")
-                    else -> throw IllegalArgumentException()
-                }
-                this.setPreferredVideoMimeTypes(*mimeType)
-            }
-            val enabledAudioCodecs = PlayerHelper.enabledAudioCodecs
-            if (enabledAudioCodecs != "all") {
-                // map the codecs to their corresponding mimetypes
-                val mimeType = when (enabledAudioCodecs) {
-                    "opus" -> arrayOf("audio/opus")
-                    "mp4" -> arrayOf("audio/mp4a-latm")
-                    else -> throw IllegalArgumentException()
-                }
-                this.setPreferredAudioMimeTypes(*mimeType)
-            }
         }
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -129,6 +129,9 @@ object PreferenceHelper {
                 "download_folder",
             ).map { key -> remove(key) }
         },
+        PreferenceMigration(3, 4) {
+            listOf("video_codecs", "audio_codecs").map { remove(it) }
+        },
     )
 
     /**

--- a/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
@@ -316,8 +316,6 @@ abstract class AbstractPlayerService : MediaLibraryService(), MediaLibrarySessio
         player.addListener(playerListener)
         this.exoPlayer = player
 
-        PlayerHelper.setPreferredCodecs(trackSelector)
-
         val forwardingPlayer = MediaSessionForwarder(player)
         mediaLibrarySession = MediaLibrarySession.Builder(this, forwardingPlayer, this)
             .setId(this.javaClass.name)

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -276,30 +276,6 @@
         <item>enabled</item>
     </string-array>
 
-    <string-array name="videoCodecs">
-        <item>@string/all</item>
-        <item>VP9</item>
-        <item>AVC</item>
-    </string-array>
-
-    <string-array name="videoCodecValues">
-        <item>all</item>
-        <item>vp9</item>
-        <item>avc</item>
-    </string-array>
-
-    <string-array name="audioCodecs">
-        <item>@string/all</item>
-        <item>opus</item>
-        <item>mp4</item>
-    </string-array>
-
-    <string-array name="audioCodecValues">
-        <item>all</item>
-        <item>opus</item>
-        <item>mp4</item>
-    </string-array>
-
     <string-array name="watchPosition">
         <item>@string/always</item>
         <item>@string/videos</item>

--- a/app/src/main/res/xml/audio_video_settings.xml
+++ b/app/src/main/res/xml/audio_video_settings.xml
@@ -64,26 +64,4 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/advanced">
-
-        <ListPreference
-            android:entries="@array/videoCodecs"
-            android:entryValues="@array/videoCodecValues"
-            android:icon="@drawable/ic_equalizer"
-            android:key="video_codecs"
-            app:defaultValue="all"
-            app:title="@string/codecs"
-            app:useSimpleSummaryProvider="true" />
-
-        <ListPreference
-            android:entries="@array/audioCodecs"
-            android:entryValues="@array/audioCodecValues"
-            android:icon="@drawable/ic_equalizer"
-            android:key="audio_codecs"
-            app:defaultValue="all"
-            app:title="@string/audio_codecs"
-            app:useSimpleSummaryProvider="true" />
-
-    </PreferenceCategory>
-
 </PreferenceScreen>


### PR DESCRIPTION
Removes support for setting the preferred audio/video codec. This preferences can be quite confusing to new, as well experienced users, since it's not immediately clear which choice is optimal (not that there necessarily is one). It also prohibited more modern codecs (such as AV1) being chosen automatically, when the preference was not set to `all`, leading to a worse user experience

Overall it's better to let the player, which has more information, decide what format to use.

Ref: https://github.com/libre-tube/LibreTube/issues/7850