### PR TITLE
fix: crash when showing snackbar on older android version

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/extensions/SetupSubscriptionButton.kt
+++ b/app/src/main/java/com/github/libretube/ui/extensions/SetupSubscriptionButton.kt
@@ -72,6 +72,7 @@ fun TextView.setupSubscriptionButton(
             if (subscribed) {
                 Snackbar
                     .make(
+                        context,
                         rootView,
                         context.getString(R.string.unsubscribe_snackbar_message, channelName),
                         1000


### PR DESCRIPTION
Supply the target `Context` of whrere we're trying to make the snackbar from.

Fixes: #7787

-----
I dont exactly know what the exact "textbook" that caused the crash in the first place and only affecting older android versions, after a bit of research a.k.a spamming llm with bunch of stupid questions (though they dont give very convincing and consistent answers), the bottom line of what happened is that it the Snackbar.make() is trying to use context from outside of  the material component library's theme, as shown from the error log: 
```
android.view.InflateException: Binary XML file line #40: Binary XML file line #40: Error inflating class android.widget.Button...
....
....
Caused by: java.lang.UnsupportedOperationException: Failed to resolve attribute at index 16: TypedValue{t=0x2/d=0x7f040162 a=3} at android.content.res.TypedArray.getDimensionPixelSize(TypedArray.java:750)
```

It tries to use the library's theme resource/style, but its not there because the context it tries to inflate from is outside of that theme, the system's.

If you dont supply context to `Snackbar.make()` as mentioned in the [docs](https://developer.android.com/reference/com/google/android/material/snackbar/Snackbar#make(View,int,int)):
> Snackbar will try and find a parent view to hold Snackbar's view from the value given to view. Snackbar will walk up the view tree trying to find a suitable parent, which is defined as a CoordinatorLayout or the window decor's content view, whichever comes first. 

and if you check their [source](https://github.com/material-components/material-components-android/blob/ac7e18efeefb331850c561faf9ab8bf81d27ba68/lib/java/com/google/android/material/snackbar/Snackbar.java#L232) the function `makeInternal()` call function `findSuitableParent()` to use as their context, and in that function it indeed crawls up the hierarchy to find `CoordinatorLayout`.

And if it doesnt find `CoordinatorLayout` it will used the rootmost view. And for some reason on older android the root most view context is out of the app's theme.

So again, to understand exactly how that happens we need to understand if the internal architecture of the android system, which is definitely not and wont be in my todo list.

The accepted answer from this https://stackoverflow.com/questions/44749028/inflateexception-when-trying-to-use-a-snackbar explain something that similar to our case, though the the fix itself is different.

I tested this in emulator api 26 and a physical device api 29, it's not crashing anymore.