### PR TITLE
fix: subscription list is displaying outdated data

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/SubscriptionsFragment.kt
@@ -98,9 +98,6 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         if (viewModel.videoFeed.value == null) {
             viewModel.fetchFeed(requireContext(), forceRefresh = false)
         }
-        if (viewModel.subscriptions.value == null) {
-            viewModel.fetchSubscriptions(requireContext())
-        }
 
         // only restore the previous state (i.e. scroll position) the first time the feed is shown
         // any other feed updates are caused by manual refreshing and thus should reset the scroll
@@ -131,7 +128,6 @@ class SubscriptionsFragment : DynamicLayoutManagerFragment(R.layout.fragment_sub
         }
 
         binding.subRefresh.setOnRefreshListener {
-            viewModel.fetchSubscriptions(requireContext())
             viewModel.fetchFeed(requireContext(), forceRefresh = true)
         }
 


### PR DESCRIPTION
Fetch subscription list on every lifecycle started in `SubscriptionsBottomSheet` and `EditChannelGroupSheet` to ensure the latest data is displayed.

- This fixes an issue where recently unsubbed channels are being re-shown when these sheets opened. This change also make sure newly subbed channels are showing without the need to refresh the feed first.

- `fetchSubscriptions()` function in `SubscriptionsFragment` is removed because I think we dont need that anymore?
---
While making this patch, I came across this line in `MainActivity.setupSubscriptionsBadge()`:
 https://github.com/libre-tube/LibreTube/blob/141b5fb70da1793ac8ba19c4692900649cc07192/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt#L270  
Is this a typo and supposed to be `getFeed()`?