### PR TITLE
attempt to fetch playlist video from database in AddToPlaylistActivity

### DIFF
--- a/app/src/main/java/com/github/libretube/api/PlaylistsHelper.kt
+++ b/app/src/main/java/com/github/libretube/api/PlaylistsHelper.kt
@@ -72,6 +72,11 @@ object PlaylistsHelper {
             playlistsRepository.addToPlaylist(playlistId, *videos)
         }
 
+    suspend fun getVideoFromPlaylist(videoId: String) =
+        withContext(Dispatchers.IO) {
+            playlistsRepository.getVideoFromPlaylist(videoId)
+        }
+
     suspend fun renamePlaylist(playlistId: String, newName: String) =
         playlistsRepository.renamePlaylist(playlistId, newName)
 

--- a/app/src/main/java/com/github/libretube/db/dao/LocalPlaylistsDao.kt
+++ b/app/src/main/java/com/github/libretube/db/dao/LocalPlaylistsDao.kt
@@ -43,4 +43,8 @@ interface LocalPlaylistsDao {
     @Query("SELECT * FROM localPlaylistItem WHERE playlistId = :playlistId AND videoId = :videoId LIMIT 1")
     suspend fun getPlaylistVideo(playlistId: String, videoId: String): LocalPlaylistItem?
 
+
+    @Query("SELECT * FROM localPlaylistItem WHERE videoId = :videoId LIMIT 1")
+    suspend fun getVideoFromPlaylist(videoId: String): LocalPlaylistItem?
+
 }

--- a/app/src/main/java/com/github/libretube/repo/LocalPlaylistsRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalPlaylistsRepository.kt
@@ -8,6 +8,7 @@ import com.github.libretube.api.obj.Playlists
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.db.DatabaseHolder
 import com.github.libretube.db.obj.LocalPlaylist
+import com.github.libretube.db.obj.LocalPlaylistItem
 import com.github.libretube.extensions.parallelMap
 import com.github.libretube.obj.PipedImportPlaylist
 
@@ -150,5 +151,9 @@ class LocalPlaylistsRepository: PlaylistRepository {
         DatabaseHolder.Database.localPlaylistsDao().deletePlaylistItemsByPlaylistId(playlistId)
 
         return true
+    }
+
+    override suspend fun getVideoFromPlaylist(videoId: String): LocalPlaylistItem? {
+        return DatabaseHolder.Database.localPlaylistsDao().getVideoFromPlaylist(videoId)
     }
 }

--- a/app/src/main/java/com/github/libretube/repo/PipedPlaylistRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/PipedPlaylistRepository.kt
@@ -7,6 +7,7 @@ import com.github.libretube.api.obj.Message
 import com.github.libretube.api.obj.Playlist
 import com.github.libretube.api.obj.Playlists
 import com.github.libretube.api.obj.StreamItem
+import com.github.libretube.db.obj.LocalPlaylistItem
 import com.github.libretube.extensions.toID
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.obj.PipedImportPlaylist
@@ -77,5 +78,9 @@ class PipedPlaylistRepository: PlaylistRepository {
                 EditPlaylistBody(playlistId)
             ).isOk()
         }.getOrDefault(false)
+    }
+
+    override suspend fun getVideoFromPlaylist(videoId: String): LocalPlaylistItem? {
+        return null
     }
 }

--- a/app/src/main/java/com/github/libretube/repo/PlaylistRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/PlaylistRepository.kt
@@ -3,6 +3,7 @@ package com.github.libretube.repo
 import com.github.libretube.api.obj.Playlist
 import com.github.libretube.api.obj.Playlists
 import com.github.libretube.api.obj.StreamItem
+import com.github.libretube.db.obj.LocalPlaylistItem
 import com.github.libretube.obj.PipedImportPlaylist
 
 interface PlaylistRepository {
@@ -16,4 +17,5 @@ interface PlaylistRepository {
     suspend fun importPlaylists(playlists: List<PipedImportPlaylist>)
     suspend fun createPlaylist(playlistName: String): String?
     suspend fun deletePlaylist(playlistId: String): Boolean
+    suspend fun getVideoFromPlaylist(videoId: String): LocalPlaylistItem?
 }

--- a/app/src/main/java/com/github/libretube/ui/activities/AddToPlaylistActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/AddToPlaylistActivity.kt
@@ -2,13 +2,16 @@ package com.github.libretube.ui.activities
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.github.libretube.R
 import com.github.libretube.api.MediaServiceRepository
+import com.github.libretube.api.PlaylistsHelper
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.IntentData
+import com.github.libretube.extensions.TAG
 import com.github.libretube.extensions.toastFromMainDispatcher
 import com.github.libretube.helpers.IntentHelper
 import com.github.libretube.helpers.PreferenceHelper
@@ -39,18 +42,27 @@ class AddToPlaylistActivity : BaseActivity() {
         ) { _, _ -> finish() }
 
         lifecycleScope.launch(Dispatchers.IO) {
-            val videoInfo = if (PreferenceHelper.getToken().isEmpty()) {
-                try {
-                    MediaServiceRepository.instance.getStreams(videoId).toStreamItem(videoId)
-                } catch (e: Exception) {
-                    toastFromMainDispatcher(R.string.unknown_error)
-                    withContext(Dispatchers.Main) {
-                        finish()
+
+            var videoInfo = try {
+                PlaylistsHelper.getVideoFromPlaylist(videoId)?.toStreamItem()
+            } catch (e: Exception) {
+                Log.e(TAG(), e.toString())
+            }
+            if (videoInfo == null) {
+
+                videoInfo = if (PreferenceHelper.getToken().isEmpty()) {
+                    try {
+                        MediaServiceRepository.instance.getStreams(videoId).toStreamItem(videoId)
+                    } catch (e: Exception) {
+                        toastFromMainDispatcher(R.string.unknown_error)
+                        withContext(Dispatchers.Main) {
+                            finish()
+                        }
+                        return@launch
                     }
-                    return@launch
+                } else {
+                    StreamItem(videoId)
                 }
-            } else {
-                StreamItem(videoId)
             }
 
             withContext(Dispatchers.Main) {


### PR DESCRIPTION
As of now, whenever an user attempts to add a video through the share menu, video info already available in database is re-fetched from youtube and the user is left with a frozen screen until this action is complete