### PR TITLE
refactor: mark required SponsorBlock properties as non-null

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/Segment.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/Segment.kt
@@ -13,34 +13,32 @@ import kotlinx.serialization.Transient
 @Serializable
 @Parcelize
 data class Segment(
-    @SerialName("UUID") val uuid: String? = null,
-    val actionType: String? = null,
-    val category: String? = null,
+    @SerialName("UUID") val uuid: String,
+    val actionType: String,
+    val category: String,
     val description: String? = null,
-    val locked: Int? = null,
+    val locked: Int,
     private val segment: List<Float> = listOf(),
     val userID: String? = null,
-    val videoDuration: Double? = null,
-    val votes: Int? = null,
+    val videoDuration: Double,
+    val votes: Int,
     var skipped: Boolean = false
 ): Parcelable {
     @Transient
     @IgnoredOnParcel
     val segmentStartAndEnd = FloatFloatPair(segment[0], segment[1])
 
-    // reminder: all the attributed that are asserted as non-null here are declared non-null by the
-    // SponsorBlock API, so it's safe to assert they're not null (if we trust the SponsorBlock API docs)
     fun toDownloadSegment(videoId: String): DownloadSponsorBlockSegment = DownloadSponsorBlockSegment(
-        uuid = uuid!!,
+        uuid = uuid,
         videoId = videoId,
         startTime = segmentStartAndEnd.first,
         endTime = segmentStartAndEnd.second,
-        actionType = actionType!!,
-        category = category!!,
+        actionType = actionType,
+        category = category,
         description = description,
-        locked = locked!!,
-        videoDuration = videoDuration!!.toFloat(),
-        votes = votes!!
+        locked = locked,
+        videoDuration = videoDuration.toFloat(),
+        votes = votes
     )
 
     companion object {


### PR DESCRIPTION
These values are guaranteed by the API to be always set, so the should be marked as non-null.

Ref: https://github.com/libre-tube/LibreTube/pull/8204#discussion_r2835163436