### PR TITLE
feat: show SponsorBlock icon on video label

### DIFF
--- a/app/src/main/java/com/github/libretube/api/SponsorBlockLabelHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SponsorBlockLabelHelper.kt
@@ -2,6 +2,7 @@ package com.github.libretube.api
 
 import android.util.LruCache
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.github.libretube.R
 import com.github.libretube.api.obj.VideoLabelData
 import com.github.libretube.extensions.sha256Sum
@@ -43,6 +44,19 @@ object SponsorBlockLabelHelper {
         "exclusive_access" -> R.drawable.ic_exclusive_content
         "selfpromo" -> R.drawable.ic_selfpromo_content
         "sponsor" -> R.drawable.ic_paid_content
+        else -> null
+    }
+
+    /**
+     * Returns a suitable label to display the category.
+     *
+     * If there is no matching label, `null` is returned.
+     */
+    @StringRes
+    fun categoryLabel(category: String?): Int? = when (category) {
+        "sponsor" -> R.string.category_sponsor
+        "exclusive_access" -> R.string.category_exclusive_access
+        "selfpromo" -> R.string.category_selfpromo
         else -> null
     }
 }

--- a/app/src/main/java/com/github/libretube/api/SponsorBlockLabelHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/SponsorBlockLabelHelper.kt
@@ -1,6 +1,8 @@
 package com.github.libretube.api
 
 import android.util.LruCache
+import androidx.annotation.DrawableRes
+import com.github.libretube.R
 import com.github.libretube.api.obj.VideoLabelData
 import com.github.libretube.extensions.sha256Sum
 
@@ -29,5 +31,18 @@ object SponsorBlockLabelHelper {
             ).firstOrNull { it.videoID == videoId }
                 .also { cache.put(videoId, it) }
         }.getOrNull()
