### PR TITLE
Preserve subscription feed thumbnail data

### DIFF
--- a/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
+++ b/app/src/main/java/com/github/libretube/api/obj/StreamItem.kt
@@ -45,19 +45,19 @@ data class StreamItem(
         )
     }
 
-    fun toFeedItem() = SubscriptionsFeedItem(
+    fun toFeedItem(existingFeedItem: SubscriptionsFeedItem? = null) = SubscriptionsFeedItem(
         videoId = url!!.toID(),
-        title = title,
-        thumbnail = thumbnail,
-        uploaderName = uploaderName,
-        uploaded = uploaded,
-        uploaderAvatar = uploaderAvatar,
-        uploaderUrl = uploaderUrl,
-        duration = duration,
-        uploaderVerified = uploaderVerified ?: false,
-        shortDescription = shortDescription,
-        views = views,
-        isShort = isShort
+        title = title ?: existingFeedItem?.title,
+        thumbnail = thumbnail ?: existingFeedItem?.thumbnail,
+        uploaderName = uploaderName ?: existingFeedItem?.uploaderName,
+        uploaded = uploaded.takeIf { it > 0 } ?: existingFeedItem?.uploaded ?: uploaded,
+        uploaderAvatar = uploaderAvatar ?: existingFeedItem?.uploaderAvatar,
+        uploaderUrl = uploaderUrl ?: existingFeedItem?.uploaderUrl,
+        duration = duration ?: existingFeedItem?.duration,
+        uploaderVerified = uploaderVerified ?: existingFeedItem?.uploaderVerified ?: false,
+        shortDescription = shortDescription ?: existingFeedItem?.shortDescription,
+        views = views ?: existingFeedItem?.views,
+        isShort = isShort || existingFeedItem?.isShort == true
     )
     
     fun toWatchHistoryItem(videoId: String) = WatchHistoryItem(

--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -113,8 +113,15 @@ class LocalFeedRepository : FeedRepository {
 
             // update subscriptions channels in case they've changed (e.g. different avatar or name)
             SubscriptionHelper.submitSubscriptionChannelInfosChanged(channels.filterNotNull())
+            val existingFeedItems = DatabaseHolder.Database.feedDao()
+                .getAll()
+                .associateBy(SubscriptionsFeedItem::videoId)
             DatabaseHolder.Database.feedDao()
-                .insertAll(collectedFeedItems.flatten().map(StreamItem::toFeedItem))
+                .insertAll(
+                    collectedFeedItems.flatten().map { streamItem ->
+                        streamItem.toFeedItem(existingFeedItems[streamItem.url?.toID()])
+                    }
+                )
         }
     }
 


### PR DESCRIPTION
This keeps existing subscription feed metadata when a refreshed local feed item omits fields that were already stored, including thumbnails. During refresh, the local feed repository now looks up saved feed rows by video ID and the feed item conversion falls back to the stored thumbnail and related metadata when the latest extracted item has missing values.

Verification: targeted content assertions for the fallback paths passed, and `git diff --check` passed. I also attempted `./gradlew :app:compileDebugKotlin --no-daemon -Dorg.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64`, but this environment does not have an Android SDK configured (`SDK location not found`).
