### PR TITLE
feat(SponsorBlock): add icons for exclusive access and self promotion

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
@@ -8,6 +8,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.ListAdapter
+import com.github.libretube.R
 import com.github.libretube.api.MediaServiceRepository
 import com.github.libretube.api.SponsorBlockLabelHelper
 import com.github.libretube.api.obj.StreamItem
@@ -134,6 +135,14 @@ class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
                     val sponsor = SponsorBlockLabelHelper.getVideoLabels(videoId)
                     withContext(Dispatchers.Main) {
                         sponsorBadgeCard.isVisible = sponsor?.segments?.isNotEmpty() == true
+                        sponsorBadgeIcon.setImageDrawable(
+                            when (sponsor?.segments?.firstOrNull()?.category) {
+                                "exclusive_access" -> context.getDrawable(R.drawable.ic_exclusive_content)
+                                "selfpromo" -> context.getDrawable(R.drawable.ic_selfpromo_content)
+                                "sponsor" -> context.getDrawable(R.drawable.ic_paid_content)
+                                else -> null
+                            }
+                        )
                     }
                 }
 

--- a/app/src/main/res/drawable/ic_exclusive_content.xml
+++ b/app/src/main/res/drawable/ic_exclusive_content.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M15.58,16.8L12,14.5L8.42,16.8L9.5,12.68L6.21,10L10.46,9.74L12,5.8L13.54,9.74L17.79,10L14.5,12.68M20,12C20,10.89 20.9,10 22,10V6C22,4.89 21.1,4 20,4H4A2,2 0,0 0,2 6V10C3.11,10 4,10.9 4,12A2,2 0,0 1,2 14V18A2,2 0,0 0,4 20H20A2,2 0,0 0,22 18V14A2,2 0,0 1,20 12Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_selfpromo_content.xml
+++ b/app/src/main/res/drawable/ic_selfpromo_content.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12,8H4A2,2 0,0 0,2 10V14A2,2 0,0 0,4 16H5V20A1,1 0,0 0,6 21H8A1,1 0,0 0,9 20V16H12L17,20V4L12,8M21.5,12C21.5,13.71 20.54,15.26 19,16V8C20.53,8.75 21.5,10.3 21.5,12Z"/>
+</vector>

--- a/app/src/main/res/layout/trending_row.xml
+++ b/app/src/main/res/layout/trending_row.xml
@@ -44,6 +44,7 @@
                 tools:visibility="visible">
 
                 <ImageView
+                    android:id="@+id/sponsor_badge_icon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:paddingHorizontal="8dp"


### PR DESCRIPTION
Shows icons for exclusive content and self promotion, allow users to distinguish, between purely sponsor content and other categories.
![Exclusive Access icon](https://github.com/user-attachments/assets/c759913e-7648-4af3-a1e4-425c9201a107)
![Selfpromotion icon](https://github.com/user-attachments/assets/2f7e8bdc-5c31-4163-826d-27b9734c84cc)