### PR TITLE
perf(sabr): avoid copying segment data

### DIFF
--- a/app/src/main/java/com/github/libretube/player/SabrDataSource.kt
+++ b/app/src/main/java/com/github/libretube/player/SabrDataSource.kt
@@ -7,16 +7,16 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.BaseDataSource
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
+import com.github.libretube.player.parser.CompositeBuffer
 import com.github.libretube.player.parser.PlaybackRequest
 import com.github.libretube.player.parser.SabrClient
 import java.io.IOException
-import java.nio.ByteBuffer
 
 @UnstableApi
 class SabrDataSource(
     private val sabrClient: SabrClient,
 ) : BaseDataSource(true) {
-    private var data: ByteBuffer? = null
+    private var data: CompositeBuffer? = null
 
     class Factory(
         private val sabrClient: SabrClient
@@ -31,7 +31,7 @@ class SabrDataSource(
         transferStarted(dataSpec)
         val segment = runCatching { sabrClient.getNextSegment(playbackRequest!!) }
             .getOrNull() ?: throw IOException()
-        data = ByteBuffer.wrap(segment.data())
+        data = CompositeBuffer(segment.data)
         return data!!.remaining().toLong()
     }
 
@@ -63,7 +63,7 @@ class SabrDataSource(
         }
 
         val bytesToRead = minOf(length, data!!.remaining())
-        data = data!!.get(buffer, offset, bytesToRead)
+        data!!.read(buffer, offset, bytesToRead)
 
         // this is not the actual amount of bytes transferred, since the SABR stream has some overhead,
         // e.g. for format metadata

--- a/app/src/main/java/com/github/libretube/player/parser/CompositeBuffer.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/CompositeBuffer.kt
@@ -1,0 +1,64 @@
+package com.github.libretube.player.parser
+
+import kotlin.math.min
+
+/**
+ * A buffer that wraps multiple smaller contiguous buffers,
+ * allowing to treat them, as if they were a single buffer.
+ */
+class CompositeBuffer(
+    private val data: List<ByteArray>,
+) {
+    private var position: Int = 0
+    private val length = data.sumOf { it.size }
+
+    /**
+     * Returns the number of [Byte]s remaining in the buffer.
+     */
+    fun remaining() = length - position
+
+    /**
+     * Returns whether the buffer still has [Byte]s to read.
+     */
+    fun hasRemaining() = position != length
+
+    /**
+     * Transfers [length] bytes into [destination] starting at [offset].
+     */
+    @Throws(IndexOutOfBoundsException::class)
+    fun read(destination: ByteArray, offset: Int, length: Int) {
+        if (destination.size < offset + length) {
+            throw IndexOutOfBoundsException("Destination buffer does not have enough space to hold ${offset + length} bytes" )
+        }
+
+        var bytesTransferred = 0
+        var globalOffset = 0
+        var writeOffset = offset
+
+        for (chunk in data) {
+            if (position >= globalOffset + chunk.size) {
+                globalOffset += chunk.size
+                continue
+            }
+
+            val chunkOffset = position - globalOffset
+            val available = chunk.size - chunkOffset
+            val remaining = length - bytesTransferred
+            val toCopy = min(available, remaining)
+
+            chunk.copyInto(
+                destination,
+                writeOffset,
+                chunkOffset,
+                chunkOffset + toCopy
+            )
+
+            position += toCopy
+            writeOffset += toCopy
+            bytesTransferred += toCopy
+
+            if (bytesTransferred == length) break
+            globalOffset += chunk.size
+        }
+    }
+}

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -81,19 +81,6 @@ data class Segment(
      * Length of the media data.
      */
     fun length(): Int = data.sumOf { it.size }
-
-    /**
-     * Media data as a single array.
-     */
-    fun data(): ByteArray {
-        val result = ByteArray(length())
-        var offset = 0
-        for (chunk in data) {
-            System.arraycopy(chunk, 0, result, offset, chunk.size)
-            offset += chunk.size
-        }
-        return result
-    }
 }
 
 /**

--- a/app/src/test/java/com/github/libretube/player/parser/CompositeBufferTest.kt
+++ b/app/src/test/java/com/github/libretube/player/parser/CompositeBufferTest.kt
@@ -1,0 +1,97 @@
+package com.github.libretube.player.parser
+
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class CompositeBufferTest {
+    @Test
+    fun testReadSingleChunk() {
+        val buffer = CompositeBuffer(
+            listOf(byteArrayOf(1, 2, 3, 4, 5))
+        )
+
+        val dst = ByteArray(5)
+        buffer.read(dst, 0, 5)
+
+        assertArrayEquals(byteArrayOf(1, 2, 3, 4, 5), dst)
+        assertEquals(0, buffer.remaining())
+        assertFalse(buffer.hasRemaining())
+    }
+
+    @Test
+    fun testReadAcrossMultipleChunks() {
+        val buffer = CompositeBuffer(
+            listOf(
+                byteArrayOf(1, 2),
+                byteArrayOf(3, 4, 5),
+                byteArrayOf(6)
+            )
+        )
+
+        val dst = ByteArray(6)
+        buffer.read(dst, 0, 6)
+        assertArrayEquals(byteArrayOf(1, 2, 3, 4, 5, 6), dst)
+        assertEquals(0, buffer.remaining())
+        assertFalse(buffer.hasRemaining())
+    }
+
+    @Test
+    fun testPartialRead() {
+        val buffer = CompositeBuffer(
+            listOf(
+                byteArrayOf(1, 2, 3),
+                byteArrayOf(4, 5)
+            )
+        )
+
+        val dst = ByteArray(2)
+        buffer.read(dst, 0, 2)
+
+        assertArrayEquals(byteArrayOf(1, 2), dst)
+        assertEquals(3, buffer.remaining())
+        assertTrue(buffer.hasRemaining())
+    }
+
+    @Test
+    fun testSequentialReadsMaintainPosition() {
+        val buffer = CompositeBuffer(
+            listOf(
+                byteArrayOf(1, 2),
+                byteArrayOf(3, 4, 5)
+            )
+        )
+
+        val first = ByteArray(3)
+        buffer.read(first, 0, 3)
+        assertArrayEquals(byteArrayOf(1, 2, 3), first)
+
+        val second = ByteArray(2)
+        buffer.read(second, 0, 2)
+        assertArrayEquals(byteArrayOf(4, 5), second)
+        assertFalse(buffer.hasRemaining())
+    }
+
+    @Test
+    fun testReadWithOffsetInDestination() {
+        val buffer = CompositeBuffer(
+            listOf(byteArrayOf(7, 8, 9))
+        )
+
+        val dst = ByteArray(5) { 0 }
+        buffer.read(dst, 1, 3)
+        assertArrayEquals(byteArrayOf(0, 7, 8, 9, 0), dst)
+    }
+
+    @Test
+    fun testReadOutOfBounds() {
+        val buffer = CompositeBuffer(
+            listOf(byteArrayOf(7, 8, 9))
+        )
+
+        val dst = ByteArray(5) { 0 }
+        assertThrows(IndexOutOfBoundsException::class.java, {
+            buffer.read(dst, 1, Int.MAX_VALUE - dst.size)
+        })
+    }
+}

--- a/app/src/test/java/com/github/libretube/player/parser/UmpParserTest.kt
+++ b/app/src/test/java/com/github/libretube/player/parser/UmpParserTest.kt
@@ -1,6 +1,5 @@
 package com.github.libretube.player.parser
 
-import androidx.annotation.VisibleForTesting
 import org.junit.Test
 import org.junit.Assert.*
 import video_streaming.UmpPartId


### PR DESCRIPTION
Uses a `CompositeBuffer`, which wraps multiple smaller contiguous buffers and allows reading from them, as if they were a single buffer. This avoids copying the segment data into a single array, before reading from it, improving performance and reducing memory pressure.

This was originally part of https://github.com/libre-tube/LibreTube/pull/7689, however it must have been some in a rebase at some point.