### PR TITLE
(BUG): Made name and url optional for deserilization

### DIFF
--- a/app/src/main/java/com/github/libretube/obj/YouTubeWatchHistoryChannelInfo.kt
+++ b/app/src/main/java/com/github/libretube/obj/YouTubeWatchHistoryChannelInfo.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class YouTubeWatchHistoryChannelInfo(
-    val name: String? = null,
+    val name: String,
     val url: String? = null
 )


### PR DESCRIPTION
Url was required at the time of deserilization i have made it optional 

Bug #7972 