### PR TITLE
fix: hide chapter button in audio mode when video has no chapters

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -465,7 +465,15 @@ class AudioPlayerFragment : Fragment(R.layout.fragment_audio_player), AudioPlaye
                 _binding?.openChapters?.isVisible = !chapters.isNullOrEmpty()
             }
         })
-        playerController?.mediaMetadata?.let { updateStreamInfo(it) }
+        playerController?.mediaMetadata?.let { mediaMetadata ->
+            updateStreamInfo(mediaMetadata)
+            // Set initial chapter button visibility based on current metadata
+            val chapters: List<ChapterSegment>? =
+                mediaMetadata.extras?.getString(IntentData.chapters)?.let {
+                    JsonHelper.json.decodeFromString(it)
+                }
+            binding.openChapters.isVisible = !chapters.isNullOrEmpty()
+        }
 
         initializeSeekBar()
 

--- a/app/src/main/res/layout/fragment_audio_player.xml
+++ b/app/src/main/res/layout/fragment_audio_player.xml
@@ -263,6 +263,7 @@
                     android:id="@+id/open_chapters"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:visibility="gone"
                     app:icon="@drawable/ic_frame" />
 
                 <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
## Summary

Fixes #8027 — The chapter button in the audio player was shown even when the video has no chapters, specifically when switching from video mode to audio mode.

## Root Cause

Two issues:
1. The `open_chapters` button had no default visibility set in the XML layout, so it defaults to `visible`
2. When connecting to the player service in `handleServiceConnection()`, the initial metadata was used to update stream info but the chapter button visibility was not checked — it was only updated in `onMediaMetadataChanged`, which doesn't fire if the metadata is already set

## Changes

- **`fragment_audio_player.xml`**: Set default visibility of the chapter button to `gone`
- **`AudioPlayerFragment.kt`**: Added initial chapter visibility check when the player service connects, using the same logic as `onMediaMetadataChanged`

## Testing

- Open a video without chapters → switch to audio mode → chapter button is hidden ✅
- Open a video with chapters → switch to audio mode → chapter button is shown ✅
- Open audio player directly for a video without chapters → chapter button is hidden ✅