### PR TITLE
Add relative seeking when dragging

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/DismissableTimeBar.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/DismissableTimeBar.kt
@@ -8,7 +8,6 @@ import android.view.ViewConfiguration
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.DefaultTimeBar
-import androidx.media3.ui.PlayerControlView
 import androidx.media3.ui.TimeBar
 import androidx.media3.ui.TimeBar.OnScrubListener
 import com.github.libretube.extensions.dpToPx
@@ -26,88 +25,92 @@ open class DismissableTimeBar(
     // Drag-only seeking state
     private var initialX: Float = 0f
     private var initialY: Float = 0f
+    private var initialPlaybackPosition: Long = 0
+    private var currentScrubPosition: Long = 0
     private var shouldPlayerSeek: Boolean = true
     private var waitingForDrag: Boolean = false
     private var dragStarted: Boolean = false
     private val touchSlopPx: Int = ViewConfiguration.get(context).scaledTouchSlop
 
-    init {
-        super.addListener(object : OnScrubListener {
-            override fun onScrubStart(timeBar: TimeBar, position: Long) {
-                listeners.forEach { it.onScrubStart(timeBar, position) }
-            }
-
-            override fun onScrubMove(timeBar: TimeBar, position: Long) {
-                listeners.forEach { it.onScrubMove(timeBar, position) }
-            }
-
-            override fun onScrubStop(timeBar: TimeBar, position: Long, canceled: Boolean) {
-                listeners.forEach { it.onScrubStop(timeBar, position, canceled) }
-
-                if (canceled) return
-                if (shouldPlayerSeek) exoPlayer?.seekTo(position)
-            }
-        })
-    }
-
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
+        val player = exoPlayer ?: return super.onTouchEvent(event)
+        val duration = player.duration
+        
+        // Fallback to absolute seeking for live streams or invalid durations
+        if (duration <= 0) return super.onTouchEvent(event)
+
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 initialX = event.x
                 initialY = event.y
                 waitingForDrag = true
                 dragStarted = false
-                // Consume without forwarding to prevent tap-to-seek or thumb jump
+                // Consume to prevent tap-to-seek or thumb jump from DefaultTimeBar
                 return true
             }
 
             MotionEvent.ACTION_MOVE -> {
                 if (waitingForDrag) {
-                    // make sure that the user dragged at least touchSlopPx pixels
-                    // which is the minimum amount to trigger a drag event
                     val dx = abs(event.x - initialX)
                     val dy = abs(event.y - initialY)
                     if (dx > touchSlopPx || dy > touchSlopPx) {
-                        // Begin scrubbing now by synthesizing a DOWN at the current progress X
-                        val fakeDown = MotionEvent.obtain(event).apply {
-                            action = MotionEvent.ACTION_DOWN
-                            setLocation(event.x, event.y)
-                        }
-                        super.onTouchEvent(fakeDown)
-                        fakeDown.recycle()
-
                         waitingForDrag = false
                         dragStarted = true
-                    } else {
-                        // Still not considered a drag; consume
-                        return true
+                        initialPlaybackPosition = player.currentPosition
+                        currentScrubPosition = initialPlaybackPosition
+                        
+                        // Notify listeners that scrubbing has started
+                        listeners.forEach { it.onScrubStart(this, initialPlaybackPosition) }
                     }
                 }
 
-                // Forward MOVE only after we've started dragging, with relative X
                 if (dragStarted) {
-                    return super.onTouchEvent(event)
+                    val deltaX = event.x - initialX
+                    val barWidth = width.toFloat()
+                    
+                    // Fine Seeking logic:
+                    // As the finger moves vertically away from the bar, decrease seeking sensitivity.
+                    val verticalDistance = abs(event.y - initialY)
+                    val sensitivityLimit = 150f.dpToPx() // Maximum distance for scaling
+                    val sensitivity = (1f - (verticalDistance / sensitivityLimit) * 0.8f).coerceIn(0.2f, 1f)
+                    
+                    // Calculate relative time offset
+                    val deltaTime = (deltaX / barWidth) * duration * sensitivity
+                    currentScrubPosition = (initialPlaybackPosition + deltaTime.toLong()).coerceIn(0, duration)
+                    
+                    // Update visual position of the bar
+                    super.setPosition(currentScrubPosition)
+                    
+                    // Notify listeners (like SeekbarPreviewListener) to update preview
+                    listeners.forEach { it.onScrubMove(this, currentScrubPosition) }
                 }
                 return true
             }
 
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                // If we started a drag, forward the terminal event to finish scrubbing
                 if (dragStarted) {
-                    waitingForDrag = false
-                    dragStarted = false
-                    shouldPlayerSeek =
-                        event.y > TOUCH_SEEK_LIMIT_ABOVE.dpToPx() &&
-                                event.y < TOUCH_SEEK_LIMIT_BELOW.dpToPx()
+                    val isCanceled = event.actionMasked == MotionEvent.ACTION_CANCEL
+                    
+                    // Determine if we should seek based on vertical drag limit (Dismissable behavior)
+                    shouldPlayerSeek = !isCanceled &&
+                            event.y > TOUCH_SEEK_LIMIT_ABOVE.dpToPx() &&
+                            event.y < TOUCH_SEEK_LIMIT_BELOW.dpToPx()
 
-                    return super.onTouchEvent(event)
+                    // Notify listeners that scrubbing has stopped
+                    listeners.forEach { it.onScrubStop(this, currentScrubPosition, isCanceled) }
+
+                    if (shouldPlayerSeek) {
+                        player.seekTo(currentScrubPosition)
+                    }
+                    
+                    dragStarted = false
+                    waitingForDrag = false
+                    return true
                 }
 
