### PR TITLE
build: fix release build error

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -128,6 +128,7 @@
 -dontwarn javax.script.**
 -keep class jdk.dynalink.** { *; }
 -dontwarn jdk.dynalink.**
+-dontwarn com.google.re2j.**
 
 # This is generated automatically by the Android Gradle plugin.
 -dontwarn java.beans.BeanDescriptor


### PR DESCRIPTION
These are optional classes, with `jsoup` safely falling back to default Java regex.

Ref: https://github.com/jhy/jsoup/issues/2459
Ref: https://github.com/TeamNewPipe/NewPipe/commit/6c5d58bed3a4e7945580c644a875aa1addf3a89b