### PR TITLE
fix(video player): video appears in small corner

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -230,6 +230,18 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
     private var bufferingTimeoutTask: Runnable? = null
 
     private val playerListener = object : Player.Listener {
+        override fun onRenderedFirstFrame() {
+            super.onRenderedFirstFrame()
+            val oldProgress = binding.playerMotionLayout.progress
+            val delta = if (oldProgress > 0) { -0.01f } else { 0.01f }
+            handler.post {
+                binding.playerMotionLayout.progress = oldProgress + delta
+            }
+            handler.postDelayed(150) {
+                binding.playerMotionLayout.progress = oldProgress
+            }
+        }
+
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             if (PlayerHelper.pipEnabled || PictureInPictureCompat.isInPictureInPictureMode(
                     baseActivity


### PR DESCRIPTION
after video's first frame rendered app slightly changes and shortly after restores container size where video being played from. it is done unnoticeably to the app user; very hacky fix

Personally, I hope better way without hacks exists. Still, this is what I can provide for a target issue

Closes #5816