### PR TITLE
Drop useless settings (image cache size and parallel downloads option)

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -111,7 +111,6 @@ object PreferenceKeys {
     // Advanced
     const val AUTOMATIC_UPDATE_CHECKS = "automatic_update_checks"
     const val DATA_SAVER_MODE = "data_saver_mode_key"
-    const val MAX_IMAGE_CACHE = "image_cache_size"
     const val RESET_SETTINGS = "reset_settings"
     const val CLEAR_SEARCH_HISTORY = "clear_search_history"
     const val CLEAR_WATCH_HISTORY = "clear_watch_history"

--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -118,7 +118,6 @@ object PreferenceKeys {
     const val SHARE_WITH_TIME_CODE = "share_with_time_code"
     const val SELECTED_SHARE_HOST = "selected_share_host"
     const val CLEAR_BOOKMARKS = "clear_bookmarks"
-    const val MAX_CONCURRENT_DOWNLOADS = "max_parallel_downloads"
     const val EXTERNAL_DOWNLOAD_PROVIDER = "external_download_provider"
     const val FULL_LOCAL_MODE = "full_local_mode"
     const val LOCAL_RYD = "local_return_youtube_dislikes"

--- a/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DownloadHelper.kt
@@ -39,6 +39,7 @@ object DownloadHelper {
     const val PLAYLIST_THUMBNAIL_DIR = "playlist_thumbnail"
     const val DOWNLOAD_CHUNK_SIZE = 8L * 1024
     const val DEFAULT_TIMEOUT = 15 * 1000
+    const val MAX_CONCURRENT_DOWNLOADS = 6
     private const val VIDEO_MIMETYPE = "video/*"
 
     fun getDownloadDir(context: Context, path: String): Path {
@@ -49,13 +50,6 @@ object DownloadHelper {
                 context.filesDir
             }
         return (storageDir.toPath() / path).createDirectories()
-    }
-
-    fun getMaxConcurrentDownloads(): Int {
-        return PreferenceHelper.getString(
-            PreferenceKeys.MAX_CONCURRENT_DOWNLOADS,
-            "6"
-        ).toFloat().toInt()
     }
 
     fun startDownloadService(context: Context, downloadData: DownloadData? = null) {

--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
+import android.os.storage.StorageManager
 import android.widget.ImageView
+import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import coil3.ImageLoader
 import coil3.disk.DiskCache
@@ -16,14 +18,12 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.toBitmap
 import com.github.libretube.BuildConfig
-import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.toAndroidUri
 import com.github.libretube.util.DataSaverMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import java.io.File
 import java.nio.file.Path
 
 object ImageHelper {
@@ -36,8 +36,6 @@ object ImageHelper {
      * Initialize the image loader
      */
     fun initializeImageLoader(context: Context) {
-        val maxCacheSize = PreferenceHelper.getString(PreferenceKeys.MAX_IMAGE_CACHE, "128")
-
         val httpClient = OkHttpClient().newBuilder()
 
         if (BuildConfig.DEBUG) {
@@ -56,26 +54,20 @@ object ImageHelper {
                 )
             }
             .apply {
-                if (maxCacheSize.isEmpty()) {
-                    diskCachePolicy(CachePolicy.DISABLED)
-                } else {
-                    diskCachePolicy(CachePolicy.ENABLED)
-                    memoryCachePolicy(CachePolicy.ENABLED)
+                diskCachePolicy(CachePolicy.ENABLED)
+                memoryCachePolicy(CachePolicy.ENABLED)
 
-                    val diskCache = generateDiskCache(
-                        directory = context.coilFile,
-                        size = maxCacheSize.toInt()
-                    )
-                    diskCache(diskCache)
-                }
+                val storageManager = context.getSystemService<StorageManager>()!!
+                val availableCache = storageManager.getCacheQuotaBytes(
+                    storageManager.getUuidForPath(context.coilFile)
+                )
+                val diskCache = DiskCache.Builder()
+                    .directory(context.coilFile)
+                    // only use a certain percentage of the available cache size for images
+                    .maxSizeBytes(availableCache)
+                    .build()
+                diskCache(diskCache)
             }
-            .build()
-    }
-
-    private fun generateDiskCache(directory: File, size: Int): DiskCache {
-        return DiskCache.Builder()
-            .directory(directory)
-            .maxSizeBytes(size * 1024 * 1024L)
             .build()
     }
 

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -10,7 +10,6 @@ import com.github.libretube.R
 import com.github.libretube.api.TrendingCategory
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.enums.SbSkipOptions
-import com.github.libretube.extensions.round
 import com.github.libretube.helpers.LocaleHelper.getDetectedCountry
 import kotlin.math.roundToInt
 
@@ -147,6 +146,10 @@ object PreferenceHelper {
         PreferenceMigration(6, 7) {
             remove("disable_video_image_proxy")
         },
+        PreferenceMigration(7, 8) {
+            remove("image_cache_size")
+            remove("max_parallel_downloads")
+        }
     )
 
     /**

--- a/app/src/main/java/com/github/libretube/services/DownloadService.kt
+++ b/app/src/main/java/com/github/libretube/services/DownloadService.kt
@@ -442,7 +442,7 @@ class DownloadService : LifecycleService() {
      */
     private fun mayStartNewDownload(): Boolean {
         val downloadCount = downloadQueue.valueIterator().asSequence().count { it }
-        return downloadCount < DownloadHelper.getMaxConcurrentDownloads()
+        return downloadCount < DownloadHelper.MAX_CONCURRENT_DOWNLOADS
     }
 
     /**
@@ -518,9 +518,8 @@ class DownloadService : LifecycleService() {
                 }
             }
 
-            val max = DownloadHelper.getMaxConcurrentDownloads()
             val current = downloadQueue.valueIterator().asSequence().count { it }
-            val slotsToFill = max - current
+            val slotsToFill = DownloadHelper.MAX_CONCURRENT_DOWNLOADS - current
 
             if (slotsToFill > 0) {
                 val candidates = incompleteItems.filter { !downloadQueue[it.id] }

--- a/app/src/main/java/com/github/libretube/ui/preferences/GeneralSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/GeneralSettings.kt
@@ -11,7 +11,6 @@ import com.github.libretube.BuildConfig
 import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.extensions.toastFromMainThread
-import com.github.libretube.helpers.ImageHelper
 import com.github.libretube.helpers.LocaleHelper
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.ui.base.BasePreferenceFragment
@@ -70,12 +69,6 @@ class GeneralSettings : BasePreferenceFragment() {
         val autoRotation = findPreference<ListPreference>(PreferenceKeys.ORIENTATION)
         autoRotation?.setOnPreferenceChangeListener { _, _ ->
             RequireRestartDialog().show(childFragmentManager, RequireRestartDialog::class.java.name)
-            true
-        }
-
-        val maxImageCache = findPreference<ListPreference>(PreferenceKeys.MAX_IMAGE_CACHE)
-        maxImageCache?.setOnPreferenceChangeListener { _, _ ->
-            ImageHelper.initializeImageLoader(requireContext())
             true
         }
 

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -225,26 +225,6 @@
         <item>unlimited</item>
     </string-array>
 
-    <string-array name="cacheSize">
-        <item>16MB</item>
-        <item>32MB</item>
-        <item>64MB</item>
-        <item>128MB</item>
-        <item>256MB</item>
-        <item>512MB</item>
-        <item>@string/limit_to_runtime</item>
-    </string-array>
-
-    <string-array name="cacheSizeValues">
-        <item>16</item>
-        <item>32</item>
-        <item>64</item>
-        <item>128</item>
-        <item>256</item>
-        <item>512</item>
-        <item />
-    </string-array>
-
     <string-array name="playlistSortingOptions">
         <item>@string/creation_date</item>
         <item>@string/creation_date_reversed</item>

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -48,15 +48,6 @@
 
     <PreferenceCategory app:title="@string/downloads">
 
-        <com.github.libretube.ui.views.SliderPreference
-            android:icon="@drawable/ic_download"
-            android:key="max_parallel_downloads"
-            android:title="@string/concurrent_downloads"
-            app:defValue="6"
-            app:stepSize="1"
-            app:valueFrom="1"
-            app:valueTo="6" />
-
         <EditTextPreference
             android:icon="@drawable/ic_open"
             android:key="external_download_provider"

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -83,15 +83,6 @@
             app:key="data_saver_mode_key"
             app:title="@string/data_saver_mode" />
 
-        <ListPreference
-            android:entries="@array/cacheSize"
-            android:entryValues="@array/cacheSizeValues"
-            android:icon="@drawable/ic_cache"
-            app:defaultValue="128"
-            app:key="image_cache_size"
-            app:title="@string/maximum_image_cache"
-            app:useSimpleSummaryProvider="true" />
-
         <SwitchPreferenceCompat
             android:icon="@drawable/ic_badge"
             android:summary="@string/new_videos_badge_summary"


### PR DESCRIPTION
Please see the individual commit descriptions on why each individual feature gets removed.

related: https://github.com/libre-tube/LibreTube/issues/8465