### PR TITLE
fix(Comments): reset comment count when resetting comments

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
+++ b/app/src/main/java/com/github/libretube/ui/models/CommentsViewModel.kt
@@ -30,8 +30,8 @@ class CommentsViewModel : ViewModel() {
     }
         .cachedIn(viewModelScope)
 
-    private val _commentCountLiveData = MutableLiveData<Long>()
-    val commentCountLiveData: LiveData<Long> = _commentCountLiveData
+    private val _commentCountLiveData = MutableLiveData<Long?>()
+    val commentCountLiveData: LiveData<Long?> = _commentCountLiveData
 
     private val _currentCommentsPosition = MutableLiveData(0)
     val currentCommentsPosition: LiveData<Int> = _currentCommentsPosition
@@ -41,6 +41,7 @@ class CommentsViewModel : ViewModel() {
 
     fun reset() {
         _currentCommentsPosition.value = 0
+        _commentCountLiveData.value = null
     }
 
     fun setCommentsPosition(position: Int) {


### PR DESCRIPTION
Fixes an issue, where the comment count of the previous video would still be displayed before loading the new comments, as the viewmodel was kept alive and not reset.