+    }
+
+    /**
+     * Returns a suitable drawable to display the category.
+     *
+     * If there is no matching icon, `null` is returned.
+     */
+    @DrawableRes
+    fun categoryIcon(category: String?): Int? = when (category) {
+        "exclusive_access" -> R.drawable.ic_exclusive_content
+        "selfpromo" -> R.drawable.ic_selfpromo_content
+        "sponsor" -> R.drawable.ic_paid_content
+        else -> null
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
@@ -132,12 +132,16 @@ class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
                 if (PlayerHelper.sponsorBlockEnabled) {
                     val sponsor = SponsorBlockLabelHelper.getVideoLabels(videoId)
                     withContext(Dispatchers.Main) {
-                        sponsorBadgeCard.isVisible = sponsor?.segments?.isNotEmpty() == true
-                        SponsorBlockLabelHelper.categoryIcon(sponsor?.segments?.firstOrNull()?.category)?.let {
+                        val category = sponsor?.segments?.firstOrNull()?.category
+                        sponsorBadgeCard.isVisible = category != null
+                        SponsorBlockLabelHelper.categoryIcon(category)?.let {
                             sponsorBadgeIcon.setImageDrawable(
                                 context.getDrawable(it)
                             )
                         }
+                        sponsorBadgeIcon.tooltipText =
+                            SponsorBlockLabelHelper.categoryLabel(category)
+                                ?.let { context.getString(it) }
                     }
                 }
 

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
@@ -8,8 +8,6 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.ListAdapter
-import com.github.libretube.R
-import com.github.libretube.api.MediaServiceRepository
 import com.github.libretube.api.SponsorBlockLabelHelper
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.IntentData
@@ -135,14 +133,11 @@ class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
                     val sponsor = SponsorBlockLabelHelper.getVideoLabels(videoId)
                     withContext(Dispatchers.Main) {
                         sponsorBadgeCard.isVisible = sponsor?.segments?.isNotEmpty() == true
-                        sponsorBadgeIcon.setImageDrawable(
-                            when (sponsor?.segments?.firstOrNull()?.category) {
-                                "exclusive_access" -> context.getDrawable(R.drawable.ic_exclusive_content)
-                                "selfpromo" -> context.getDrawable(R.drawable.ic_selfpromo_content)
-                                "sponsor" -> context.getDrawable(R.drawable.ic_paid_content)
-                                else -> null
-                            }
-                        )
+                        SponsorBlockLabelHelper.categoryIcon(sponsor?.segments?.firstOrNull()?.category)?.let {
+                            sponsorBadgeIcon.setImageDrawable(
+                                context.getDrawable(it)
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -56,6 +56,7 @@ class DescriptionLayout(
             when (it.category) {
                 "sponsor" -> context.getString(R.string.category_sponsor)
                 "exclusive_access" -> context.getString(R.string.category_exclusive_access)
+                "selfpromo" -> context.getString(R.string.category_selfpromo)
                 else -> null
             }
         }

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -56,12 +56,7 @@ class DescriptionLayout(
         val category = segments.filter { it.actionType == Segment.TYPE_FULL }.firstNotNullOfOrNull { it.category }
         binding.playerSponsorBadge.isVisible = category != null
         binding.playerSponsorBadge.chipIcon = SponsorBlockLabelHelper.categoryIcon(category)?.let { context.getDrawable(it) }
-        binding.playerSponsorBadge.text = when (category) {
-            "sponsor" -> context.getString(R.string.category_sponsor)
-            "exclusive_access" -> context.getString(R.string.category_exclusive_access)
-            "selfpromo" -> context.getString(R.string.category_selfpromo)
-            else -> null
-        }
+        binding.playerSponsorBadge.text = SponsorBlockLabelHelper.categoryLabel(category)?.let { context.getString(it) }
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DescriptionLayout.kt
@@ -11,6 +11,7 @@ import androidx.core.text.parseAsHtml
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.github.libretube.R
+import com.github.libretube.api.SponsorBlockLabelHelper
 import com.github.libretube.api.obj.Segment
 import com.github.libretube.api.obj.Streams
 import com.github.libretube.databinding.DescriptionLayoutBinding
@@ -52,16 +53,15 @@ class DescriptionLayout(
            return
         }
 
-        val segment = segments.filter { it.actionType == Segment.TYPE_FULL }.firstNotNullOfOrNull {
-            when (it.category) {
-                "sponsor" -> context.getString(R.string.category_sponsor)
-                "exclusive_access" -> context.getString(R.string.category_exclusive_access)
-                "selfpromo" -> context.getString(R.string.category_selfpromo)
-                else -> null
-            }
+        val category = segments.filter { it.actionType == Segment.TYPE_FULL }.firstNotNullOfOrNull { it.category }
+        binding.playerSponsorBadge.isVisible = category != null
+        binding.playerSponsorBadge.chipIcon = SponsorBlockLabelHelper.categoryIcon(category)?.let { context.getDrawable(it) }
+        binding.playerSponsorBadge.text = when (category) {
+            "sponsor" -> context.getString(R.string.category_sponsor)
+            "exclusive_access" -> context.getString(R.string.category_exclusive_access)
+            "selfpromo" -> context.getString(R.string.category_selfpromo)
+            else -> null
         }
-        binding.playerSponsorBadge.isVisible = segment != null
-        binding.playerSponsorBadge.text = segment
     }
 
     @SuppressLint("SetTextI18n")

--- a/app/src/main/res/layout/description_layout.xml
+++ b/app/src/main/res/layout/description_layout.xml
@@ -21,6 +21,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checkable="false"
+            android:clickable="false"
+            app:chipIconTint="?colorOnSecondaryContainer"
             android:text="Sponsor"
             android:visibility="gone" />
 


### PR DESCRIPTION
Adds a badge for the selfpromotion category, as well as the same icon used for the thumbnail label, to help users associate the thumbnail icons to the labels. 
![Sponsorblock badge with icon](https://github.com/user-attachments/assets/031fe1d3-4cb3-4aec-abdd-94a0481123d8)
