### PR TITLE
build: add support for user-provided keystore for local release builds without a hassle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ app/release/
 # Keystore files
 *.jks
 *.keystore
+keystore.properties
 
 # Google Services (e.g. APIs or Firebase)
 google-services.json


### PR DESCRIPTION
Closes #7970

Right now it is a hassle cause those changes need to be added each time for building from sources.
Are those changes affect building release artifacts without providing keystore.properties? No
Are those changes affect building debug artifacts without providing keystore.properties? No
Are those changes affect building release artifacts with providing keystore.properties? Yes