### PR TITLE
fix playlist info inconsistency after removing videos

### DIFF
--- a/app/src/main/java/com/github/libretube/db/obj/DownloadItem.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/DownloadItem.kt
@@ -2,7 +2,6 @@ package com.github.libretube.db.obj
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.Ignore
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.github.libretube.enums.FileType
@@ -34,6 +33,5 @@ data class DownloadItem(
     var language: String? = null,
     var downloadSize: Long = -1L
 ) {
-    @Ignore
     val isFinished get() = runCatching { path.fileSize() }.getOrDefault(0L) < downloadSize
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -149,13 +149,8 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
             playlistName = response.name
             isLoading = false
 
-            if (!response.thumbnailUrl.isNullOrEmpty()) {
-                ImageHelper.loadImage(response.thumbnailUrl, binding.thumbnail)
-            } else {
-                binding.thumbnail.setImageResource(R.drawable.ic_empty_playlist)
-                binding.thumbnail.setPadding(64f.dpToPx())
-                binding.thumbnail.setBackgroundColor(com.google.android.material.R.attr.colorSurface)
-            }
+            setPlaylistThumbnail(response.thumbnailUrl)
+
             binding.playlistProgress.isGone = true
             binding.playlistAppBar.isVisible = true
             binding.playlistRecView.isVisible = true
@@ -186,7 +181,8 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
                         )
                     }
 
-                    binding.playlistInfo.text = getChannelAndVideoString(response, playlistFeed.size)
+                    binding.playlistInfo.text =
+                        getChannelAndVideoString(response, playlistFeed.size)
                 }
             })
 
@@ -388,9 +384,10 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
 
         playlistAdapter?.submitList(videos)
 
-        updatePlaylistDuration()
+        updatePlaylistDuration(videos)
     }
 
+    @SuppressLint("StringFormatInvalid")
     private fun removeFromPlaylist(sortedFeedPosition: Int) {
         val playlistAdapter = playlistAdapter ?: return
 
@@ -423,12 +420,23 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
                             )
                         }
                         .show()
+                    updateInfo(updatedList)
                 }
             } catch (e: Exception) {
                 Log.e(TAG(), e.toString())
                 context?.toastFromMainDispatcher(R.string.unknown_error)
             }
         }
+    }
+
+    private fun updateInfo(updatedList: List<PlaylistItem>) {
+        val playlistCount = updatedList.size
+        binding.playlistInfo.text = getChannelAndVideoString(
+            Playlist(name = playlistName, videos = playlistCount),
+            playlistCount
+        )
+        updatePlaylistDuration(updatedList)
+        setPlaylistThumbnail(updatedList.firstOrNull()?.item?.thumbnail)
     }
 
     private fun reAddToPlaylist(
@@ -447,6 +455,7 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
 
                 withContext(Dispatchers.Main) {
                     playlistAdapter.submitList(fixedList)
+                    updateInfo(fixedList)
                 }
             } catch (e: Exception) {
                 Log.e(TAG(), e.toString())
@@ -464,7 +473,11 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
      *
      * I.e., this method adds the given offset to all videos with an originalPlaylistIndex > modifiedPosition.
      */
-    private fun fixItemIndices(items: List<PlaylistItem>, modifiedPosition: Int, offset: Int): List<PlaylistItem> {
+    private fun fixItemIndices(
+        items: List<PlaylistItem>,
+        modifiedPosition: Int,
+        offset: Int
+    ): List<PlaylistItem> {
         return items.map {
             if (it.originalPlaylistIndex > modifiedPosition) {
                 it.copy(originalPlaylistIndex = it.originalPlaylistIndex + offset)
@@ -504,17 +517,29 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
                 PlaylistItem(item, currentList.size + index)
             }
             playlistAdapter?.submitList(newList)
-            updatePlaylistDuration()
+            updatePlaylistDuration(newList)
             isLoading = false
         }
     }
 
     @SuppressLint("SetTextI18n")
-    private fun updatePlaylistDuration() {
-        val totalDuration = playlistFeed.sumOf { it.duration ?: 0 } ?: return
+    private fun updatePlaylistDuration(updatedList: List<PlaylistItem>) {
+        val totalDuration = updatedList.sumOf { it.item.duration ?: 0 }
         binding.playlistDuration.text = DateUtils.formatElapsedTime(totalDuration) +
                 if (nextPage != null) "+" else ""
     }
+
+    // Update the Cover/Thumbnail of the playlist if the first video was removed
+    private fun setPlaylistThumbnail(thumbnailUrl: String?) {
+        if (!thumbnailUrl.isNullOrEmpty()) {
+            ImageHelper.loadImage(thumbnailUrl, binding.thumbnail)
+        } else {
+            binding.thumbnail.setImageResource(R.drawable.ic_empty_playlist)
+            binding.thumbnail.setPadding(64f.dpToPx())
+            binding.thumbnail.setBackgroundColor(com.google.android.material.R.attr.colorSurface)
+        }
+    }
+
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)


### PR DESCRIPTION
update playlist info after removing a video (update the video count, duration & thumbnail after you remove a video, also update if you undo the removed video)

closes #8517