### PR TITLE
fix: initialize `brightnessHelper` before `playerGestureController`

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -142,8 +142,8 @@ abstract class CustomExoPlayerView(
     }
 
     init {
-        playerGestureController = PlayerGestureController(activity, this)
         brightnessHelper = BrightnessHelper(activity)
+        playerGestureController = PlayerGestureController(activity, this)
         audioHelper = AudioHelper(context)
         fullscreenGestureAnimationController = FullscreenGestureAnimationController(
             playerView = this,


### PR DESCRIPTION
Fixes a regeression that could result in the player view crashing, as the `playerGestureController` was initialized after the `brightnessHelper`, but required it to function.

Ref: 61f3201b35e5a3381b25224daf1ae0227a4e02e2