### PR TITLE
Default "Delete only watched videos" to true in delete all downloads dialog

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/DownloadsFragment.kt
@@ -323,13 +323,13 @@ class DownloadsFragmentPage : DynamicLayoutManagerFragment(R.layout.fragment_dow
     }
 
     private fun showDeleteAllDialog(context: Context, adapter: DownloadsAdapter) {
-        var onlyDeleteWatchedVideos = false
+        var onlyDeleteWatchedVideos = true
 
         MaterialAlertDialogBuilder(context)
             .setTitle(R.string.delete_all)
             .setMultiChoiceItems(
                 arrayOf(getString(R.string.delete_only_watched_videos)),
-                null
+                booleanArrayOf(true)
             ) { _, _, selected ->
                 onlyDeleteWatchedVideos = selected
             }


### PR DESCRIPTION
The "Delete only watched videos" option in the DownloadsFragment delete all dialog to be checked by default.

1. User Behavior: I believe clearing out only watched content would occur with a much higher frequency than the action of wiping the entire download library.

2. Data Safety and Cost: If a user accidentally confirms the dialog contrary to their intent, the cost(data/bandwidth cost, time/effort cost, cognitive cost, ...) of losing their entire library including unwatched content is far higher than the inconvenience of having to re-run the process to remove the remaining unwatched videos. This change improves overall user experience and prioritizes data safety by defaulting to the more conservative option while still allowing users to opt for a full deletion if they choose.

Another option could be to set the default behavior to delete only watched videos, changing the checkbox to "Delete all" for users who explicitly want to clear the entire library.