### PR TITLE
chore(settings): remove screen orientation option

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,27 +41,21 @@
             android:label="@string/noInternet"
             android:launchMode="singleTop"
             android:configChanges="keyboard|keyboardHidden|screenSize|smallestScreenSize|screenLayout|orientation|uiMode"
-            android:supportsPictureInPicture="true"
-            android:screenOrientation="locked" />
+            android:supportsPictureInPicture="true" />
 
         <activity
             android:name=".ui.activities.SettingsActivity"
-            android:label="@string/settings"
-            android:screenOrientation="locked" />
+            android:label="@string/settings" />
 
         <activity
             android:name=".ui.activities.AboutActivity"
-            android:label="@string/settings"
-            android:screenOrientation="locked" />
+            android:label="@string/settings" />
 
         <activity
             android:name=".ui.activities.HelpActivity"
-            android:label="@string/settings"
-            android:screenOrientation="locked" />
+            android:label="@string/settings" />
 
-        <activity
-            android:name=".ui.activities.ZoomableImageActivity"
-            android:screenOrientation="locked" />
+        <activity android:name=".ui.activities.ZoomableImageActivity" />
 
         <activity
             android:name=".ui.activities.AddToQueueActivity"
@@ -115,7 +109,6 @@
             android:configChanges="keyboard|keyboardHidden|screenSize|smallestScreenSize|screenLayout|orientation|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
-            android:screenOrientation="locked"
             android:supportsPictureInPicture="true"
             android:theme="@style/SplashScreenTheme"
             android:windowSoftInputMode="adjustPan">
@@ -399,7 +392,7 @@
             android:foregroundServiceType="mediaPlayback">
 
             <intent-filter>
-                <action android:name="androidx.media3.session.MediaSessionService"/>
+                <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
 
         </service>
@@ -411,7 +404,7 @@
             android:foregroundServiceType="mediaPlayback">
 
             <intent-filter>
-                <action android:name="androidx.media3.session.MediaSessionService"/>
+                <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>
 
         </service>

--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -13,7 +13,6 @@ object PreferenceKeys {
     const val LANGUAGE = "language"
     const val REGION = "region"
     const val TRENDING_CATEGORY = "trending_category"
-    const val ORIENTATION = "orientation"
     const val NAVBAR_ITEMS = "navbar_items"
     const val START_FRAGMENT = "start_fragment"
     const val UNLIMITED_SEARCH_HISTORY = "unlimited_search_history"

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -10,7 +10,6 @@ import com.github.libretube.R
 import com.github.libretube.api.TrendingCategory
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.enums.SbSkipOptions
-import com.github.libretube.extensions.round
 import com.github.libretube.helpers.LocaleHelper.getDetectedCountry
 import kotlin.math.roundToInt
 

--- a/app/src/main/java/com/github/libretube/ui/base/BaseActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/base/BaseActivity.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.helpers.LocaleHelper
 import com.github.libretube.helpers.PreferenceHelper
@@ -23,19 +22,6 @@ import java.util.Locale
 open class BaseActivity : AppCompatActivity() {
     open val isDialogActivity: Boolean = false
 
-    val screenOrientationPref by lazy {
-        val orientationPref = PreferenceHelper.getString(
-            PreferenceKeys.ORIENTATION,
-            resources.getString(R.string.config_default_orientation_pref)
-        )
-        when (orientationPref) {
-            "portrait" -> ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
-            "landscape" -> ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
-            "auto" -> ActivityInfo.SCREEN_ORIENTATION_USER
-            else -> throw IllegalArgumentException()
-        }
-    }
-
     /**
      * Whether the phone of the user has a cutout like a notch or not
      */
@@ -46,8 +32,8 @@ open class BaseActivity : AppCompatActivity() {
         ThemeHelper.updateTheme(this)
         if (isDialogActivity) ThemeHelper.applyDialogActivityTheme(this)
 
-        // enable auto-rotation if enabled
-        requestOrientationChange()
+        // enable auto-rotation
+        restoreAutoRotation()
 
         // wait for the window decor view to be drawn before detecting display cutouts
         window.decorView.setOnApplyWindowInsetsListener { view, insets ->
@@ -79,9 +65,9 @@ open class BaseActivity : AppCompatActivity() {
     }
 
     /**
-     * Rotate the screen according to the app orientation preference
+     * Re-enable automatic rotation of the screen.
      */
-    open fun requestOrientationChange() {
-        requestedOrientation = screenOrientationPref
+    open fun restoreAutoRotation() {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
     }
 }

--- a/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/AudioPlayerFragment.kt
@@ -242,7 +242,7 @@ class AudioPlayerFragment : Fragment(R.layout.fragment_audio_player), AudioPlaye
                 binding.audioPlayerContainer.isClickable = false
                 binding.playerMotionLayout.transitionToEnd()
                 activity.minimizePlayerContainerLayout()
-                activity.requestOrientationChange()
+                activity.restoreAutoRotation()
             }
 
             override fun handleOnBackProgressed(backEvent: BackEventCompat) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -353,11 +353,6 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         }
     }
 
-    private val lockedOrientations = listOf(
-        ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT,
-        ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-    )
-
     private var screenshotBitmap: Bitmap? = null
     private val openScreenshotFile =
         registerForActivityResult(ActivityResultContracts.CreateDocument("image/png")) { uri ->
@@ -497,7 +492,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
                     binding.playerMotionLayout.setTransitionDuration(250)
                     binding.playerMotionLayout.transitionToEnd()
                     baseActivity.minimizePlayerContainerLayout()
-                    baseActivity.requestOrientationChange()
+                    baseActivity.restoreAutoRotation()
                 }
             }
 
