### PR TITLE
feat: always remember playback speed

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -46,7 +46,6 @@ object PreferenceKeys {
     const val AUTO_FULLSCREEN = "auto_fullscreen"
     const val AUTOPLAY = "autoplay"
     const val RELATED_STREAMS = "related_streams_toggle"
-    const val REMEMBER_PLAYBACK_SPEED = "remember_playback_speed"
     const val PLAYBACK_SPEED = "playback_speed"
     const val FULLSCREEN_ORIENTATION = "fullscreen_orientation"
     const val PAUSE_ON_SCREEN_OFF = "pause_screen_off"

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -132,6 +132,9 @@ object PreferenceHelper {
         PreferenceMigration(3, 4) {
             listOf("video_codecs", "audio_codecs").map { remove(it) }
         },
+        PreferenceMigration(4, 5) {
+            remove("remember_playback_speed")
+        },
     )
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
@@ -130,10 +130,8 @@ class PlaybackOptionsSheet(
         binding.semitoneEditText.setText((binding.pitch.value).round(2).toString())
         binding.pitchResetButton.isGone = binding.pitch.value == 0f
 
-        if (PreferenceHelper.getBoolean(PreferenceKeys.REMEMBER_PLAYBACK_SPEED, true)) {
-            val currentSpeed = player.playbackParameters.speed.toString()
-            PreferenceHelper.putString(PreferenceKeys.PLAYBACK_SPEED, currentSpeed)
-        }
+        val currentSpeed = player.playbackParameters.speed.toString()
+        PreferenceHelper.putString(PreferenceKeys.PLAYBACK_SPEED, currentSpeed)
     }
 
     private fun clearEditTextFocusAndHideKeyboard() {

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -141,29 +141,6 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/defaults">
-
-        <SwitchPreferenceCompat
-            android:icon="@drawable/ic_headphones"
-            android:summaryOff="@string/disabled"
-            android:summaryOn="@string/enabled"
-            app:defaultValue="true"
-            app:disableDependentsState="true"
-            app:key="remember_playback_speed"
-            app:title="@string/remember_playback_speed" />
-
-        <com.github.libretube.ui.views.SliderPreference
-            android:dependency="remember_playback_speed"
-            android:icon="@drawable/ic_speed"
-            app:defValue="1.0"
-            app:key="playback_speed"
-            app:stepSize="0.05"
-            app:title="@string/playback_speed"
-            app:valueFrom="0.2"
-            app:valueTo="4.0" />
-
-    </PreferenceCategory>
-
     <PreferenceCategory app:title="@string/misc">
 
         <com.github.libretube.ui.preferences.EditNumberPreference


### PR DESCRIPTION
Removes the preference to set the playback speed, instead the last set playback speed is remembered. This improves the UX by reducing the available options, as well providing a consistent experience, as the manually set playback speed was already remembered per player session, which is no longer recreated for each video.

Ref: https://github.com/libre-tube/LibreTube/issues/7961
Ref: https://github.com/libre-tube/LibreTube/pull/4901