### PR TITLE
feat: dynamic indicator width for bottom navigation on tablets

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.core.os.bundleOf
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.allViews
 import androidx.core.view.children
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.isNotEmpty
 import androidx.core.widget.NestedScrollView
 import androidx.lifecycle.lifecycleScope
@@ -238,9 +239,8 @@ class MainActivity : AbstractPlayerHostActivity() {
         val menuView =
             binding.bottomNav.getChildAt(0) as? ViewGroup ?: return
         val selectedId = binding.bottomNav.selectedItemId
-        if (cachedIndicatorWidths[selectedId] != null) {
-            binding.bottomNav.itemActiveIndicatorWidth =
-                cachedIndicatorWidths[selectedId] ?: 0
+        cachedIndicatorWidths[selectedId]?.let { cachedWidth ->
+            binding.bottomNav.itemActiveIndicatorWidth = cachedWidth
             return
         }
         calculateSelectedItemSize(selectedId, menuView, visibleCount)
@@ -254,11 +254,14 @@ class MainActivity : AbstractPlayerHostActivity() {
         val selectedIndex = (0 until binding.bottomNav.menu.size)
             .firstOrNull { binding.bottomNav.menu[it].itemId == selectedId }
             ?: return
-        binding.bottomNav.postDelayed({
-            val selectedChild = menuView.getChildAt(selectedIndex) ?: return@postDelayed
-            binding.bottomNav.itemActiveIndicatorWidth = selectedChild.width / visibleCount
-            cachedIndicatorWidths[selectedId] = selectedChild.width / visibleCount
-        }, 200)
+
+        val selectedChild = menuView.getChildAt(selectedIndex) ?: return
+
+        selectedChild.doOnPreDraw {
+            val width = selectedChild.width / visibleCount
+            binding.bottomNav.itemActiveIndicatorWidth = width
+            cachedIndicatorWidths[selectedId] = width
+        }
     }
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -7,6 +7,7 @@ import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
@@ -63,6 +64,8 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import androidx.core.view.get
+import androidx.core.view.size
 
 class MainActivity : AbstractPlayerHostActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -81,7 +84,8 @@ class MainActivity : AbstractPlayerHostActivity() {
     private val searchViewModel: SearchViewModel by viewModels()
     private val downloadViewModel: DownloadsViewModel by viewModels()
     private val playlistViewModel: PlaylistViewModel by viewModels()
-
+    //this to save width of the selected item Indicator after calculate it
+    private var cachedIndicatorWidths = mutableMapOf<Int, Int>()
     // registering for activity results is only possible, this here should have been part of
     // PlaylistOptionsBottomSheet instead if Android allowed us to
     private var playlistExportFormat: ImportFormat = ImportFormat.NEWPIPE
@@ -205,6 +209,9 @@ class MainActivity : AbstractPlayerHostActivity() {
         }
 
         binding.bottomNav.setOnItemSelectedListener {
+            if (resources.configuration.smallestScreenWidthDp >= 600) {
+                applyIndicatorForSelection()
+            }
             navigateToBottomSelectedItem(it)
         }
 
@@ -223,6 +230,35 @@ class MainActivity : AbstractPlayerHostActivity() {
         loadIntentData()
 
         showUserInfoDialogIfNeeded()
+    }
+
+    private fun applyIndicatorForSelection() {
+        val visibleCount = (0 until binding.bottomNav.menu.size)
+            .count { binding.bottomNav.menu[it].isVisible }
+        val menuView =
+            binding.bottomNav.getChildAt(0) as? ViewGroup ?: return
+        val selectedId = binding.bottomNav.selectedItemId
+        if (cachedIndicatorWidths[selectedId] != null) {
+            binding.bottomNav.itemActiveIndicatorWidth =
+                cachedIndicatorWidths[selectedId] ?: 0
+            return
+        }
+        calculateSelectedItemSize(selectedId, menuView, visibleCount)
+    }
+
+    private fun calculateSelectedItemSize(
+        selectedId: Int,
+        menuView: ViewGroup,
+        visibleCount: Int
+    ) {
+        val selectedIndex = (0 until binding.bottomNav.menu.size)
+            .firstOrNull { binding.bottomNav.menu[it].itemId == selectedId }
+            ?: return
+        binding.bottomNav.postDelayed({
+            val selectedChild = menuView.getChildAt(selectedIndex) ?: return@postDelayed
+            binding.bottomNav.itemActiveIndicatorWidth = selectedChild.width / visibleCount
+            cachedIndicatorWidths[selectedId] = selectedChild.width / visibleCount
+        }, 200)
     }
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/github/libretube/ui/activities/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AbstractPlayerHostActivity() {
     private val searchViewModel: SearchViewModel by viewModels()
     private val downloadViewModel: DownloadsViewModel by viewModels()
     private val playlistViewModel: PlaylistViewModel by viewModels()
-    //this to save width of the selected item Indicator after calculate it
+    // save width of selected bottom bar item Indicator after calculating it
     private var cachedIndicatorWidths = mutableMapOf<Int, Int>()
     // registering for activity results is only possible, this here should have been part of
     // PlaylistOptionsBottomSheet instead if Android allowed us to
@@ -210,7 +210,7 @@ class MainActivity : AbstractPlayerHostActivity() {
         }
 
         binding.bottomNav.setOnItemSelectedListener {
-            if (resources.configuration.smallestScreenWidthDp >= 600) {
+            if (resources.configuration.smallestScreenWidthDp >= MINIMUM_SCREEN_SIZE_TABLET) {
                 applyIndicatorForSelection()
             }
             navigateToBottomSelectedItem(it)
@@ -243,10 +243,10 @@ class MainActivity : AbstractPlayerHostActivity() {
             binding.bottomNav.itemActiveIndicatorWidth = cachedWidth
             return
         }
-        calculateSelectedItemSize(selectedId, menuView, visibleCount)
+        updateBottomBarSelectionBackgroundSize(selectedId, menuView, visibleCount)
     }
 
-    private fun calculateSelectedItemSize(
+    private fun updateBottomBarSelectionBackgroundSize(
         selectedId: Int,
         menuView: ViewGroup,
         visibleCount: Int
@@ -733,5 +733,8 @@ class MainActivity : AbstractPlayerHostActivity() {
 
         searchView.clearFocus()
         return true
+    }
+    companion object {
+        const val MINIMUM_SCREEN_SIZE_TABLET = 600
     }
 }


### PR DESCRIPTION
Implements a mechanism to adjust the `itemActiveIndicatorWidth` of the bottom navigation bar based on the menu item count and container width, specifically for devices with a screen width of 600dp or greater.
this is fix for #8604 In tablet mode, the Material button border in the navigation bar deforms when switching

Changes:
- Added `applyIndicatorForSelection` to calculate and set the active indicator width when an item is selected.
- Introduced `cachedIndicatorWidths` to store calculated widths, avoiding redundant calculations.
- Implemented `calculateSelectedItemSize` using a delayed post to ensure the view hierarchy is laid out before measuring child widths.
- Updated `setOnItemSelectedListener` to trigger the indicator adjustment on large screens.

[Uploading Screen_recording_20260721_015012.webm…]()