@@ -629,7 +624,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
                     playerBackgroundBinding.sbSkipBtn.isGone = true
 
                     baseActivity.setPlayerContainerProgress(1f)
-                    baseActivity.requestOrientationChange()
+                    baseActivity.restoreAutoRotation()
                 }
 
                 updateMaxSheetHeight()
@@ -838,7 +833,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         commonPlayerViewModel.isFullscreen.value = false
 
         if (!PlayerHelper.autoFullscreenEnabled) {
-            baseActivity.requestedOrientation = baseActivity.screenOrientationPref
+            baseActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
         }
 
         openOrCloseFullscreenDialog(false)
@@ -983,7 +978,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         }
 
         // restore the orientation that's used by the main activity
-        baseActivity.requestOrientationChange()
+        baseActivity.restoreAutoRotation()
 
         _binding = null
     }
@@ -1321,14 +1316,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
      */
     @SuppressLint("SourceLockedOrientationActivity")
     private fun changeOrientationMode() {
-        if (PlayerHelper.autoFullscreenEnabled) {
-            // enable auto rotation
-            baseActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
-        } else {
-            // go to portrait mode
-            baseActivity.requestedOrientation =
-                (requireActivity() as BaseActivity).screenOrientationPref
-        }
+        baseActivity.restoreAutoRotation()
     }
 
 
@@ -1405,7 +1393,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
      * If true, the activity will be automatically restarted
      */
     private fun restartActivityIfNeeded() {
-        if (baseActivity.screenOrientationPref in lockedOrientations || viewModel.isOrientationChangeInProgress) return
+        if (viewModel.isOrientationChangeInProgress) return
 
         val orientation = resources.configuration.orientation
         if (commonPlayerViewModel.isFullscreen.value != true && orientation != playerLayoutOrientation) {

--- a/app/src/main/java/com/github/libretube/ui/preferences/GeneralSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/GeneralSettings.kt
@@ -67,18 +67,6 @@ class GeneralSettings : BasePreferenceFragment() {
             }
         }
 
-        val autoRotation = findPreference<ListPreference>(PreferenceKeys.ORIENTATION)
-        autoRotation?.setOnPreferenceChangeListener { _, _ ->
-            RequireRestartDialog().show(childFragmentManager, RequireRestartDialog::class.java.name)
-            true
-        }
-
-        val maxImageCache = findPreference<ListPreference>(PreferenceKeys.MAX_IMAGE_CACHE)
-        maxImageCache?.setOnPreferenceChangeListener { _, _ ->
-            ImageHelper.initializeImageLoader(requireContext())
-            true
-        }
-
         val resetSettings = findPreference<Preference>(PreferenceKeys.RESET_SETTINGS)
         resetSettings?.setOnPreferenceClickListener {
             showResetDialog()

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -315,18 +315,6 @@
         <item>automatic_once</item>
     </string-array>
 
-    <string-array name="orientation">
-        <item>@string/portrait</item>
-        <item>@string/landscape</item>
-        <item>@string/auto_rotation</item>
-    </string-array>
-
-    <string-array name="orientation_values">
-        <item>portrait</item>
-        <item>landscape</item>
-        <item>auto</item>
-    </string-array>
-
     <string-array name="sponsorBlockSegments">
         <item>sponsor</item>
         <item>intro</item>

--- a/app/src/main/res/xml/general_settings.xml
+++ b/app/src/main/res/xml/general_settings.xml
@@ -22,15 +22,6 @@
             android:title="@string/audio_only_mode"
             app:key="audio_only_mode" />
 
-        <ListPreference
-            android:defaultValue="@string/config_default_orientation_pref"
-            android:entries="@array/orientation"
-            android:entryValues="@array/orientation_values"
-            android:icon="@drawable/ic_screen_rotation"
-            app:key="orientation"
-            app:title="@string/screen_orientation"
-            app:useSimpleSummaryProvider="true" />
-
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:icon="@drawable/ic_suggestions"


### PR DESCRIPTION
This has been a left-over from the times where the landscape player has still been experimental. Also, setting a fixed screen orientation is deprecated by Android, so this option would break in upcoming Android versions anyways.

continuation of https://github.com/libre-tube/LibreTube/pull/8525