### PR TITLE
build: optimize protobuf classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,6 +19,9 @@
 # prevents obfuscation in debug logs
 -dontobfuscate
 
+# optimise protobuf classes
+-shrinkunusedprotofields
+
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
@@ -116,7 +119,6 @@
 -keep class com.github.libretube.ui.preferences.** { *; }
 
 ## Rules for NewPipeExtractor
--keep class org.schabi.newpipe.extractor.services.youtube.protos.** { *; }
 -keep class org.schabi.newpipe.extractor.timeago.patterns.** { *; }
 -keep class org.mozilla.javascript.** { *; }
 -keep class org.mozilla.javascript.engine.** { *; }


### PR DESCRIPTION
Currently, we keep all of NewPipeExtractors protobuf classes. This is overly broad as it disables all of R8's optimizations (e.g. it keeps unused fields and classes), however when not set, R8 removes all protobuf classes. R8 has an undocumented flag, which keeps and optimizes protobuf-generated classes. It also saves us from manually excluding all (new) protobuf classes.

While this currently has little impact, as all the generated protobuf classes are used, it will have a larger impact once https://github.com/libre-tube/LibreTube/pull/7689 is merged, which brings quite a few (unused) generated protobuf classes.

Ref: https://github.com/libre-tube/LibreTube/pull/7571
Ref: https://issuetracker.google.com/issues/144631039