### PR TITLE
feat(Instances): always show hard-coded fallback instances

### DIFF
--- a/app/src/main/java/com/github/libretube/api/ExternalApi.kt
+++ b/app/src/main/java/com/github/libretube/api/ExternalApi.kt
@@ -25,15 +25,11 @@ private const val RYD_API_URL = "https://ryd-proxy.kavin.rocks"
 private const val GOOGLE_API_KEY = "AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw"
 const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.3"
 private const val PIPED_INSTANCES_URL = "https://piped-instances.kavin.rocks"
-private const val PIPED_INSTANCES_MARKDOWN_URL = "https://raw.githubusercontent.com/TeamPiped/documentation/refs/heads/main/content/docs/public-instances/index.md"
 
 interface ExternalApi {
     // only for fetching servers list
     @GET
     suspend fun getInstances(@Url url: String = PIPED_INSTANCES_URL): List<PipedInstance>
-
-    @GET
-    suspend fun getInstancesMarkdown(@Url url: String = PIPED_INSTANCES_MARKDOWN_URL): Response<ResponseBody>
 
     @GET("config")
     suspend fun getInstanceConfig(@Url url: String): PipedConfig

--- a/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/InstanceRepository.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 class InstanceRepository {
-
     /**
      * Fetch official public instances from kavin.rocks
      */
@@ -17,19 +16,10 @@ class InstanceRepository {
         }
     }
 
-    suspend fun getInstancesFallback(): List<PipedInstance> = withContext(Dispatchers.IO) {
-        return@withContext try {
-            RetrofitInstance.externalApi.getInstancesMarkdown().body()!!.string().lines().reversed()
-                .takeWhile { !it.startsWith("---") }
-                .filter { it.isNotBlank() }
-                .map { line ->
-                    val infoParts = line.split("|").map { it.trim() }
-
-                    PipedInstance(name = infoParts[0], apiUrl = infoParts[1], locations = infoParts[2], cdn = infoParts[3] == "Yes")
-                }
-        } catch (_: Exception) {
-            // worst case scenario: only return official instance
-            return@withContext listOf(PipedInstance(name = PIPED_API_URL.toHttpUrl().host, apiUrl = PIPED_API_URL))
-        }
+    companion object {
+        /**
+         * Hardcoded list of fallback instances.
+         */
+        val FALLBACK_INSTANCES = listOf(PipedInstance(name = PIPED_API_URL.toHttpUrl().host, apiUrl = PIPED_API_URL));
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/models/InstancesModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/InstancesModel.kt
@@ -28,9 +28,9 @@ class InstancesModel : ViewModel() {
     private val instancesRepo = InstanceRepository()
 
     suspend fun fetchCustomInstances(onIntermediateError: (Throwable) -> Unit) {
-        val instances =instancesRepo.getInstances()
+        val instances = instancesRepo.getInstances()
             .onFailure { onIntermediateError(it) }
-            .getOrElse { instancesRepo.getInstancesFallback() }
+            .getOrElse { InstanceRepository.FALLBACK_INSTANCES }
 
         publicInstances.emit(instances)
     }

--- a/app/src/main/java/com/github/libretube/ui/models/WelcomeViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/WelcomeViewModel.kt
@@ -40,7 +40,7 @@ class WelcomeViewModel(
                 }
                 .onFailure {
                     savedStateHandle[UI_STATE] = _uiState.value.copy(
-                        instances = instanceRepository.getInstancesFallback(),
+                        instances = InstanceRepository.FALLBACK_INSTANCES,
                         error = R.string.failed_fetching_instances,
                     )
                 }


### PR DESCRIPTION
Avoids using the soft-fallback of fetching the Markdown list of available instances, as it is severely out-of-date, misleading users when trying to sign-up into offline instances. Instead, we always fallback to the hardcoded official instance (this isn't great either, as the official instance also isn't online often).