### PR TITLE
feat(Channel): add support for `Podcasts` and `Courses` tabs

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/ChannelFragment.kt
@@ -53,7 +53,9 @@ class ChannelFragment : Fragment(R.layout.fragment_channel) {
         "shorts" to R.string.yt_shorts,
         "livestreams" to R.string.livestreams,
         "playlists" to R.string.playlists,
-        "albums" to R.string.albums
+        "albums" to R.string.albums,
+        "podcasts" to R.string.podcasts,
+        "courses" to R.string.courses,
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="color">Color</string>
     <string name="invalid_color">Invalid color value entered!</string>
     <string name="livestreams">Livestreams</string>
+    <string name="courses">Courses</string>
     <string name="defaultIconLight">Default light</string>
     <string name="playlistCloned">Playlist cloned</string>
     <string name="unsubscribe_snackbar_message">Successfully unsubscribed from %1$s</string>


### PR DESCRIPTION
Implements support for displaying the `Podcasts` and `Courses` channel tabs. Requires a bump in the NewPipeExtractor, which is not included in this PR.

Ref: https://github.com/TeamNewPipe/NewPipeExtractor/pull/1524

<img width="363" height="552" alt="Courses tab" src="https://github.com/user-attachments/assets/aa95b93f-d11e-4cff-8334-f13bac4ddfd6" />
<img width="363" height="552" alt="Podcasts tab" src="https://github.com/user-attachments/assets/8b4aadac-dbee-4d21-85cb-d30ba95f1bfa" />
