### PR TITLE
feat: rename `Mark as unwatched` → `Reset playback position`

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -420,7 +420,7 @@
     <string name="welcome">Welcome to LibreTube</string>
     <string name="choose_instance">Please choose an instance first!</string>
     <string name="choose_instance_long">Please choose a Piped instance to use from below. The Piped instance will act as the middleman between you and YouTube. These instances are located at different physical locations - indicated by their country flag(s). Instances physically closer to you are likely faster than instances that are not. You can change the instance you use in the settings at any time.</string>
-    <string name="mark_as_unwatched">Mark as unwatched</string>
+    <string name="mark_as_unwatched">Reset playback position</string>
     <string name="change_playlist_description">Change playlist description</string>
     <string name="playlist_description">Playlist description</string>
     <string name="emptyPlaylistDescription">The playlist description can\'t be empty</string>


### PR DESCRIPTION
Renames the option to mark a video as unwatched to `Reset playback position`, this better indicates what the option does and avoids having two very similarly named options directly next to each other.