### PR TITLE
 fix: display country for audio tracks 

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/DashHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DashHelper.kt
@@ -98,7 +98,7 @@ object DashHelper {
             adapSetElement.setAttribute("subsegmentAlignment", "true")
 
             if (adapSet.audioTrackId != null) {
-                adapSetElement.setAttribute("lang", adapSet.audioTrackId.substring(0, 2))
+                adapSetElement.setAttribute("lang", adapSet.audioTrackId.split('.')[0])
             } else if (adapSet.audioLocale != null) {
                 adapSetElement.setAttribute("lang", adapSet.audioLocale)
             }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -709,7 +709,7 @@ object PlayerHelper {
      */
     fun getAudioTrackNameFromFormat(
         context: Context,
-        audioLanguageAndRoleFlags: Pair<String?, @C.RoleFlags Int>
+        audioLanguageAndRoleFlags: Pair<String?, @C.RoleFlags Int>,
     ): String {
         val audioLanguage = audioLanguageAndRoleFlags.first
         return context.getString(R.string.audio_track_format)
@@ -718,7 +718,7 @@ object PlayerHelper {
                     context.getString(R.string.unknown_audio_language)
                 } else {
                     Locale.forLanguageTag(audioLanguage)
-                        .getDisplayLanguage(Locale.getDefault())
+                        .getDisplayName(Locale.getDefault())
                         .ifEmpty { context.getString(R.string.unknown_audio_language) }
                 },
                 getDisplayAudioTrackTypeFromFormat(context, audioLanguageAndRoleFlags.second)

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -710,7 +710,7 @@ class CustomExoPlayerView(
         }
 
         // The player reference should be not changed between the null check
-        // and its access, so a non null assertion should be safe here
+        // and its access, so a non-null assertion should be safe here
         val selectedAudioLanguagesAndRoleFlags =
             PlayerHelper.getAudioLanguagesAndRoleFlagsFromTrackGroups(
                 player!!.currentTracks.groups,
@@ -739,9 +739,10 @@ class CustomExoPlayerView(
             return context.getString(R.string.default_or_unknown_audio_track)
         }
 
+
         return PlayerHelper.getAudioTrackNameFromFormat(
             context,
-            firstSelectedAudioFormat
+            firstSelectedAudioFormat,
         )
     }
 


### PR DESCRIPTION
A video may have multiple audio tracks of the same language, but for different regions (e.g. 'English (United States)' and 'English (United Kingdom)').

Also fixes an issue, where 3 letter language codes would be incorrectly set as a different language with a 2 letter language code.

| Before                                                                                                           	| After                                                                                                         	|
|------------------------------------------------------------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------------	|
| ![Audio tracks without country](https://github.com/user-attachments/assets/58ce876a-a1bc-462c-9a5c-d50162bda9a6) 	| ![Audio tracks with country](https://github.com/user-attachments/assets/b052d294-1917-42a9-af7a-054035a52a24) 	|