### PR TITLE
fix: playlist videos list showing empty for some users

### DIFF
--- a/app/src/main/java/com/github/libretube/LibreTubeApp.kt
+++ b/app/src/main/java/com/github/libretube/LibreTubeApp.kt
@@ -58,7 +58,7 @@ class LibreTubeApp : Application() {
          */
         ShortcutHelper.createShortcuts(this)
 
-        NewPipeExtractorInstance.init()
+        NewPipeExtractorInstance.init(this)
     }
 
     /**

--- a/app/src/main/java/com/github/libretube/helpers/NewPipeExtractorInstance.kt
+++ b/app/src/main/java/com/github/libretube/helpers/NewPipeExtractorInstance.kt
@@ -1,16 +1,27 @@
 package com.github.libretube.helpers
+  
+  import android.content.Context
+  import com.github.libretube.util.NewPipeDownloaderImpl
+  import org.schabi.newpipe.extractor.NewPipe
+  import org.schabi.newpipe.extractor.ServiceList
+  import org.schabi.newpipe.extractor.StreamingService
+  import org.schabi.newpipe.extractor.localization.ContentCountry
+  import org.schabi.newpipe.extractor.localization.Localization
+  
+  object NewPipeExtractorInstance {
+      val extractor: StreamingService by lazy {
+          NewPipe.getService(ServiceList.YouTube.serviceId)
+      }   
+      
+      fun init(context: Context) {
+          @Suppress("DEPRECATION")
+          val locale = LocaleHelper.getAppLocale()
+          val region = PreferenceHelper.getTrendingRegion(context)
 
-import com.github.libretube.util.NewPipeDownloaderImpl
-import org.schabi.newpipe.extractor.NewPipe
-import org.schabi.newpipe.extractor.ServiceList
-import org.schabi.newpipe.extractor.StreamingService
-
-object NewPipeExtractorInstance {
-    val extractor: StreamingService by lazy {
-        NewPipe.getService(ServiceList.YouTube.serviceId)
-    }
-
-    fun init() {
-        NewPipe.init(NewPipeDownloaderImpl())
-    }
-}
+          NewPipe.init(
+              NewPipeDownloaderImpl(),
+              Localization(locale.language, locale.country.ifEmpty { null }),
+              ContentCountry(region)
+          )
+      }
+  }

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlaylistFragment.kt
@@ -99,8 +99,6 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
         _binding = FragmentPlaylistBinding.bind(view)
         super.onViewCreated(view, savedInstanceState)
 
-        binding.playlistProgress.isVisible = true
-
         isBookmarked = runBlocking(Dispatchers.IO) {
             DatabaseHolder.Database.playlistBookmarkDao().includes(playlistId)
         }
@@ -133,6 +131,9 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
     }
 
     private fun fetchPlaylist() {
+        binding.playlistError.isGone = true
+        binding.playlistProgress.isVisible = true
+        
         lifecycleScope.launch {
             val response = try {
                 withContext(Dispatchers.IO) {
@@ -140,6 +141,10 @@ class PlaylistFragment : DynamicLayoutManagerFragment(R.layout.fragment_playlist
                 }
             } catch (e: Exception) {
                 Log.e(TAG(), e.toString())
+                val binding = _binding ?: return@launch
+                binding.playlistProgress.isGone = true
+                binding.playlistError.isVisible = true
+                binding.playlistRetry.setOnClickListener { fetchPlaylist() }
                 return@launch
             }
             val binding = _binding ?: return@launch

--- a/app/src/main/res/layout/fragment_playlist.xml
+++ b/app/src/main/res/layout/fragment_playlist.xml
@@ -14,6 +14,39 @@
         android:layout_gravity="center"
         android:visibility="gone" />
 
+    <LinearLayout
+        android:id="@+id/playlist_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <ImageView
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:src="@drawable/ic_info" />
+
+        <TextView
+            android:id="@+id/playlist_error_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/unknown_error"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/playlist_retry"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/retry" />
+
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/playlist_recView"
         android:layout_width="match_parent"


### PR DESCRIPTION
what was the issue:
  opening a playlist was showing the playlist name, thumbnail and
  video count correctly, but the video list itself was empty,
  "Nothing here" shown even though playlist have videos.

  checked logcat, no exception was thrown, so extractor call was
  success but returned no items. compared with NewPipe app, same
  playlist loads fine there.

  found NewPipeExtractorInstance.kt was calling NewPipe.init() without
  passing Localization/ContentCountry, so it fallback to extractor
  default locale instead of using device/app locale. NewPipe app
  passes this properly. this was causing youtube to return different
  playlist response for item list.

  fix:
  1) pass Localization and ContentCountry (from existing Language/Region
    preference) to NewPipe.init()
  2) also handled the case when playlist fetch throws exception, before
    this it was just stuck on loading spinner with no error, now shows
    error state with retry button

  tested on device, playlist which was not working before is loading
  fine now, tried few more playlist from different channel too, all
  working.