### PR TITLE
fix(Player): check if correct preference when stopping fast-forward

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -1356,7 +1356,7 @@ class CustomExoPlayerView(
     }
 
     override fun onLongPressEnd() {
-        if (!PlayerHelper.doubleTapToSeek) return
+        if (!PlayerHelper.longPressFastForward) return
 
         backgroundBinding.fastForwardView.isGone = true
 


### PR DESCRIPTION
Fixes a regression introduced in 761b94606945d7082ad3924c747355f68925e9ed, where it would be possible to start fast-forward, but not stop it, as the stopping used a different preference key then for starting.

Closes: https://github.com/libre-tube/LibreTube/issues/8356