### PR TITLE
feat: use primary color for creator comments

### DIFF
--- a/app/src/main/res/drawable/comment_channel_owner_bg.xml
+++ b/app/src/main/res/drawable/comment_channel_owner_bg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="?colorSecondaryContainer" />
+    <solid android:color="?colorPrimaryContainer" />
     <corners android:radius="12dp" />
     <padding
         android:bottom="3dp"

--- a/app/src/main/res/layout/comments_row.xml
+++ b/app/src/main/res/layout/comments_row.xml
@@ -40,7 +40,7 @@
                     android:ellipsize="end"
                     android:maxLines="1"
                     android:textAlignment="viewStart"
-                    android:textColor="?android:attr/textColorSecondary"
+                    android:textColor="@color/text_on_primary_or_default"
                     android:textSize="12sp"
                     tools:text="Octacat" />
 


### PR DESCRIPTION
Using the same text coloring as in https://github.com/libre-tube/LibreTube/pull/8229, we can use the primary color once again for creator comments without contrast issues.

Ref: https://github.com/libre-tube/LibreTube/pull/7809