### PR TITLE
chore: lower minimum SDK requirement to API 25

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 
     defaultConfig {
         applicationId = "com.github.libretube"
-        minSdk = 26
+        minSdk = 25
         targetSdk = 36
         versionCode = 70
         versionName = "31.4"

--- a/app/src/main/java/com/github/libretube/api/poToken/PoTokenWebView.kt
+++ b/app/src/main/java/com/github/libretube/api/poToken/PoTokenWebView.kt
@@ -1,10 +1,12 @@
 package com.github.libretube.api.poToken
 
 import android.content.Context
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.annotation.MainThread
 import com.github.libretube.BuildConfig
@@ -32,12 +34,20 @@ class PoTokenWebView private constructor(
     }
     private lateinit var expirationInstant: Instant
 
+    private var WebSettings.safeBrowsingEnabledCompat: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && safeBrowsingEnabled
+        set(value) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                safeBrowsingEnabled = value
+            }
+        }
+
     //region Initialization
     init {
         webView.settings.apply {
             //noinspection SetJavaScriptEnabled we want to use JavaScript!
             javaScriptEnabled = true
-            safeBrowsingEnabled = false
+            safeBrowsingEnabledCompat = false
             userAgentString = USER_AGENT
             blockNetworkLoads = true // the WebView does not need internet access
         }

--- a/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
+++ b/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
@@ -3,11 +3,13 @@ package com.github.libretube.compat
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 
 object PictureInPictureCompat {
 
     fun isPictureInPictureAvailable(context: Context) =
-        context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
     fun isInPictureInPictureMode(activity: Activity) = activity.isInPictureInPictureMode
 

--- a/app/src/main/java/com/github/libretube/helpers/DisplayHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/DisplayHelper.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.helpers
 
 import android.content.Context
+import android.os.Build
 import androidx.core.content.ContextCompat
 
 object DisplayHelper {
@@ -8,5 +9,7 @@ object DisplayHelper {
      * Detect whether the device supports HDR as the ExoPlayer doesn't handle it properly
      * Returns false below SDK 24
      */
-    fun supportsHdr(context: Context) = ContextCompat.getDisplayOrDefault(context).isHdr
+    fun supportsHdr(context: Context) =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && ContextCompat.getDisplayOrDefault(context).isHdr
 }

--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
+import android.os.Build
 import android.os.storage.StorageManager
 import android.widget.ImageView
 import androidx.core.content.getSystemService
@@ -24,6 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import java.io.File
 import java.nio.file.Path
 
 object ImageHelper {
@@ -57,14 +59,26 @@ object ImageHelper {
                 diskCachePolicy(CachePolicy.ENABLED)
                 memoryCachePolicy(CachePolicy.ENABLED)
 
-                val storageManager = context.getSystemService<StorageManager>()!!
-                val availableCache = storageManager.getCacheQuotaBytes(
-                    storageManager.getUuidForPath(context.coilFile)
-                )
+                fun Context.maxCacheSizeBytes(path: File): Long {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        getSystemService<StorageManager>()?.let {
+                            return it.getCacheQuotaBytes(it.getUuidForPath(path))
+                        }
+                    }
+
+                    val totalGb = path.totalSpace / (1024 * 1024 * 1024)
+                    val cacheMb = when {
+                        totalGb <= 16 -> 32
+                        totalGb <= 32 -> 64
+                        else -> 128
+                    }
+                    return cacheMb * 1024 * 1024L
+                }
+
                 val diskCache = DiskCache.Builder()
                     .directory(context.coilFile)
                     // only use a certain percentage of the available cache size for images
-                    .maxSizeBytes(availableCache)
+                    .maxSizeBytes(context.maxCacheSizeBytes(context.coilFile))
                     .build()
                 diskCache(diskCache)
             }

--- a/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
+++ b/app/src/main/java/com/github/libretube/ui/adapters/VideoCardsAdapter.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -140,9 +141,12 @@ class VideoCardsAdapter(private val columnWidthDp: Float? = null) :
                                 context.getDrawable(it)
                             )
                         }
-                        sponsorBadgeIcon.tooltipText =
-                            SponsorBlockLabelHelper.categoryLabel(category)
-                                ?.let { context.getString(it) }
+                        SponsorBlockLabelHelper.categoryLabel(category)?.let {
+                            ViewCompat.setTooltipText(
+                                sponsorBadgeIcon,
+                                context.getString(it)
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
This patch adds LibreTube compatibility for Nougat devices.

The change is not that big, so I think it is worth bringing old devices back to life.

As the StorageManager API used for image cache size calculation is unavailable on Nougat, I referenced commit 2200a4c to select the cache size (16/32/64/128/256/512 MB) based on internal storage instead.