### PR TITLE
fix(Search): show deletion icon only for previous searches

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/adapters/SearchSuggestionsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/SearchSuggestionsAdapter.kt
@@ -63,7 +63,6 @@ class SearchSuggestionsAdapter(
         holder.binding.apply {
             when (item.type) {
                 SearchDataType.HISTORY -> {
-                    deleteHistory.isVisible = true
                     deleteHistory.setOnClickListener {
                         onSearchHistoryItemDeleted(SearchHistoryItem(suggestion))
                     }
@@ -78,6 +77,7 @@ class SearchSuggestionsAdapter(
                     )
                 }
             }
+            deleteHistory.isVisible = item.type == SearchDataType.HISTORY
             suggestionText.text = suggestion
             root.setOnClickListener {
                 onRootClickListener(suggestion)


### PR DESCRIPTION
Due to how Android recycles widgets, the deletion icon could still be shown on search suggestion, that where not from the users search history.

Closes https://github.com/libre-tube/LibreTube/issues/8385