### PR TITLE
fix(Local/RYD): use correct API URL

### DIFF
--- a/app/src/main/java/com/github/libretube/api/ExternalApi.kt
+++ b/app/src/main/java/com/github/libretube/api/ExternalApi.kt
@@ -21,7 +21,7 @@ import retrofit2.http.Url
 
 private const val GITHUB_API_URL = "https://api.github.com/repos/libre-tube/LibreTube/releases/latest"
 private const val SB_API_URL = "https://sponsor.ajay.app"
-private const val RYD_API_URL = "https://ryd-proxy.kavin.rocks/"
+private const val RYD_API_URL = "https://ryd-proxy.kavin.rocks"
 private const val GOOGLE_API_KEY = "AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw"
 const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.3"
 private const val PIPED_INSTANCES_URL = "https://piped-instances.kavin.rocks"


### PR DESCRIPTION
Fixes a regression in 906fd0a62195820d69fb14c068069d84f9ab0761, where both the base API URL and the path contained a `/`, leading to an invalid URL, causing no dislikes to be shown.

Ref: https://github.com/libre-tube/LibreTube/pull/8150