### PR TITLE
fix: default resolution not properly set

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -523,8 +523,6 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             onBackPressedCallback.isEnabled = isMiniPlayerVisible != true
         }
 
-        connectToPlayerView()
-
         toggleVideoInfoVisibility(false)
     }
 
@@ -561,6 +559,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
             playerController = it
             playerController.addListener(playerListener)
+            connectToPlayerView()
             updatePlayPauseButton()
 
             if (!startNewSession) {
@@ -1074,6 +1073,9 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         // set the default subtitle if available
         binding.player.updateCurrentSubtitle(viewModel.currentCaptionId)
 
+        // set the default resolution
+        binding.player.updateResolution(commonPlayerViewModel.isFullscreen.value == true)
+
         if (streams.category == Streams.CATEGORY_MUSIC) {
             playerController.setPlaybackSpeed(1f)
         }
@@ -1117,6 +1119,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             viewLifecycleOwner,
             this
         )
+        binding.player.player = playerController
     }
 
     @SuppressLint("SetTextI18n")
@@ -1125,10 +1128,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
         setPlayerDefaults()
 
-        binding.player.apply {
-            useController = false
-            player = playerController
-        }
+        binding.player.useController = false
 
         if (binding.playerMotionLayout.progress != 1.0f) {
             // show controllers when not in picture in picture mode

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1074,7 +1074,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         binding.player.updateCurrentSubtitle(viewModel.currentCaptionId)
 
         // set the default resolution
-        binding.player.updateResolution(commonPlayerViewModel.isFullscreen.value == true)
+        binding.player.setToDefaultResolution()
 
         if (streams.category == Streams.CATEGORY_MUSIC) {
             playerController.setPlaybackSpeed(1f)

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -559,7 +559,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
             playerController = it
             playerController.addListener(playerListener)
-            connectToPlayerView()
+            connectToPlayerView(playerController)
             updatePlayPauseButton()
 
             if (!startNewSession) {
@@ -802,7 +802,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             )
         )
 
-        binding.player.player = null
+        binding.player.detachPlayer()
 
         playerController.release()
         killPlayerFragment()
@@ -1110,16 +1110,16 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         playerBackgroundBinding.videoTransitionProgress.isVisible = !show
     }
 
