### PR TITLE
fix: avoid leaking `SubscriptionsFragment`

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -163,7 +163,7 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
                 super.onScrollStateChanged(recyclerView, newState)
                 viewModel.subFeedRecyclerViewState =
                     recyclerView.layoutManager?.onSaveInstanceState()?.takeIf {
-                        binding.subFeed.computeVerticalScrollOffset() != 0
+                        recyclerView.computeVerticalScrollOffset() != 0
                     }
             }
         })


### PR DESCRIPTION
Currently we leak the `SubscriptionsFragment`, this seems to be due to a cyclic reference between the `subFeed` scroll listener and the `SubscriptionsFragment` binding. We can avoided it, by simply using the already existing `recyclerView` in the listener.