### PR TITLE
feat: use more user-friendly terms for audio tracks

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -1121,9 +1121,7 @@ class CustomExoPlayerView(
                 .map {
                     PlayerHelper.getAudioTrackNameFromFormat(context, it)
                 },
-                preselectedItem = selectedAudioLanguageAndRoleFlags?.let {
-                    PlayerHelper.getAudioTrackNameFromFormat(context, it)
-                },
+                preselectedItem = getCurrentAudioTrackTitle(),
             ) { index ->
                 val selectedAudioFormat = audioLanguagesAndRoleFlags[index]
                 player.sendCustomCommand(

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -1095,9 +1095,6 @@ class CustomExoPlayerView(
             player.currentTracks.groups,
             false
         )
-        val audioLanguages = audioLanguagesAndRoleFlags.map {
-            PlayerHelper.getAudioTrackNameFromFormat(context, it)
-        }
         val baseBottomSheet = BaseBottomSheet()
 
         if (audioLanguagesAndRoleFlags.isEmpty() || (audioLanguagesAndRoleFlags.size == 1 &&
@@ -1117,7 +1114,13 @@ class CustomExoPlayerView(
             )
         } else {
             baseBottomSheet.setSimpleItems(
-                audioLanguages,
+                audioLanguagesAndRoleFlags
+                // audio tracks have only a single flag set
+                // ordered by main, dubbed, audio descriptive
+                .sortedBy { it.second }
+                .map {
+                    PlayerHelper.getAudioTrackNameFromFormat(context, it)
+                },
                 preselectedItem = selectedAudioLanguageAndRoleFlags?.let {
                     PlayerHelper.getAudioTrackNameFromFormat(context, it)
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,10 +483,10 @@
     <string name="audio_track_format">%1$s - %2$s</string>
     <string name="unknown_audio_language">Unknown audio language</string>
     <string name="unknown_audio_track_type">Unknown audio track type</string>
-    <string name="original_or_main_audio_track">original or main</string>
-    <string name="dubbed_audio_track">dubbed</string>
-    <string name="descriptive_audio_track">descriptive</string>
-    <string name="default_or_unknown_audio_track">default or unknown</string>
+    <string name="original_or_main_audio_track">Original</string>
+    <string name="dubbed_audio_track">Dubbed</string>
+    <string name="descriptive_audio_track">Audio Description</string>
+    <string name="default_or_unknown_audio_track">Default</string>
     <string name="unknown_or_no_audio">unknown or no audio</string>
     <string name="continue_watching">Continue watching</string>
     <string name="screen_orientation">Screen orientation</string>


### PR DESCRIPTION
Switches to using for user-friendly terms for the audio tracks, by avoid technical terms and multiple types, such as 'original or main' instead of simply 'Original' or 'default or unknown' instead of simply 'Default'.

Ideally, we would also mark tracks as auto-translated as appropriate, but unfortunately, that's not possible with the current setup.

![Audio tracks with user friendly terms](https://github.com/user-attachments/assets/95706ed8-34e0-4a0b-b88b-6c8beef0eb88)