### PR TITLE
fix: fullscreen button hidden whenever auto-fullscreen is enabled

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -310,7 +310,6 @@ class CustomExoPlayerView(
         commonPlayerViewModel.isFullscreen.observe(viewLifecycleOwner) { isFullscreen ->
             updateTopBarMargin()
 
-            binding.fullscreen.isInvisible = PlayerHelper.autoFullscreenEnabled
             val fullscreenDrawable =
                 if (isFullscreen) R.drawable.ic_fullscreen_exit else R.drawable.ic_fullscreen
             binding.fullscreen.setImageResource(fullscreenDrawable)


### PR DESCRIPTION
Fixes #8155 

**Problem:**
Vertical videos currently cannot be viewed in full screen when “Auto full screen” is enabled and “Enter/exit full screen gesture” is disabled.
The line of code seems to come from this commit [d0a4e539](https://github.com/libre-tube/LibreTube/commit/d0a4e539010d7e5b7c743aa1c5fb81ef6d6c307a).  However, I'm not entirely sure why it had to be hidden in the first place.

I tested it and got the same result as when I use the exit gesture.