### PR TITLE
feat(playback-options): set speed steps to 0.25

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -10,7 +10,9 @@ import com.github.libretube.R
 import com.github.libretube.api.TrendingCategory
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.enums.SbSkipOptions
+import com.github.libretube.extensions.round
 import com.github.libretube.helpers.LocaleHelper.getDetectedCountry
+import kotlin.math.roundToInt
 
 object PreferenceHelper {
     private val TAG = PreferenceHelper::class.simpleName
@@ -134,6 +136,13 @@ object PreferenceHelper {
         },
         PreferenceMigration(4, 5) {
             remove("remember_playback_speed")
+        },
+        PreferenceMigration(5, 6) {
+            val currentSpeed = (settings.getString(PreferenceKeys.PLAYBACK_SPEED, null)
+                ?: return@PreferenceMigration).replace("F", "").toFloat()
+            // round to the nearest .25 playback speed
+            val speed = (currentSpeed * 4f).roundToInt() / 4f
+            putString(PreferenceKeys.PLAYBACK_SPEED, speed.toString())
         },
     )
 

--- a/app/src/main/res/layout/playback_bottom_sheet.xml
+++ b/app/src/main/res/layout/playback_bottom_sheet.xml
@@ -59,9 +59,9 @@
                             android:id="@+id/speed"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:stepSize="0.05"
+                            android:stepSize="0.25"
                             android:value="1.0"
-                            android:valueFrom="0.2"
+                            android:valueFrom="0.25"
                             android:valueTo="4.0"
                             android:layout_marginTop="5dp"
                             android:layout_marginHorizontal="10dp" />


### PR DESCRIPTION
Changes the step size of the playback speed slider to `0.25`. This makes it easier to select an appropriate speed as well as following established standard in most other video players (e.g. the official one). Existing users are migrated to the nearest .25 playback speed to avoid crashes when upgrading.

Closes: https://github.com/libre-tube/LibreTube/issues/8243