### PR TITLE
feat: show seek increment in pip forward/rewind actions

### DIFF
--- a/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/ImageHelper.kt
@@ -2,7 +2,10 @@ package com.github.libretube.helpers
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
 import android.net.Uri
 import android.os.storage.StorageManager
 import android.widget.ImageView
@@ -129,18 +132,15 @@ object ImageHelper {
         return imageLoader.execute(request).image?.toBitmap()
     }
 
-    /**
-     * Get a squared bitmap with the same width and height from a bitmap
-     * @param bitmap The bitmap to resize
-     */
-    fun getSquareBitmap(bitmap: Bitmap): Bitmap {
-        val newSize = minOf(bitmap.width, bitmap.height)
-        return Bitmap.createBitmap(
-            bitmap,
-            (bitmap.width - newSize) / 2,
-            (bitmap.height - newSize) / 2,
-            newSize,
-            newSize
-        )
+    fun insertText(bitmap: Bitmap, text: String, posX: Float, posY: Float, fontSize: Float) {
+        val canvas = Canvas(bitmap)
+
+        canvas.drawBitmap(bitmap, null, Rect(0, 0, bitmap.width, bitmap.height), null)
+        canvas.drawText(text, bitmap.width * posX, bitmap.height * posY, Paint().apply {
+            style = Paint.Style.FILL
+            textSize = fontSize
+            color = Color.WHITE
+            textAlign = Paint.Align.CENTER
+        })
     }
 }

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -4,16 +4,20 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.res.Resources
 import android.net.Uri
 import android.os.Looper
 import android.util.Base64
 import android.view.accessibility.CaptioningManager
+import androidx.annotation.DrawableRes
 import androidx.annotation.OptIn
 import androidx.annotation.StringRes
 import androidx.core.app.PendingIntentCompat
 import androidx.core.app.RemoteActionCompat
 import androidx.core.content.getSystemService
+import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.IconCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -406,7 +410,7 @@ object PlayerHelper {
 
     private fun getRemoteAction(
         activity: Activity,
-        id: Int,
+        icon: IconCompat,
         @StringRes title: Int,
         event: PlayerEvent
     ): RemoteActionCompat {
@@ -417,9 +421,14 @@ object PlayerHelper {
             PendingIntentCompat.getBroadcast(activity, event.ordinal, intent, 0, false)!!
 
         val text = activity.getString(title)
-        val icon = IconCompat.createWithResource(activity, id)
-
         return RemoteActionCompat(icon, text, text, pendingIntent)
+    }
+
+    private fun seekIconWithSpeed(resources: Resources, @DrawableRes resourceId: Int): IconCompat {
+        val textSize = 15 * resources.displayMetrics.density
+        val bitmap = ResourcesCompat.getDrawable(resources, resourceId, null)!!.toBitmap()
+        ImageHelper.insertText(bitmap, seekIncrement.div(1000).toString(), 0.5f, 0.65f, textSize)
+        return IconCompat.createWithBitmap(bitmap)
     }
 
     /**
@@ -428,35 +437,36 @@ object PlayerHelper {
     fun getPiPModeActions(activity: Activity, isPlaying: Boolean): List<RemoteActionCompat> {
         val audioModeAction = getRemoteAction(
             activity,
-            R.drawable.ic_headphones,
+            IconCompat.createWithResource(activity, R.drawable.ic_headphones),
             R.string.background_mode,
             PlayerEvent.Background
         )
 
+
         val rewindAction = getRemoteAction(
             activity,
-            R.drawable.ic_rewind,
+            seekIconWithSpeed(activity.resources, R.drawable.ic_rewind),
             R.string.rewind,
             PlayerEvent.Rewind
         )
 
         val playPauseAction = getRemoteAction(
             activity,
-            if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play,
+            IconCompat.createWithResource(activity, if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play),
             if (isPlaying) R.string.resume else R.string.pause,
             PlayerEvent.PlayPause
         )
 
         val skipNextAction = getRemoteAction(
             activity,
-            R.drawable.ic_next,
+            IconCompat.createWithResource(activity, R.drawable.ic_next),
             R.string.play_next,
             PlayerEvent.Next
         )
 
         val forwardAction = getRemoteAction(
             activity,
-            R.drawable.ic_forward,
+            seekIconWithSpeed(activity.resources, R.drawable.ic_forward),
             R.string.forward,
             PlayerEvent.Forward
         )


### PR DESCRIPTION
Screenshot of what it looks like (only tested on a single device, there might be issues on different screen sizes, idk):
<img width="1067" height="539" alt="foo" src="https://github.com/user-attachments/assets/8b7bcdfa-ec54-4ad3-9223-99147015c475" />

It's debatable if the better option wouldn't be to remove the seek increment option, but I'm not sure how widely it's used. And even if we removed the setting, we would need to draw such an icon with a "10" (or whatever seek increment) in it in Inkscape, because in the player the text is also just a `TextView` and not part of the icon.

