### PR TITLE
feat(video player): properly increase timebar touch area

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -331,11 +331,6 @@ class CustomExoPlayerView(
             if (isLive) player?.let { it.seekTo(it.duration) }
         }
 
-        // forward touch events to the time bar for better accessibility
-        binding.progressBar.setOnTouchListener { _, motionEvent ->
-            binding.exoProgress.onTouchEvent(motionEvent)
-        }
-
         updateCurrentPosition()
 
         activity.supportFragmentManager.setFragmentResultListener(
@@ -1171,8 +1166,8 @@ class CustomExoPlayerView(
      */
     fun updateMarginsByFullscreenMode() {
         // add a larger bottom margin to the time bar in landscape mode
-        binding.progressBar.updateLayoutParams<MarginLayoutParams> {
-            bottomMargin = (if (isFullscreen()) 20f else 10f).dpToPx()
+        binding.exoProgress.updateLayoutParams<MarginLayoutParams> {
+            bottomMargin = (if (isFullscreen()) 20f else 0f).dpToPx()
         }
 
         updateTopBarMargin()

--- a/app/src/main/res/layout/exo_styled_player_control_view.xml
+++ b/app/src/main/res/layout/exo_styled_player_control_view.xml
@@ -323,7 +323,8 @@
                 app:played_color="?attr/colorSecondary"
                 app:scrubber_color="?attr/colorSecondary"
                 app:scrubber_dragged_size="16dp"
-                app:scrubber_enabled_size="12dp" />
+                app:scrubber_enabled_size="12dp"
+                app:touch_target_height="35dp" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Turns out these lines 
https://github.com/libre-tube/LibreTube/blob/14f2b3bb6606515f4165eb6006e1ed22c4eb497d/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt#L268-L271

dont work as how we would expect them to be. Here's some demo:

https://github.com/user-attachments/assets/df5287d4-0109-4472-895c-3192da9560de

The green area is the parent layout (`id:progress_bar`) and the red area is the timebar itself, the timebar fills the entire parent. And as you can see in the video that the seeking only happens in the seekBar area, not the whole view, so forwarding the parent touch events still wont do anything.
After digging into `DefaultTimeBar` source, I found this in their source:

```kotlin
      case MotionEvent.ACTION_DOWN:
        if (isInSeekBar(x, y)) {
             ...
        }
```
from: https://github.com/androidx/media/blob/630c1af455a16b8eb1ab36f49d82d9db799d7f5e/libraries/ui/src/main/java/androidx/media3/ui/DefaultTimeBar.java#L611-L618

It only start seeking if the touch is in the allowable area. And as it turns out `DefaultTimeBar` has custom attribute that you can set called `touch_target_height` to increase the "allowable" area.

Here's after the change:

https://github.com/user-attachments/assets/839e5725-c09c-4f85-acd5-a0ef21f85e68

---
-~Currently I set the height (both the parent and the timebar) to 40dp, I think it's the closest to the original `wrap_content` size.~ - (I was wrong, as it turns out the `wrap_content` size is around the size of the default value of `touch_target_height`, which is [26dp](https://github.com/androidx/media/blob/630c1af455a16b8eb1ab36f49d82d9db799d7f5e/libraries/ui/src/main/java/androidx/media3/ui/DefaultTimeBar.java#L139), so setting `touch_target_height` has similiar effect like setting `minHeight`)

**Update da47ec21b **: touch size is set to 35dp, and the margin that is set in `updateMarginsByFullscreenMode()` is omitted (changed to 0dp when not in fullscreen). This is the closest I can get without looking much different than the original layout while still having the benefit of the increased touch area. Let me know what you think :)

ref: #8185


