### PR TITLE
chore: mirror to Codeberg

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,21 @@
+name: Mirror to Codeberg
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Mirror Code to Codeberg
+        uses: yesolutions/mirror-action@master
+        with:
+          REMOTE: 'ssh://git@codeberg.org/libre-tube/LibreTube.git'
+          GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
+          GIT_SSH_KNOWN_HOSTS: ${{ secrets.GIT_SSH_KNOWN_HOSTS }}


### PR DESCRIPTION
Introduces a new workflow, that automatically mirrors the repository to Codeberg on every push to `master`. This makes to the available to users who prefer not use use GitHub and is the first step in a possible migration.

Marked as a draft, as there is still quite a few things missing:
- [x] [The repo](https://codeberg.org/FineFindus/LibreTube) is currently under my namespace, as I don't have the permissions to accept a transfer
- [ ] Secrets are not setup
  - [ ] Should we create an account for libretube-bot to uses as a mirroring account?
 - [ ] The migrated repo has issues/PRs disabled to avoid divergence, I'm not sure if it's possible to migrate them later (without re-migrating the repo)