### PR TITLE
refactor(settings): remove label visibility, playback during call, behavior when minimized, notification stream thumbnails and watch history size settings

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -25,7 +25,6 @@ object PreferenceKeys {
     const val ACCENT_COLOR = "accent_color"
     const val GRID_COLUMNS_PORTRAIT = "grid"
     const val GRID_COLUMNS_LANDSCAPE = "grid_landscape"
-    const val LABEL_VISIBILITY = "label_visibility"
     const val APP_ICON = "icon_change"
     const val NEW_VIDEOS_BADGE = "new_videos_badge"
     const val PLAYLISTS_ORDER = "playlists_order"
@@ -78,8 +77,6 @@ object PreferenceKeys {
     const val PLAY_AUTOMATICALLY = "play_automatically"
     const val FULLSCREEN_GESTURES = "fullscreen_gestures"
     const val SHOW_TIME_LEFT = "show_time_left"
-    const val ALLOW_PLAYBACK_DURING_CALL = "playback_during_call"
-    const val BEHAVIOR_WHEN_MINIMIZED = "behavior_when_minimized"
     const val REPEAT_MODE = "repeat_mode"
 
     // SponsorBlock
@@ -91,7 +88,6 @@ object PreferenceKeys {
 
     // Notifications
     const val NOTIFICATION_ENABLED = "notification_toggle"
-    const val SHOW_STREAM_THUMBNAILS = "show_stream_thumbnails"
     const val SHORTS_NOTIFICATIONS = "shorts_notifications"
     const val CHECKING_FREQUENCY = "checking_frequency"
     const val REQUIRED_NETWORK = "required_network"
@@ -125,7 +121,6 @@ object PreferenceKeys {
     const val INCLUDE_TIMESTAMP_IN_BACKUP_FILENAME = "include_timestamp_in_filename"
 
     // History
-    const val WATCH_HISTORY_SIZE = "watch_history_size"
     const val SELECTED_HISTORY_STATUS_FILTER = "filter_history_status"
 
     // Internally saved data / not a preference

--- a/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
+++ b/app/src/main/java/com/github/libretube/db/DatabaseHelper.kt
@@ -24,19 +24,6 @@ object DatabaseHelper {
     suspend fun addToWatchHistory(watchHistoryItem: WatchHistoryItem) =
         withContext(Dispatchers.IO) {
             Database.watchHistoryDao().insert(watchHistoryItem)
-            val maxHistorySize = PreferenceHelper.getString(
-                PreferenceKeys.WATCH_HISTORY_SIZE,
-                "100"
-            )
-            if (maxHistorySize == "unlimited") {
-                return@withContext
-            }
-
-            // delete the first watch history entry if the limit is reached
-            val historySize = Database.watchHistoryDao().getSize()
-            if (historySize > maxHistorySize.toInt()) {
-                Database.watchHistoryDao().delete(Database.watchHistoryDao().getOldest())
-            }
         }
 
     suspend fun getWatchHistoryPage(page: Int, pageSize: Int): List<WatchHistoryItem> {

--- a/app/src/main/java/com/github/libretube/helpers/NavBarHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/NavBarHelper.kt
@@ -13,7 +13,6 @@ import com.github.libretube.R
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.ui.dialogs.NavBarItem
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import com.google.android.material.navigation.NavigationBarView
 
 object NavBarHelper {
 
@@ -73,16 +72,6 @@ object NavBarHelper {
      * @return Id of the start fragment
      */
     fun applyNavBarStyle(bottomNav: BottomNavigationView): Int {
-        val labelVisibilityMode = when (
-            PreferenceHelper.getString(PreferenceKeys.LABEL_VISIBILITY, "selected")
-        ) {
-            "always" -> NavigationBarView.LABEL_VISIBILITY_LABELED
-            "selected" -> NavigationBarView.LABEL_VISIBILITY_SELECTED
-            "never" -> NavigationBarView.LABEL_VISIBILITY_UNLABELED
-            else -> NavigationBarView.LABEL_VISIBILITY_AUTO
-        }
-        bottomNav.labelVisibilityMode = labelVisibilityMode
-
         val navBarItems = getNavBarItemPreference(bottomNav.context)
         val startFragmentId = getStartFragmentId(bottomNav.context)
 

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -251,18 +251,6 @@ object PlayerHelper {
             false
         )
 
-    private val behaviorWhenMinimized
-        get() = PreferenceHelper.getString(
-            PreferenceKeys.BEHAVIOR_WHEN_MINIMIZED,
-            "pip"
-        )
-
-    val pipEnabled: Boolean
-        get() = behaviorWhenMinimized == "pip"
-
-    val pauseOnQuit: Boolean
-        get() = behaviorWhenMinimized == "pause"
-
     var autoPlayEnabled: Boolean
         get() = PreferenceHelper.getBoolean(
             PreferenceKeys.AUTOPLAY,
@@ -381,12 +369,6 @@ object PlayerHelper {
             .getBoolean(PreferenceKeys.AUTOPLAY_PLAYLISTS, false))
     }
 
-    private val handleAudioFocus
-        get() = !PreferenceHelper.getBoolean(
-            PreferenceKeys.ALLOW_PLAYBACK_DURING_CALL,
-            false
-        )
-
     fun getDefaultResolution(context: Context, isFullscreen: Boolean): Int? {
         var prefKey = if (NetworkHelper.isNetworkMetered(context)) {
             PreferenceKeys.DEFAULT_RESOLUTION_MOBILE
@@ -501,7 +483,7 @@ object PlayerHelper {
             .setTrackSelector(trackSelector)
             .setHandleAudioBecomingNoisy(true)
             .setLoadControl(getLoadControl())
-            .setAudioAttributes(audioAttributes, handleAudioFocus)
+            .setAudioAttributes(audioAttributes, true)
             .build()
             .apply {
                 loadPlaybackParams()

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -149,6 +149,13 @@ object PreferenceHelper {
         PreferenceMigration(7, 8) {
             remove("image_cache_size")
             remove("max_parallel_downloads")
+        },
+        PreferenceMigration(8, 9) {
+            remove("label_visibility")
+            remove("playback_during_call")
+            remove("behavior_when_minimized")
+            remove("show_stream_thumbnails")
+            remove("watch_history_size")
         }
     )
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -221,12 +221,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
     private val playerListener = object : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            if (PlayerHelper.pipEnabled || PictureInPictureCompat.isInPictureInPictureMode(
-                    baseActivity
-                )
-            ) {
-                PictureInPictureCompat.setPictureInPictureParams(requireActivity(), pipParams)
-            }
+            PictureInPictureCompat.setPictureInPictureParams(requireActivity(), pipParams)
 
             if (isPlaying && PlayerHelper.sponsorBlockEnabled) {
                 handler.postDelayed(
@@ -271,7 +266,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             }
 
             // listen for the stop button in the notification
-            if (playbackState == PlaybackState.STATE_STOPPED && PlayerHelper.pipEnabled &&
+            if (playbackState == PlaybackState.STATE_STOPPED &&
                 PictureInPictureCompat.isInPictureInPictureMode(requireActivity())
             ) {
                 // finish PiP by finishing the activity
@@ -646,9 +641,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
         binding.playerMotionLayout.transitionToStart()
 
         val activity = requireActivity()
-        if (PlayerHelper.pipEnabled) {
-            PictureInPictureCompat.setPictureInPictureParams(activity, pipParams)
-        }
+        PictureInPictureCompat.setPictureInPictureParams(activity, pipParams)
     }
 
     private fun closeMiniPlayer() {
@@ -713,8 +706,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             switchToAudioMode()
         }
 
-        binding.relPlayerPip.isVisible =
-            PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
+        binding.relPlayerPip.isVisible = isPipAvailable()
 
         binding.relPlayerPip.setOnClickListener {
             PictureInPictureCompat.enterPictureInPictureMode(requireActivity(), pipParams)
@@ -891,7 +883,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
         // disable video stream since it's not needed when screen off or when PiP is not
         // enabled, except when the user is intentionally entering PiP mode via the dedicated button
-        if ((!isInteractive || !PlayerHelper.pipEnabled) && !isEnteringPiPMode) {
+        if (!isInteractive && !isEnteringPiPMode) {
             // disable the autoplay countdown while the screen is off or when PiP is not enabled
             setAutoPlayCountdownEnabled(false)
 
@@ -899,13 +891,9 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             setVideoTrackTypeDisabled(true)
         }
 
-        val shouldPausePlayer =
-            (isInteractive && PlayerHelper.pauseOnQuit) ||
-                    (!isInteractive && PlayerHelper.pausePlayerOnScreenOffEnabled)
-
         // pause player if screen off or app is put the background, except when
         // the user is intentionally entering PiP mode via the dedicated button
-        if (shouldPausePlayer && !isEnteringPiPMode) {
+        if (PlayerHelper.pausePlayerOnScreenOffEnabled && !isInteractive && !isEnteringPiPMode) {
             playerController.pause()
         }
 
@@ -966,11 +954,9 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             playerController.release()
         }
 
-        if (PlayerHelper.pipEnabled) {
-            // disable the auto PiP mode for SDK >= 32
-            PictureInPictureCompat
-                .setPictureInPictureParams(requireActivity(), pipParams)
-        }
+        // disable the auto PiP mode for SDK >= 32
+        PictureInPictureCompat
+            .setPictureInPictureParams(requireActivity(), pipParams)
 
         runCatching {
             if (fullscreenDialog.isShowing) fullscreenDialog.dismiss()
@@ -1132,8 +1118,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
         if (binding.playerMotionLayout.progress != 1.0f) {
             // show controllers when not in picture in picture mode
-            val inPipMode = PlayerHelper.pipEnabled &&
-                    PictureInPictureCompat.isInPictureInPictureMode(requireActivity())
+            val inPipMode = PictureInPictureCompat.isInPictureInPictureMode(requireActivity())
             if (!inPipMode) {
                 binding.player.useController = true
             }
@@ -1364,8 +1349,6 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
     fun onUserLeaveHint() {
         if (shouldStartPiP()) {
             PictureInPictureCompat.enterPictureInPictureMode(requireActivity(), pipParams)
-        } else if (PlayerHelper.pauseOnQuit) {
-            playerController.pause()
         }
     }
 
@@ -1380,7 +1363,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
                         isPlaying
                     )
                 )
-                .setAutoEnterEnabled(PlayerHelper.pipEnabled && isPlaying)
+                .setAutoEnterEnabled(isPlaying)
                 .apply {
                     if (isPlaying) {
                         setAspectRatio(playerController.videoSize)
@@ -1392,12 +1375,12 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
     /**
      * Detect whether PiP is supported and enabled
      */
-    private fun shouldUsePip(): Boolean {
-        return PictureInPictureCompat.isPictureInPictureAvailable(requireContext()) && PlayerHelper.pipEnabled
+    private fun isPipAvailable(): Boolean {
+        return PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
     }
 
     private fun shouldStartPiP(): Boolean {
-        return shouldUsePip() && ::playerController.isInitialized && playerController.isPlaying
+        return isPipAvailable() && ::playerController.isInitialized && playerController.isPlaying
     }
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/preferences/AppearanceSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/AppearanceSettings.kt
@@ -50,12 +50,6 @@ class AppearanceSettings : BasePreferenceFragment() {
             true
         }
 
-        val labelVisibilityMode = findPreference<ListPreference>(PreferenceKeys.LABEL_VISIBILITY)
-        labelVisibilityMode?.setOnPreferenceChangeListener { _, _ ->
-            RequireRestartDialog().show(childFragmentManager, RequireRestartDialog::class.java.name)
-            true
-        }
-
         val navBarOptions = findPreference<Preference>(PreferenceKeys.NAVBAR_ITEMS)
         navBarOptions?.setOnPreferenceClickListener {
             NavBarOptionsDialog().show(childFragmentManager, null)

--- a/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
+++ b/app/src/main/java/com/github/libretube/ui/preferences/PlayerSettings.kt
@@ -9,7 +9,6 @@ import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import com.github.libretube.R
-import com.github.libretube.compat.PictureInPictureCompat
 import com.github.libretube.constants.PreferenceKeys
 import com.github.libretube.helpers.LocaleHelper
 import com.github.libretube.ui.base.BasePreferenceFragment
@@ -33,22 +32,8 @@ class PlayerSettings : BasePreferenceFragment() {
             true
         }
 
-        val behaviorWhenMinimized =
-            findPreference<ListPreference>(PreferenceKeys.BEHAVIOR_WHEN_MINIMIZED)!!
         val alternativePipControls =
             findPreference<SwitchPreferenceCompat>(PreferenceKeys.ALTERNATIVE_PIP_CONTROLS)
-
-        val pipAvailable = PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
-        if (!pipAvailable) {
-            with(behaviorWhenMinimized) {
-                // remove PiP option entry
-                entries = entries.toList().subList(1, 3).toTypedArray()
-                entryValues = entryValues.toList().subList(1, 3).toTypedArray()
-                if (value !in entryValues) value = entryValues.first().toString()
-            }
-        }
-
-        alternativePipControls?.isVisible = pipAvailable
     }
 
     private fun setupSubtitlePref(preference: ListPreference) {

--- a/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
+++ b/app/src/main/java/com/github/libretube/workers/NotificationWorker.kt
@@ -84,7 +84,7 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
             withContext(Dispatchers.IO) {
                 SubscriptionHelper.getFeed(forceRefresh = true)
             }.filter { !it.isUpcoming }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             return false
         }
 
@@ -208,7 +208,7 @@ class NotificationWorker(appContext: Context, parameters: WorkerParameters) :
     }
 
     private suspend fun downloadImage(url: String?): Bitmap? {
-        return if (PreferenceHelper.getBoolean(PreferenceKeys.SHOW_STREAM_THUMBNAILS, false)) {
+        return if (PreferenceHelper.getBoolean(PreferenceKeys.DATA_SAVER_MODE, false)) {
             ImageHelper.getImage(applicationContext, url)
         } else {
             null

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:menu="@menu/bottom_menu" />
+        app:menu="@menu/bottom_menu"
+        app:labelVisibilityMode="selected" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment"

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -207,24 +207,6 @@
         <item>metered</item>
     </string-array>
 
-    <string-array name="historySize">
-        <item>20</item>
-        <item>50</item>
-        <item>100</item>
-        <item>150</item>
-        <item>200</item>
-        <item>@string/unlimited</item>
-    </string-array>
-
-    <string-array name="historySizeValues">
-        <item>20</item>
-        <item>50</item>
-        <item>100</item>
-        <item>150</item>
-        <item>200</item>
-        <item>unlimited</item>
-    </string-array>
-
     <string-array name="playlistSortingOptions">
         <item>@string/creation_date</item>
         <item>@string/creation_date_reversed</item>
@@ -329,17 +311,5 @@
         <item>@string/category_filler</item>
         <item>@string/category_music_offtopic</item>
         <item>@string/category_preview</item>
-    </string-array>
-
-    <string-array name="onMinimize">
-        <item>@string/picture_in_picture</item>
-        <item>@string/pause</item>
-        <item>@string/none</item>
-    </string-array>
-
-    <string-array name="onMinimizeValues">
-        <item>pip</item>
-        <item>pause</item>
-        <item>none</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/appearance_settings.xml
+++ b/app/src/main/res/xml/appearance_settings.xml
@@ -36,25 +36,12 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory app:title="@string/navigation_bar">
+    <PreferenceCategory app:title="@string/layout">
 
         <Preference
             android:icon="@drawable/ic_home"
             app:key="navbar_items"
-            app:title="@string/navbar_order" />
-
-        <ListPreference
-            android:icon="@drawable/ic_label"
-            app:defaultValue="selected"
-            app:entries="@array/labelVisibility"
-            app:entryValues="@array/labelVisibilityValues"
-            app:key="label_visibility"
-            app:title="@string/navLabelVisibility"
-            app:useSimpleSummaryProvider="true" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory app:title="@string/layout">
+            app:title="@string/navigation_bar" />
 
         <MultiSelectListPreference
             android:entries="@array/homeTabItems"

--- a/app/src/main/res/xml/history_settings.xml
+++ b/app/src/main/res/xml/history_settings.xml
@@ -34,16 +34,6 @@
             app:key="watch_history_toggle"
             app:title="@string/watch_history" />
 
-        <ListPreference
-            android:defaultValue="100"
-            android:dependency="watch_history_toggle"
-            android:entries="@array/historySize"
-            android:entryValues="@array/historySizeValues"
-            android:icon="@drawable/ic_list"
-            app:key="watch_history_size"
-            app:title="@string/history_size"
-            app:useSimpleSummaryProvider="true" />
-
         <Preference
             android:icon="@drawable/ic_trash"
             app:key="clear_watch_history"

--- a/app/src/main/res/xml/notification_settings.xml
+++ b/app/src/main/res/xml/notification_settings.xml
@@ -13,14 +13,6 @@
 
         <SwitchPreferenceCompat
             android:dependency="notification_toggle"
-            android:icon="@drawable/ic_image"
-            app:defaultValue="false"
-            app:key="show_stream_thumbnails"
-            app:summary="@string/show_stream_thumbnails_summary"
-            app:title="@string/show_stream_thumbnails" />
-
-        <SwitchPreferenceCompat
-            android:dependency="notification_toggle"
             android:icon="@drawable/ic_video"
             app:defaultValue="false"
             app:key="shorts_notifications"

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -58,15 +58,6 @@
             app:key="skip_buttons"
             app:title="@string/skip_buttons" />
 
-        <ListPreference
-            android:defaultValue="pip"
-            android:icon="@drawable/ic_window"
-            app:entries="@array/onMinimize"
-            app:entryValues="@array/onMinimizeValues"
-            app:key="behavior_when_minimized"
-            app:title="@string/behavior_when_minimized"
-            app:useSimpleSummaryProvider="true" />
-
         <SwitchPreferenceCompat
             android:disableDependentsState="true"
             android:icon="@drawable/ic_rotating_circle"
@@ -156,13 +147,6 @@
             app:key="buffering_goal"
             app:summary="@string/buffering_goal_summary"
             app:title="@string/buffering_goal" />
-
-        <SwitchPreferenceCompat
-            android:icon="@drawable/ic_call"
-            android:summary="@string/playback_during_call_summary"
-            app:defaultValue="false"
-            app:key="playback_during_call"
-            app:title="@string/playback_during_call" />
 
         <SwitchPreferenceCompat
             android:defaultValue="false"


### PR DESCRIPTION
- label visibility: Seems very pointless? only a visual change probably almost nobody uses
- playback during call: this has various bad side effects, e.g. if you start playback in another app then LibreTube would continue playing at the same time
- behavior when minimized: picture in picture can be disabled in the Android settings for the app
- show stream thumbnails in notifications: merged with data saver mode
- watch history size: has only been useful while the app didn't support pagination in the watch history (i.e. the UI became laggy). not needed anymore and might be confusing if users search the history and don't find what they're looking for because by default, old videos automatically got wiped once the history reached a size of 100