### PR TITLE
fix: prevent watch history navigation crash

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/WatchHistoryFragment.kt
@@ -31,7 +31,6 @@ import com.github.libretube.ui.models.CommonPlayerViewModel
 import com.github.libretube.ui.models.WatchHistoryModel
 import com.github.libretube.util.PlayingQueue
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -161,7 +160,7 @@ class WatchHistoryFragment : DynamicLayoutManagerFragment(R.layout.fragment_watc
             viewModel.fetchNextPage()
         }
 
-        CoroutineScope(Dispatchers.IO).launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             val hasItems = Database.watchHistoryDao().getSize() != 0
 
             withContext(Dispatchers.Main) {


### PR DESCRIPTION
Run the initial history-size lookup in the view lifecycle's coroutine scope so navigation that destroys the History view cancels the pending work before it can update `binding`. Opening a creator profile from the History tab and immediately selecting Home can crash LibreTube while the profile is still loading.

With at least one watch-history entry, open History and let the size lookup complete; the Clear button becomes enabled as before; From History, tap a creator profile and immediately tap Home while the destination is loading; the app remains on Home without a `WatchHistoryFragment` binding crash.

Closes #8598
