### PR TITLE
feat: use RYD Proxy API

### DIFF
--- a/app/src/main/java/com/github/libretube/api/ExternalApi.kt
+++ b/app/src/main/java/com/github/libretube/api/ExternalApi.kt
@@ -21,7 +21,7 @@ import retrofit2.http.Url
 
 private const val GITHUB_API_URL = "https://api.github.com/repos/libre-tube/LibreTube/releases/latest"
 private const val SB_API_URL = "https://sponsor.ajay.app"
-private const val RYD_API_URL = "https://returnyoutubedislikeapi.com"
+private const val RYD_API_URL = "https://ryd-proxy.kavin.rocks/"
 private const val GOOGLE_API_KEY = "AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw"
 const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.3"
 private const val PIPED_INSTANCES_URL = "https://piped-instances.kavin.rocks"


### PR DESCRIPTION
Switches from the default Return YouTube Dislike API, as it theoretically allows for tracking the user's viewing habits, to the Piped RYD Proxy. This has been discussed before, but was conclude to not be necessary. However, recently the developer added a premium version that allows [access to some analytics](https://www.patreon.com/posts/advanced-update-141941708), which again raises privacy concerns.

Ref: https://github.com/libre-tube/LibreTube/pull/6483