### PR TITLE
fix(sabr): set visionOS as streaming client

### DIFF
--- a/app/src/main/java/com/github/libretube/player/SabrDataSource.kt
+++ b/app/src/main/java/com/github/libretube/player/SabrDataSource.kt
@@ -1,6 +1,7 @@
 package com.github.libretube.player
 
 import android.net.Uri
+import android.util.Log
 import androidx.core.net.toUri
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
@@ -29,8 +30,16 @@ class SabrDataSource(
 
         transferInitializing(dataSpec)
         transferStarted(dataSpec)
-        val segment = runCatching { sabrClient.getNextSegment(playbackRequest!!) }
-            .getOrNull() ?: throw IOException()
+        val segment = try {
+            sabrClient.getNextSegment(playbackRequest!!)!!
+        } catch (e: Exception) {
+            Log.e(
+                SabrClient::class.java.name,
+                "open: failed to get segment ${playbackRequest!!.segment} for ${playbackRequest.format.itag}: $e"
+            )
+            throw IOException()
+        }
+
         data = CompositeBuffer(segment.data)
         return data!!.remaining().toLong()
     }

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -383,11 +383,10 @@ class SabrClient private constructor(
 
         val playbackRequest = VideoPlaybackAbrRequest.newBuilder().setClientAbrState(clientState)
             .setPlayerTimeMs(playerTimeMs)
-            .addAllSelectedFormatIds(initializedFormats.values.map { it.id }.toList())
             .setVideoPlaybackUstreamerConfig(ustreamerConfig)
             .addAllPreferredAudioFormatIds(listOfNotNull(audioFormat?.formatId()))
             .addAllPreferredVideoFormatIds(listOfNotNull(videoFormat?.formatId()))
-            .addAllSelectedFormatIds(initializedFormats.map { it.value.id }.toList())
+            .addAllSelectedFormatIds(initializedFormats.values.map { it.id }.toList())
             .addAllBufferedRanges(initializedFormats.values.flatMap { it.buildBufferedRanges() })
             .setStreamerContext(
                 StreamerContext.newBuilder()

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -38,6 +38,7 @@ import video_streaming.StreamerContextOuterClass.StreamerContext.SabrContext
 import video_streaming.UmpPartId.UMPPartId
 import video_streaming.VideoPlaybackAbrRequestOuterClass.VideoPlaybackAbrRequest
 import java.time.Instant
+import kotlin.math.max
 
 class PlaybackRequest(
     /* Format for which new media data is being requested */
@@ -373,6 +374,10 @@ class SabrClient private constructor(
             .setEnableVoiceBoost(xtags?.isVoiceBoosted() ?: false)
             .setClientViewportIsFlexible(false)
             .setBandwidthEstimate(bandwidthEstimator.bitrateEstimate)
+            .setStickyResolution(max(videoFormat?.stream?.height ?: 0, 360))
+            .setClientViewportHeight(max(videoFormat?.stream?.height ?: 0, 360))
+            .setClientViewportWidth(max(videoFormat?.stream?.width ?: 0, 640))
+            .setLastManualSelectedResolution(max(videoFormat?.stream?.height ?: 0, 360))
             .setVisibility(1)
             .build()
 

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -358,9 +358,9 @@ class SabrClient private constructor(
         val now = Instant.now().toEpochMilli()
         val xtags = audioFormat?.formatId()?.xtags?.let { Xtags(it) }
 
+        val playerTimeMs = playbackRequest.segmentStartTimeMs
         val clientState = ClientAbrState.newBuilder()
-            // we pretend we're slightly in the previous (n-1) segment, so we get n-th segment, instead of the (n+1)-th one
-            .setPlayerTimeMs(playbackRequest.segmentStartTimeMs.minus(500).coerceAtLeast(0))
+            .setPlayerTimeMs(playerTimeMs)
             //TODO: setMediaCapabilities for Android client: https://github.com/coletdjnz/yt-dlp-dev/blob/effe62991b1b87aafcc8f77a374d7ead9d461803/yt_dlp/extractor/youtube/_streaming/sabr/processor.py#L239
             .setEnabledTrackTypesBitfield(if (videoFormat == null) 1 else 0)
             .setPlaybackRate(playbackRequest.playbackSpeed)
@@ -377,6 +377,7 @@ class SabrClient private constructor(
             .build()
 
         val playbackRequest = VideoPlaybackAbrRequest.newBuilder().setClientAbrState(clientState)
+            .setPlayerTimeMs(playerTimeMs)
             .addAllSelectedFormatIds(initializedFormats.values.map { it.id }.toList())
             .setVideoPlaybackUstreamerConfig(ustreamerConfig)
             .addAllPreferredAudioFormatIds(listOfNotNull(audioFormat?.formatId()))

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -212,6 +212,9 @@ class SabrClient private constructor(
         }
         .build()
 
+    /** Sequence number of the request. */
+    private var requestNumber = 1
+
     /**
      * PlaybackCookie
      *
@@ -409,7 +412,7 @@ class SabrClient private constructor(
 
         // ideally we would use HTTP3 here, like the official, however okhttp does not support it
         val request = Request.Builder()
-            .url(url)
+            .url("$url&rn=${requestNumber++}")
             .post(
                 playbackRequest.toByteArray()
                     .toRequestBody(CONTENT_TYPE.toMediaType())

--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -396,10 +396,12 @@ class SabrClient private constructor(
                     .setPoToken(poToken ?: ByteString.empty())
                     .setClientInfo(
                         StreamerContext.ClientInfo.newBuilder()
-                            .setClientName(1)
-                            .setClientVersion(YoutubeParsingHelper.getClientVersion())
-                            .setOsName("Windows")
-                            .setOsVersion("10")
+                            .setClientName(101)
+                            .setClientVersion("1.02")
+                            .setDeviceMake("Apple")
+                            .setDeviceModel("RealityDevice14,1")
+                            .setOsName("visionOS")
+                            .setOsVersion("25.6.0.23O471")
                             .build()
                     )
                     .addAllSabrContexts(activeSabrContexts.mapNotNull { sabrContexts[it] })
@@ -626,7 +628,6 @@ class SabrClient private constructor(
         private const val CONTENT_TYPE = "application/x-protobuf"
         private const val ENCODING = "identity"
         private const val ACCEPT = "application/vnd.yt-ump"
-        private const val USER_AGENT =
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0"
+        private const val USER_AGENT = "com.google.visionos.youtube/1.02(RealityDevice14,1; U; CPU visionOS 25_6_0 like Mac OS X; GB)";
     }
 }


### PR DESCRIPTION
Also requires a patch to NewPipeExtractor to return the serverAbrUrl of the visionOS client instead of the Android client, thus marked as a draft.

Thanks to @Priveetee for pointing out that we used the wrong client.

Closes: https://github.com/libre-tube/LibreTube/issues/8609