### PR TITLE
fix: prevent crash when switching apps and clicking audio button early

### DIFF
--- a/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
+++ b/app/src/main/java/com/github/libretube/services/AbstractPlayerService.kt
@@ -307,6 +307,10 @@ abstract class AbstractPlayerService : MediaLibraryService(), MediaLibrarySessio
 
     @OptIn(UnstableApi::class)
     private fun createPlayerAndMediaSession() {
+        // Release existing session if it exists to prevent ID collision (fixes #8031)
+        mediaLibrarySession?.release()
+        mediaLibrarySession = null
+
         val trackSelector = DefaultTrackSelectorWithAudioQualitySupport(this)
         this.trackSelector = trackSelector
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -737,7 +737,8 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
         }
 
         binding.relPlayerBackground.setOnClickListener {
-            // start the background mode
+            // start the background mode (guard for #8010)
+            if (!::playerController.isInitialized) return@setOnClickListener
             switchToAudioMode()
         }
 
@@ -820,6 +821,9 @@ class PlayerFragment : Fragment(R.layout.fragment_player), OnlinePlayerOptions {
     }
 
     fun switchToAudioMode() {
+        // Guard against uninitialized playerController (fixes #8010)
+        if (!::playerController.isInitialized) return
+
         playerController.sendCustomCommand(
             AbstractPlayerService.runPlayerActionCommand,
             bundleOf(PlayerCommand.TOGGLE_AUDIO_ONLY_MODE.name to true)


### PR DESCRIPTION
## Summary

This PR fixes two crash bugs:

### Fix #8031: Session ID collision when switching apps
- **Root cause**: When rapidly switching apps, the old service's onDestroy() uses a 50ms delay before releasing the MediaLibrarySession. If a new service starts before completion, both try to use the same session ID, causing an IllegalStateException.
- **Fix**: Release existing session (if any) at the start of createPlayerAndMediaSession() before creating a new one.

### Fix #8010: Crash when clicking Audio button before player loads
- **Root cause**: The switchToAudioMode() function accesses playerController without checking if it's initialized. If the user clicks the Audio button before the player service connects, it throws UninitializedPropertyAccessException.
- **Fix**: Add initialization guard if (!::playerController.isInitialized) return before accessing the property.

## Testing
- Tested on physical Android device
- Rapidly switching apps no longer causes crashes
- Pressing Audio button before player loads no longer crashes (gracefully ignored)