### PR TITLE
fix(Shortcuts): run blocking method on IO dispatcher

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ShortcutHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ShortcutHelper.kt
@@ -8,6 +8,9 @@ import androidx.core.graphics.drawable.IconCompat
 import com.github.libretube.constants.IntentData
 import com.github.libretube.enums.TopLevelDestination
 import com.github.libretube.ui.activities.MainActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 object ShortcutHelper {
 
@@ -25,9 +28,12 @@ object ShortcutHelper {
     }
 
     fun createShortcuts(context: Context) {
-        if (ShortcutManagerCompat.getDynamicShortcuts(context).isEmpty()) {
-            val dynamicShortcuts = TopLevelDestination.entries.map { createShortcut(context, it) }
-            ShortcutManagerCompat.setDynamicShortcuts(context, dynamicShortcuts)
+        CoroutineScope(Dispatchers.IO).launch {
+            if (ShortcutManagerCompat.getDynamicShortcuts(context).isEmpty()) {
+                val dynamicShortcuts =
+                    TopLevelDestination.entries.map { createShortcut(context, it) }
+                ShortcutManagerCompat.setDynamicShortcuts(context, dynamicShortcuts)
+            }
         }
     }
 }


### PR DESCRIPTION
`getDynamicShortcuts` and `setDynamicShortcuts` can block and thus should be run on the IO thread.

Close: https://github.com/libre-tube/LibreTube/issues/8403