### PR TITLE
Fix : shows 1 week ago instead of 0 weeks ago for 7 days old items (#8295)

### DIFF
--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -123,8 +123,13 @@ object TextUtils {
                 .format(time.toDouble(), RelativeDateTimeFormatter.Direction.LAST, timeFormat)
         } else {
             val weeks = date.until(now, ChronoUnit.WEEKS)
-            val minResolution = if (weeks > 0) DateUtils.WEEK_IN_MILLIS else 0L
-            DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), minResolution)
+            
+            if(weeks > 0){
+                RelativeDateTimeFormatter.getInstance()
+                  .format(weeks.toDouble(), RelativeDateTimeFormatter.Direction.LAST, RelativeDateTimeFormatter.RelativeUnit.WEEKS)
+            } else {
+                DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), 0L)
+            }
         }
     }
 

--- a/app/src/main/java/com/github/libretube/util/TextUtils.kt
+++ b/app/src/main/java/com/github/libretube/util/TextUtils.kt
@@ -107,30 +107,42 @@ object TextUtils {
     }
 
     fun formatRelativeDate(unixTime: Long): CharSequence {
-        val date = LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTime), ZoneId.systemDefault())
+        
         val now = LocalDateTime.now()
-        val months = date.until(now, ChronoUnit.MONTHS)
+        val relativeTime = getRelativeTimeUnit(unixTime, now)
 
-        return if (months > 0) {
-            val years = months / 12
-
-            val (timeFormat, time) = if (years > 0) {
-                RelativeDateTimeFormatter.RelativeUnit.YEARS to years
-            } else {
-                RelativeDateTimeFormatter.RelativeUnit.MONTHS to months
+        return if (relativeTime != null) {
+            val (unit,amount) = relativeTime
+            val formatUnit = when (unit){
+                ChronoUnit.YEARS -> RelativeDateTimeFormatter.RelativeUnit.YEARS
+                ChronoUnit.MONTHS -> RelativeDateTimeFormatter.RelativeUnit.MONTHS
+                else -> RelativeDateTimeFormatter.RelativeUnit.WEEKS
             }
+           
             RelativeDateTimeFormatter.getInstance()
-                .format(time.toDouble(), RelativeDateTimeFormatter.Direction.LAST, timeFormat)
+                .format(amount.toDouble(), RelativeDateTimeFormatter.Direction.LAST, formatUnit)
         } else {
-            val weeks = date.until(now, ChronoUnit.WEEKS)
-            
-            if(weeks > 0){
-                RelativeDateTimeFormatter.getInstance()
-                  .format(weeks.toDouble(), RelativeDateTimeFormatter.Direction.LAST, RelativeDateTimeFormatter.RelativeUnit.WEEKS)
-            } else {
                 DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), 0L)
             }
-        }
+    }
+    
+
+    internal fun getRelativeTimeUnit(
+        unixTime:Long, now: LocalDateTime, zone: ZoneId = ZoneId.systemDefault()
+    ): Pair<ChronoUnit, Long>? {
+
+     val date= LocalDateTime.ofInstant(Instant.ofEpochMilli(unixTime), zone)
+     val months = date.until(now, ChronoUnit.MONTHS)
+     if(months>0){
+        val years = months/12
+        return if (years>0) ChronoUnit.YEARS to  years 
+        else ChronoUnit.MONTHS to months
+     }
+
+     val weeks = date.until(now, ChronoUnit.WEEKS)
+     if(weeks>0) return ChronoUnit.WEEKS to weeks
+     return null
+
     }
 
     fun formatBitrate(bitrate: Int?): String {

--- a/app/src/test/java/com/github/libretube/RelativeDateTest.kt
+++ b/app/src/test/java/com/github/libretube/RelativeDateTest.kt
@@ -1,0 +1,20 @@
+package com.github.libretube
+
+import com.github.libretube.util.TextUtils
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RelativeDateTest {
+    @Test
+    fun reportOneWeek() {
+        val zone = ZoneId.of("America/New_York")
+        val now = LocalDateTime.of(2025, 3, 12, 12, 0)
+        val sevenago = ZonedDateTime.of(2025, 3, 5, 12, 0, 0, 0, zone).toInstant().toEpochMilli()
+
+        assertEquals(ChronoUnit.WEEKS to 1L, TextUtils.getRelativeTimeUnit(sevenago, now, zone))
+    }
+}


### PR DESCRIPTION
Fixes #8295 

## Bug : "When some of the videos listed were approximately 7 days old they were visible as 0 weeks ago instead of 1 week ago"
## Reason : In else block of formatRelativeDate(), weeks were being calculated in bit of contradictory method :
1. `date.until(now, ChronoUnit.WEEKS)` => this counted the weeks exactly according to the calendar algorithm i.e returns 1 week on 7 days.
2. Previously we used to call `DateUtils.getRelativeTimeSpanString(....)` along with `minResolution = WEEK_IN_MILLIS` , Here minResolution was a flag which asks DateUtils to shows show "weeks in unit" but DateUtils counts milliseconds inside itself seperately due to which if time was bit less than 7 then it returns count to be 0 i.e "0 weeks ago".

In short : our count(1) and inner count(0) of DateUtils clashes hence contradiction occurs.

## FIX: 
Before :
``val weeks = date.until(now, ChronoUnit.WEEKS)``
``val minResolution = if (weeks > 0) DateUtils.WEEK_IN_MILLIS else 0L``
``DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), minResolution)``

After :
``val weeks = date.until(now, ChronoUnit.WEEKS)``
``if (weeks > 0) {``
    ``RelativeDateTimeFormatter.getInstance()``
      ``  .format(weeks.toDouble(), RelativeDateTimeFormatter.Direction.LAST, RelativeDateTimeFormatter.RelativeUnit.WEEKS)``
``} else {``
    ``DateUtils.getRelativeTimeSpanString(unixTime, System.currentTimeMillis(), 0L)``
``}``

## Changes :

1. We Removed the concept of ``minResolution``` where ``DateUtils``  used to handle  week operations.
2. Now when ``weeks>=1``, the formatting is done with the ``RelativeDateTimeFormatter`` , through this that "0 weeks" thing becomes impossible.
3. When ``weeks<1`` then ``DateUtils`` now shows ``DateUtils( 0L )`` like this shows the proper format in days.


Verified by compiling the project successfully.