### PR TITLE
add a preference to control the stepSize for playback speed slider

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -72,6 +72,7 @@ object PreferenceKeys {
     const val DOUBLE_TAP_TO_SEEK = "double_tap_seek"
     const val LONG_PRESS_FAST_FORWARD = "long_press_fast_forward"
     const val ALTERNATIVE_PIP_CONTROLS = "alternative_pip_controls"
+    const val SPEED_STEP_SIZE = "playback_speed_step_size"
     const val SKIP_SILENCE = "skip_silence"
     const val AUTOPLAY_COUNTDOWN = "autoplay_countdown"
     const val AUTO_FULLSCREEN_SHORTS = "auto_fullscreen_shorts"

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -298,6 +298,12 @@ object PlayerHelper {
             true
         )
 
+    val speedStepSize: Float
+        get() = PreferenceHelper.getString(
+            PreferenceKeys.SPEED_STEP_SIZE,
+            "0.25"
+        ).toFloat()
+
     val swipeGestureEnabled: Boolean
         get() = PreferenceHelper.getBoolean(
             PreferenceKeys.PLAYER_SWIPE_CONTROLS,

--- a/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/PlaybackOptionsSheet.kt
@@ -15,12 +15,14 @@ import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.databinding.PlaybackBottomSheetBinding
 import com.github.libretube.enums.PlayerCommand
 import com.github.libretube.extensions.round
+import com.github.libretube.helpers.PlayerHelper
 import com.github.libretube.helpers.PreferenceHelper
 import com.github.libretube.services.AbstractPlayerService
 import com.github.libretube.ui.adapters.SliderLabelsAdapter
 import kotlin.math.absoluteValue
 import kotlin.math.log
 import kotlin.math.pow
+import kotlin.math.round
 
 class PlaybackOptionsSheet(
     private val player: MediaController
@@ -36,10 +38,14 @@ class PlaybackOptionsSheet(
             LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
 
         binding.speedShortcuts.adapter = SliderLabelsAdapter(SUGGESTED_SPEEDS) {
-            binding.speed.value = it
+            binding.speed.value =
+                (round(it / PlayerHelper.speedStepSize) * PlayerHelper.speedStepSize)
         }
-
-        binding.speed.value = player.playbackParameters.speed
+        PlayerHelper.speedStepSize.also {
+            binding.speed.stepSize = it
+            binding.speed.valueFrom = it
+            binding.speed.value = (round(player.playbackParameters.speed / it) * it)
+        }
         binding.pitch.value = playbackPitchToSemitone(player.playbackParameters.pitch)
 
         val currentSemitone = binding.pitch.value.round(2)

--- a/app/src/main/res/drawable/ic_step.xml
+++ b/app/src/main/res/drawable/ic_step.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM18,8h-2.42v3.33H13v3.33h-2.58V18H6v-2h2.42v-3.33H11V9.33h2.58V6H18V8z" />
+
+</vector>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -342,4 +342,12 @@
         <item>pause</item>
         <item>none</item>
     </string-array>
+
+    <string-array name="playback_speed_step_sizes">
+        <item>0.05</item>
+        <item>0.1</item>
+        <item>0.25</item>
+        <item>0.5</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -150,6 +150,15 @@
 
     <PreferenceCategory app:title="@string/misc">
 
+        <ListPreference
+            android:defaultValue="0.25"
+            android:entries="@array/playback_speed_step_sizes"
+            android:entryValues="@array/playback_speed_step_sizes"
+            android:icon="@drawable/ic_step"
+            app:key="playback_speed_step_size"
+            app:title="speed Step Size"
+            app:useSimpleSummaryProvider="true" />
+
         <com.github.libretube.ui.preferences.EditNumberPreference
             android:icon="@drawable/ic_time"
             app:defaultValue="50"


### PR DESCRIPTION
after implementing the following code, i realized that we could instead have an preference that would turn off the discrete steps by removing the stepSize attribute from the speed slider