### PR TITLE
feat: enable memory tagging

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/BaseTheme"
+        android:memtagMode="async"
         tools:targetApi="tiramisu">
 
         <activity


### PR DESCRIPTION
Opts into Android’s/ARM’s Memory Tagging Extension (MTE) to improve memory safety and detection of spatial/temporal memory errors on supported devices. This is particularly relevant to us, as we're largely parsing external media, which is common source of vulnerabilities.
MTE makes invalid memory accesses much harder, as the system tracks each pointer and the memory it belongs to.

Support is limited to devices with explicit hardware support (Google Pixel 8 and later). MTE has a small performance overhead (as each pointer needs to be checked) and may lead to crashes when an invalid memory access happens (which is preferable to an exploitable state). 
Unfortunately, I do not have such hardware, however, MTE is already [enabled on GrapheneOS](https://grapheneos.social/@GrapheneOS/114721878120169404), which appears to be used by quite of few of our users.

Ref: https://source.android.com/docs/security/test/memory-safety/arm-mte#enable-mte-apps
Ref: https://thore.io/posts/2025/09/introduction-to-arm-memory-tagging-extensions/