### PR TITLE
build: drop support for split-abi apks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,16 +86,6 @@ android {
         jvmTarget = "17"
     }
 
-    // Comment this block if issues occur while generating the baseline profile
-    splits {
-        abi {
-            isEnable = true
-            reset()
-            include("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
-            isUniversalApk = true
-        }
-    }
-
     packaging {
         jniLibs.excludes.add("lib/armeabi-v7a/*_neon.so")
     }


### PR DESCRIPTION
As we do not ship any native modules (and haven't done so since we removed cronet in https://github.com/libre-tube/LibreTube/commit/93275b9) the additional split [ABI apks are identical to the universal apk](
https://github.com/libre-tube/NightlyBuilds/blob/main/checksums). Dropping them simplifies our build process, avoids uploading  and makes it easier for users to download the 'right' apk.