### PR TITLE
Fix page reload error

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ constraintlayout = "2.2.1"
 loggingInterceptor = "4.12.0"
 material = "1.14.0-alpha08"
 navigation = "2.8.9"
-newpipeextractor = "70be3a4"
+newpipeextractor = "v0.25.1"
 preference = "1.2.1"
 extJunit = "1.3.0"
 espresso = "3.7.0"
@@ -62,7 +62,7 @@ androidx-media3-exoplayer-hls = { group = "androidx.media3", name="media3-exopla
 androidx-media3-exoplayer-dash = { group = "androidx.media3", name="media3-exoplayer-dash", version.ref="media3" }
 androidx-media3-session = { group="androidx.media3", name="media3-session", version.ref="media3" }
 androidx-media3-ui = { group="androidx.media3", name="media3-ui", version.ref="media3" }
-newpipeextractor = { module = "com.github.libre-tube:NewPipeExtractor", version.ref = "newpipeextractor" }
+newpipeextractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version.ref = "newpipeextractor" }
 square-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
 desugaring = { group = "com.android.tools", name = "desugar_jdk_libs_nio", version.ref = "desugaring" }


### PR DESCRIPTION
Closes https://github.com/libre-tube/LibreTube/issues/8099

This PR switches back to the official NewPipeExtractor. The fork implements a fix that has been merged in the official extractor, so I assume it is safe to switch back to the original extractor: https://github.com/TeamNewPipe/NewPipe/issues/12907