### PR TITLE
fix: correct isFinished logic in DownloadItem

### DIFF
--- a/app/src/main/java/com/github/libretube/db/obj/DownloadItem.kt
+++ b/app/src/main/java/com/github/libretube/db/obj/DownloadItem.kt
@@ -33,5 +33,5 @@ data class DownloadItem(
     var language: String? = null,
     var downloadSize: Long = -1L
 ) {
-    val isFinished get() = runCatching { path.fileSize() }.getOrDefault(0L) < downloadSize
+    val isFinished get() = downloadSize > 0L && runCatching { path.fileSize() }.getOrDefault(0L) >= downloadSize
 }


### PR DESCRIPTION
Update isFinished property to correctly determine if a download is complete. The logic now ensures downloadSize is valid and checks if the current file size is greater than or equal to the expected total size.