-    private fun connectToPlayerView() {
+    private fun connectToPlayerView(player: Player) {
         // initialize the player view actions
         binding.player.initialize(
             chaptersViewModel,
             commonPlayerViewModel,
             viewModel,
             viewLifecycleOwner,
-            this
+            this,
+            player
         )
-        binding.player.player = playerController
     }
 
     @SuppressLint("SetTextI18n")
@@ -1415,7 +1415,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             viewModel.isOrientationChangeInProgress = true
 
             // detach player view from player to stop surface rendering
-            binding.player.player = null
+            binding.player.detachPlayer()
 
             if (::playerController.isInitialized) playerController.release()
 

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -197,13 +197,15 @@ class CustomExoPlayerView(
         commonPlayerViewModel: CommonPlayerViewModel,
         playerViewModel: PlayerViewModel,
         viewLifecycleOwner: LifecycleOwner,
-        playerCallback: CustomPlayerCallback
+        playerCallback: CustomPlayerCallback,
+        player: Player,
     ) {
         this.chaptersViewModel = chaptersViewModel
         this.playerViewModel = playerViewModel
         this.commonPlayerViewModel = commonPlayerViewModel
         this.viewLifecycleOwner = viewLifecycleOwner
         this.playerCallback = playerCallback
+        super.player = player
 
         initializeGestureProgress()
 
@@ -262,14 +264,14 @@ class CustomExoPlayerView(
             updateDisplayedDurationType(false)
         }
         binding.position.setOnClickListener {
-            if (playerCallback.isVideoLive()) player?.let { it.seekTo(it.duration) }
+            if (playerCallback.isVideoLive()) player.let { it.seekTo(it.duration) }
         }
 
         activity.supportFragmentManager.setFragmentResultListener(
             ChaptersBottomSheet.SEEK_TO_POSITION_REQUEST_KEY,
             findViewTreeLifecycleOwner() ?: activity
         ) { _, bundle ->
-            player?.seekTo(bundle.getLong(IntentData.currentPosition))
+            player.seekTo(bundle.getLong(IntentData.currentPosition))
         }
 
         // enable the chapters dialog in the player
@@ -277,7 +279,7 @@ class CustomExoPlayerView(
             val sheet = chaptersBottomSheet ?: ChaptersBottomSheet()
                 .apply {
                     arguments = bundleOf(
-                        IntentData.duration to player?.duration?.div(1000)
+                        IntentData.duration to player.duration.div(1000)
                     )
                 }
                 .also {
@@ -352,22 +354,6 @@ class CustomExoPlayerView(
             submitDialog.show((context as BaseActivity).supportFragmentManager, null)
         }
 
-        fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
-        noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
-    }
-
-    override fun setPlayer(player: Player?) {
-        // ensure that the below listeners are only
-        // initialized one single time to the same player
-        if (player == this.player) return
-
-        super.setPlayer(player)
-        player?.let {
-            connectViewToPlayer(it)
-        }
-    }
-
-    private fun connectViewToPlayer(player: Player) {
         binding.playPauseBTN.setOnClickListener {
             player.togglePlayPauseState()
         }
@@ -414,7 +400,23 @@ class CustomExoPlayerView(
             if (isFullscreen()) toggleSystemBars(!isPlayerLocked)
         }
 
+        fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
+        noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
+
         updateCurrentPosition()
+    }
+
+    /**
+     * @see CustomExoPlayerView.initialize
+     * @see CustomExoPlayerView.detachPlayer
+     */
+    @Deprecated("Use `initialize()` instead to attach `Player` and use `detachPlayer()` to detach it")
+    override fun setPlayer(player: Player?) {
+        super.setPlayer(player)
+    }
+
+    fun detachPlayer(){
+        super.setPlayer(null)
     }
 
     private fun syncQueueButtons() {

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -400,9 +400,6 @@ class CustomExoPlayerView(
             if (isFullscreen()) toggleSystemBars(!isPlayerLocked)
         }
 
-        fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
-        noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
-
         updateCurrentPosition()
     }
 
@@ -1059,7 +1056,13 @@ class CustomExoPlayerView(
             .show(supportFragmentManager)
     }
 
-    fun updateResolution(isFullscreen: Boolean) {
+    fun setToDefaultResolution() {
+        fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
+        noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
+        updateResolution(isFullscreen())
+    }
+
+    private fun updateResolution(isFullscreen: Boolean) {
         if (!isFullscreen && noFullscreenResolution != null) {
             setPlayerResolution(noFullscreenResolution!!)
         } else if (fullscreenResolution != null) {

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -354,7 +354,6 @@ class CustomExoPlayerView(
 
         fullscreenResolution = PlayerHelper.getDefaultResolution(context, true)
         noFullscreenResolution = PlayerHelper.getDefaultResolution(context, false)
-        updateResolution(commonPlayerViewModel.isFullscreen.value == true)
     }
 
     override fun setPlayer(player: Player?) {
@@ -1058,7 +1057,7 @@ class CustomExoPlayerView(
             .show(supportFragmentManager)
     }
 
-    private fun updateResolution(isFullscreen: Boolean) {
+    fun updateResolution(isFullscreen: Boolean) {
         if (!isFullscreen && noFullscreenResolution != null) {
             setPlayerResolution(noFullscreenResolution!!)
         } else if (fullscreenResolution != null) {


### PR DESCRIPTION
Due to recent changes to the `CustomExoPlayerView`, the patch b77a95fc586bfe5b288a55ae7bee7cec9766cfd5 no longer work because we tried to update the resolution when the `Player` instance is not yet initialized.

The default resolution set call is now moved to `PlayerFragment` inside `setPlayerDefaults()`, so the function `updateResolution()` is now made public.

The player initialization logic also slightly modified, so that the playerView is initialized after we get the `MediaController/Player` ready, rather than calling `connectToPlayerView()` in `onViewCreated()`.

And then I realized the code can be slightly simplified more, so I made the change d057951fccd7ea212b37056a28454fb0f13f442f by merging `connectViewToPlayer()` with `initialize()` inside `CustomExoPlayerView`, so now we dont need to override the `setPlayer()` function since the initialization call only happen once already.

Closes: #8351