### PR TITLE
fix: updated ungrouped channels immediately after adding to group

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/AddChannelToGroupSheet.kt
@@ -11,9 +11,13 @@ import com.github.libretube.ui.adapters.AddChannelToGroupAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.fragment.app.activityViewModels
+import com.github.libretube.ui.models.SubscriptionsViewModel
 
 class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_to_group) {
     private lateinit var channelId: String
+
+    private val viewModel: SubscriptionsViewModel by activityViewModels()
 
     private val addToGroupAdapter by lazy(LazyThreadSafetyMode.NONE) {
         AddChannelToGroupAdapter(channelId)
@@ -47,6 +51,8 @@ class AddChannelToGroupSheet : ExpandedBottomSheet(R.layout.dialog_add_channel_t
 
                     lifecycleScope.launch(Dispatchers.IO) {
                         subGroupsDao.updateAll(subscriptionGroups)
+
+                        viewModel.groups.postValue(subscriptionGroups)
 
                         withContext(Dispatchers.Main) {
                             dialog?.dismiss()

--- a/app/src/main/java/com/github/libretube/ui/sheets/SubscriptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/SubscriptionsBottomSheet.kt
@@ -95,7 +95,7 @@ class SubscriptionsBottomSheet : ExpandedBottomSheet(R.layout.sheet_subscription
         if (!viewModel.groups.value.isNullOrEmpty()) {
             binding.ungroupedSubsBtn.text = requireContext().getString(
                 R.string.ungrouped_channels_with_count,
-                viewModel.subscriptions.value?.size ?: 0
+                getUngroupedChannels().size
             )
             binding.ungroupedSubsBtn.setOnClickListener {
                 binding.groupEditBtn.isVisible = false


### PR DESCRIPTION
Fixes #8428

## Issue

When a channel was added in the group, then it wasn't getting updated instantly and also was showing wrong count of the channels and the channel were still in the ungrouped section even after adding them in group.



## Fix

1. Ungrouped Count was using size of all the subsciptions rather than of ungrouped. Now it uses getUngroupedChannels().size.

2. On the long press -> Add to Group was updating the DB but not viewModel.groups hence list was lagging. Now after save viewModel.groups also gets updated hence instant refresh.

## Tested

On Physical Device 

<img width="300" alt="WhatsApp Image 2026-06-24 at 3 52 05 PM" src="https://github.com/user-attachments/assets/6b512a30-a57d-4627-b286-9e298a4051c8" />
