### PR TITLE
Prevent video from moving to the start when re-adding to local playlist

### DIFF
--- a/app/src/main/java/com/github/libretube/db/dao/LocalPlaylistsDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/LocalPlaylistsDao.kt
@@ -28,6 +28,9 @@ interface LocalPlaylistsDao {
     @Insert
     suspend fun addPlaylistVideo(playlistVideo: LocalPlaylistItem)
 
+    @Update
+    suspend fun updatePlaylistVideo(playlistVideo: LocalPlaylistItem)
+
     @Delete
     suspend fun removePlaylistVideo(playlistVideo: LocalPlaylistItem)
 
@@ -37,6 +40,7 @@ interface LocalPlaylistsDao {
     @Query("DELETE FROM localPlaylistItem WHERE playlistId = :playlistId AND videoId = :videoId")
     suspend fun deletePlaylistItemsByVideoId(playlistId: String, videoId: String)
 
-    @Query("SELECT EXISTS(SELECT 1 FROM localPlaylistItem WHERE playlistId = :playlistId AND videoId = :videoId)")
-    suspend fun videoExistsInPlaylist(playlistId: String, videoId: String): Boolean
+    @Query("SELECT * FROM localPlaylistItem WHERE playlistId = :playlistId AND videoId = :videoId LIMIT 1")
+    suspend fun getPlaylistVideo(playlistId: String, videoId: String): LocalPlaylistItem?
+
 }

--- a/app/src/main/java/com/github/libretube/repo/LocalPlaylistsRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalPlaylistsRepository.kt
@@ -45,9 +45,14 @@ class LocalPlaylistsRepository: PlaylistRepository {
         for (video in videos) {
             val localPlaylistItem = video.toLocalPlaylistItem(playlistId)
 
-            val videoExists = DatabaseHolder.Database.localPlaylistsDao()
-                .videoExistsInPlaylist(playlistId, localPlaylistItem.videoId)
-            if (videoExists) continue
+            val existingVideo = DatabaseHolder.Database.localPlaylistsDao()
+                .getPlaylistVideo(playlistId, localPlaylistItem.videoId)
+            if (existingVideo != null) {
+                // update existing video metadata
+                localPlaylistItem.id = existingVideo.id
+                DatabaseHolder.Database.localPlaylistsDao().updatePlaylistVideo(localPlaylistItem)
+                continue
+            }
 
             // add the new video to the database
             DatabaseHolder.Database.localPlaylistsDao().addPlaylistVideo(localPlaylistItem)


### PR DESCRIPTION
When you try to add a video that's already in a local playlist, it now gets silently skipped instead of being moved to the start of the playlist

Why?
* Users don't expect videos to jump around when re-adding them
* Keeps playlist order intact
* Matches expected behavior from YouTube, etc