### PR TITLE
fix: correct "0 weeks ago" relative date for ~7 day old items (#8295)

### DIFF
--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -109,23 +109,47 @@ object TextUtils {
     fun formatRelativeDate(unixTime: Long): CharSequence {
         val date = LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTime), ZoneId.systemDefault())
         val now = LocalDateTime.now()
-        val months = date.until(now, ChronoUnit.MONTHS)
 
-        return if (months > 0) {
-            val years = months / 12
-
-            val (timeFormat, time) = if (years > 0) {
-                RelativeDateTimeFormatter.RelativeUnit.YEARS to years
-            } else {
-                RelativeDateTimeFormatter.RelativeUnit.MONTHS to months
+       //Before hand the issue was contradicting as we were calulating through two different
+       //methods one through ChoronUnit.WEEKS and other in milliseconds hence contradicting to each other !!
+        
+        val relativeTime = getRelativeTimeUnit(date, now)
+        return if (relativeTime != null) {
+            val (unit, amount) = relativeTime
+            val formatUnit = when (unit) {
+                ChronoUnit.YEARS -> RelativeDateTimeFormatter.RelativeUnit.YEARS
+                ChronoUnit.MONTHS -> RelativeDateTimeFormatter.RelativeUnit.MONTHS
+                else -> RelativeDateTimeFormatter.RelativeUnit.WEEKS
             }
             RelativeDateTimeFormatter.getInstance()
-                .format(time.toDouble(), RelativeDateTimeFormatter.Direction.LAST, timeFormat)
+                .format(amount.toDouble(), RelativeDateTimeFormatter.Direction.LAST, formatUnit)
         } else {
-            val weeks = date.until(now, ChronoUnit.WEEKS)
-            val minResolution = if (weeks > 0) DateUtils.WEEK_IN_MILLIS else 0L
-            DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), minResolution)
+
+
+            // Less than a week ago: DateUtils handles days/hours/minutes correctly.
+            // now DateUtils will work only when time is genuinely less thna a week
+            DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), 0L)
         }
+    }
+
+    
+    // Decide which relative time unit (and how many of it) to display for a date in the past.
+    
+    
+    internal fun getRelativeTimeUnit(
+        date: LocalDateTime,
+        now: LocalDateTime
+    ): Pair<ChronoUnit, Long>? {
+        val months = date.until(now, ChronoUnit.MONTHS)
+        if (months > 0) {
+            val years = months / 12
+            return if (years > 0) ChronoUnit.YEARS to years else ChronoUnit.MONTHS to months
+        }
+
+        val weeks = date.until(now, ChronoUnit.WEEKS)
+        if (weeks > 0) return ChronoUnit.WEEKS to weeks
+
+        return null
     }
 
     fun formatBitrate(bitrate: Int?): String {

--- a/app/src/test/java/com/github/libretube/RelativeTimeUnitTest.kt
+++ b/app/src/test/java/com/github/libretube/RelativeTimeUnitTest.kt
@@ -1,0 +1,51 @@
+package com.github.libretube
+
+import com.github.libretube.util.TextUtils.getRelativeTimeUnit
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RelativeTimeUnitTest {
+    // Fixed reference point so the assertions are deterministic.
+    private val now: LocalDateTime = LocalDateTime.of(2026, 6, 19, 12, 0)
+
+    private fun unitFor(date: LocalDateTime) = getRelativeTimeUnit(date, now)
+
+    @Test
+    fun lessThanAWeekFallsBackToFinerGrainedFormatter() {
+        // null signals the caller to delegate to DateUtils (days/hours/minutes).
+        assertNull(unitFor(now))
+        assertNull(unitFor(now.minusHours(5)))
+        assertNull(unitFor(now.minusDays(1)))
+        assertNull(unitFor(now.minusDays(6)))
+    }
+
+    @Test
+    fun exactlySevenDaysAgoIsOneWeek() {
+        // Regression test for #8295: this used to render "0 weeks ago".
+        assertEquals(ChronoUnit.WEEKS to 1L, unitFor(now.minusDays(7)))
+    }
+
+    @Test
+    fun weeksAreReportedForSpansBelowAMonth() {
+        assertEquals(ChronoUnit.WEEKS to 1L, unitFor(now.minusDays(13)))
+        assertEquals(ChronoUnit.WEEKS to 2L, unitFor(now.minusDays(14)))
+        assertEquals(ChronoUnit.WEEKS to 3L, unitFor(now.minusDays(21)))
+    }
+
+    @Test
+    fun monthsAreReportedBelowAYear() {
+        assertEquals(ChronoUnit.MONTHS to 1L, unitFor(now.minusMonths(1)))
+        assertEquals(ChronoUnit.MONTHS to 2L, unitFor(now.minusMonths(2)))
+        assertEquals(ChronoUnit.MONTHS to 11L, unitFor(now.minusMonths(11)))
+    }
+
+    @Test
+    fun yearsAreReportedFromTwelveMonths() {
+        assertEquals(ChronoUnit.YEARS to 1L, unitFor(now.minusMonths(12)))
+        assertEquals(ChronoUnit.YEARS to 1L, unitFor(now.minusMonths(23)))
+        assertEquals(ChronoUnit.YEARS to 2L, unitFor(now.minusYears(2)))
+    }
+}


### PR DESCRIPTION
Fixes #8295

## Problem

`TextUtils.formatRelativeDate()` could display **"0 weeks ago"** for an item
uploaded roughly 7 days ago, instead of **"1 week ago"**.

## Root cause

The week branch used **two independent time calculations** that could disagree:

1. `date.until(now, ChronoUnit.WEEKS)` — a calendar-based count — would evaluate
   to `1`, so the code forced `DateUtils` to render in *week* units by passing
   `minResolution = DateUtils.WEEK_IN_MILLIS`.
2. `DateUtils.getRelativeTimeSpanString(...)` then did its own **millisecond-based**
   count, which could come out as *just under* a week (`0`).

So we told `DateUtils` "show this in weeks", while its internal count was `0` →
the result was the contradictory **"0 weeks ago"**. This matches the maintainer's
own analysis in the issue thread.

## Fix

Let a **single** calendar calculation decide both the unit *and* the amount, so
the two can never disagree:

- Extracted the unit-selection logic into a small, Android-free helper
  `getRelativeTimeUnit(date, now)` that returns a `Pair<ChronoUnit, Long>?`
  (years / months / weeks), or `null` when the span is below one week.
- `formatRelativeDate()` now formats weeks itself via `RelativeDateTimeFormatter`
  (exactly like it already did for months/years), instead of delegating the count
  to `DateUtils`.
- `DateUtils` is now only used when the span is genuinely **less than a week**
  (days / hours / minutes), where it works correctly.

Because the displayed number now comes from the same count that selects the unit,
"1 week" can no longer render as "0 weeks".

## Tests

Added `RelativeTimeUnitTest` (plain JUnit, no Robolectric needed since the helper
is dependency-free) covering the calendar logic against a fixed reference time:

- **Regression for this issue:** exactly 7 days ago → `(WEEKS, 1)`
- `< 1 week` (now, 5h, 1d, 6d) → `null` (falls back to DateUtils)
- 13d / 14d / 21d → 1 / 2 / 3 weeks
- 1 / 2 / 11 months → months
- 12 / 23 months, 2 years → years

All 5 pass locally (`./gradlew :app:testDebugUnitTest`).
