### PR TITLE
fix: default resolution is not applied when the player first created

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -420,6 +420,7 @@ class CustomExoPlayerView(
 
         fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
         noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
+        updateResolution(commonPlayerViewModel.isFullscreen.value == true)
     }
 
     private fun syncQueueButtons() {


### PR DESCRIPTION
`fullscreenResolution` and `noFullscreenResolution` value are still null when the player first created, causing the resolution being set to max.