-                // It's a tap without drag: do nothing (prevent seek and thumb jump)
                 waitingForDrag = false
                 dragStarted = false
-                // Optionally report click for accessibility without side effects
                 performClick()
                 return true
             }
@@ -116,12 +119,18 @@ open class DismissableTimeBar(
         return super.onTouchEvent(event)
     }
 
+    override fun setPosition(position: Long) {
+        if (!dragStarted) {
+            super.setPosition(position)
+        }
+    }
+
     /**
      * DO NOT CALL THIS METHOD DIRECTLY. Use [addSeekBarListener] instead!
      */
     @Deprecated("Use addSeekBarListener instead")
     override fun addListener(listener: OnScrubListener) {
-        // do nothing, see below on how listeners should be set
+        // Ignored
     }
 
     /**
@@ -129,19 +138,13 @@ open class DismissableTimeBar(
      */
     @Deprecated("Use removeSeekBarListener instead")
     override fun removeListener(listener: OnScrubListener) {
-        // do nothing
+        // Ignored
     }
 
-    /**
-     * Wrapper to circumvent adding the listener created by [PlayerControlView]
-     */
     fun addSeekBarListener(listener: OnScrubListener) {
         listeners.add(listener)
     }
 
-    /**
-     * Wrapper to circumvent removing the listener created by [PlayerControlView]
-     */
     fun removeSeekBarListener(listener: OnScrubListener) {
         listeners.remove(listener)
     }


### PR DESCRIPTION
Closes #8569 
Currently, DismissableTimeBar seeks in absolute mode: touching the bar jumps the thumb (and playback position) directly to the X-coordinate of the touch. This makes fine seeking difficult, especially on longer videos where a small touch offset translates to a large time jump.
This PR changes the seeking behavior to relative dragging, similar to YouTube: the seek position is now calculated as an offset from the player's position at the start of the drag, rather than being mapped directly from the touch's absolute X position.
Changes

Relative delta calculation: On ACTION_DOWN, no seek happens immediately. Once a drag is detected (past touch slop), the current playback position is captured as initialPlaybackPosition. Subsequent ACTION_MOVE events compute a time delta from the horizontal drag distance (deltaX / barWidth * duration) and apply it relative to that anchor.
Removed synthetic ACTION_DOWN forwarding: The previous approach faked a DOWN event at the touch location to trick DefaultTimeBar into absolute-seeking from that point. This is no longer needed since the scrub position is computed and set manually via setPosition.
setPosition override: Prevents background player progress updates from overwriting the bar's visual position while the user is actively dragging.
Manual listener notification: onScrubStart / onScrubMove / onScrubStop are now invoked directly with the calculated relative position instead of relying on DefaultTimeBar's internal scrub listener.
ACTION_CANCEL handling: Seeking is now correctly skipped when the touch is canceled (isCanceled check), in addition to the existing vertical dismiss-to-cancel threshold.
Live stream / invalid duration fallback: If player.duration is unavailable or <= 0, the view falls back to the previous (super) touch handling to avoid division-by-zero and undefined relative-seek behavior.

Behavior

Tap without drag: no-op (as before), just triggers performClick().
Drag horizontally: seek position moves relative to the player's position at drag start, not the absolute touch X.
Drag vertically past the dismiss threshold: cancels the seek on release (existing DismissableTimeBar behavior, preserved).