### PR TITLE
fix(Import/FreeTube): filter empty lines

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ImportHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImportHelper.kt
@@ -166,7 +166,7 @@ object ImportHelper {
                     context.contentResolver.openInputStream(uri)?.use { inputStream ->
                         val text = inputStream.bufferedReader().readText()
                         runCatching {
-                            text.lines().map { line ->
+                            text.lines().filter { it.isNotEmpty() }.map { line ->
                                 JsonHelper.json.decodeFromString<FreeTubeImportPlaylist>(line)
                             }
                         }.getOrNull() ?: runCatching {


### PR DESCRIPTION
Avoids trying to parse empty lines (such as the end of the file), which would fail and thus invalidate the entire import.

Closes: #8268