### PR TITLE
fix: Crash when starting online stream while offline stream in progress

### DIFF
--- a/app/src/main/java/com/github/libretube/services/OfflinePlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/OfflinePlayerService.kt
@@ -112,7 +112,7 @@ open class OfflinePlayerService : AbstractPlayerService() {
 
         val downloadWithItems = withContext(Dispatchers.IO) {
             Database.downloadDao().findById(videoId)
-        }!!
+        } ?: return
         this.downloadWithItems = downloadWithItems
 
         PlayingQueue.updateCurrent(downloadWithItems.download.toStreamItem())


### PR DESCRIPTION
Fixes the crash that occurs when a new online video is played, while the offline video is playing.

Closes: https://github.com/libre-tube/LibreTube/issues/7987

Screen recording:

https://github.com/user-attachments/assets/cf387b52-4d14-4de1-b2a7-89cdba0a054d

