### PR TITLE
fix: prevent crash when shuffling video downloads

### DIFF
--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -416,13 +416,16 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
 
         val playerData = requireArguments().parcelable<PlayerData>(IntentData.playerData)!!
-        videoId = playerData.videoId!!
+        // when shuffling downloads, the video to start with is picked by the player service
+        // and reported back through the playlist metadata, so there is none to show yet
+        playerData.videoId?.let { videoId = it }
         isOffline = playerData.isOffline
         playlistId = playerData.playlistId
         channelId = playerData.channelId
 
         // remember if playback already started once and only restart playback if that's the first run
         val createNewSession = !requireArguments().getBoolean(IntentData.alreadyStarted)
+                || playerData.videoId == null
         requireArguments().putBoolean(IntentData.alreadyStarted, true)
 
         changeOrientationMode()
@@ -450,7 +453,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             }
         }
 
-        val localDownloadVersion = runBlocking(Dispatchers.IO) {
+        val localDownloadVersion = if (isOffline) null else runBlocking(Dispatchers.IO) {
             DatabaseHolder.Database.downloadDao().findById(videoId)
         }
 
@@ -526,7 +529,7 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
             val isNoInternet = activity is NoInternetActivity
 
             OfflinePlayerService::class.java to bundleOf(
-                IntentData.videoId to videoId,
+                IntentData.videoId to playerData.videoId,
                 IntentData.playerData to playerData
                     .copy(downloadTab = playerData.downloadTab ?: DownloadTab.VIDEO),
                 IntentData.noInternet to isNoInternet


### PR DESCRIPTION
Fixes #8686

## Problem

Shuffling downloads from the **Videos** tab crashes the app immediately:

```
java.lang.NullPointerException: Attempt to invoke virtual method
'java.lang.Class java.lang.Object.getClass()' on a null object reference
	at com.github.libretube.ui.fragments.PlayerFragment.onViewCreated
	...
	at com.github.libretube.helpers.NavigationHelper.openVideoPlayerFragment
	at com.github.libretube.ui.fragments.DownloadsFragmentPage$$ExternalSyntheticLambda2
```

The shuffle button is the only place in the app that builds a `PlayerData` without a video id
(`DownloadsFragment.kt:281`). That is deliberate: the video to start with is picked later by
`OfflinePlayerService`, which draws a random download from the database and reports it back
through the playlist metadata, which `PlayerFragment.onPlaylistMetadataChanged` already listens
for.

`PlayerFragment.onViewCreated` did not allow for that and unwrapped the id with `!!`.

Audio downloads never hit this: `audioOnlyPlayerRequested` sends them to `AudioPlayerFragment`,
which doesn't read `playerData.videoId` at all and waits for the metadata, exactly as the service
intends.

## Changes

All in `PlayerFragment`:

- Only assign `videoId` when it is already known, instead of asserting it is non-null.
- Treat a missing id as "there is no session to resume", so a fragment recreated before the
  service has reported its pick starts a fresh session rather than calling `playNextVideo()` with
  an unset `videoId`.
- Skip the local-download lookup while already playing offline. Its result is only read by the
  online "play the downloaded version instead?" dialog, which is guarded by `!isOffline`, so
  offline playback was doing a `runBlocking` database read on the main thread for a value it
  then discarded.
- Pass `playerData.videoId` into the offline service bundle rather than the field. The service
  derives its own id from `playerData` and never reads this extra as input, so this only keeps
  the bundle from touching the field before it is set.

The queue itself is untouched — `OfflinePlayerService` still shuffles and picks the starting
video exactly as before.

## Why the other paths are unaffected

Each change only takes a different branch when the video id is absent, which today is exactly the
case that crashes:

- Every other `PlayerData` in the app carries a concrete id, so the assignment is unchanged for
  them and `createNewSession` short-circuits on its first operand exactly as before.
- The local-download lookup was already discarded whenever `isOffline`, since its only consumer is
  guarded by `!isOffline` — so skipping it offline is behaviour-preserving.
- `OfflinePlayerService` derives its own id from `playerData`; the only occurrence of
  `IntentData.videoId` in the services is `AbstractPlayerService.kt:232`, which *writes* it into
  the media metadata rather than reading it, so nothing consumes the extra that changed.

## Testing

- `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL, no new warnings from the changed file.
- `./gradlew testDebugUnitTest` — existing unit tests pass.
- Traced the crash to `PlayerFragment.onViewCreated`: the reported
  `Object.getClass()`-on-null is R8's optimised form of a Kotlin `!!`, and the only nullable
  unwrapped there was the video id.

I don't have an Android device or a configured emulator to hand, so I have not reproduced the
crash on-device — the diagnosis is from the reported stack trace plus the call graph above. Happy
to adjust if you'd prefer a different approach, or to verify anything specific.
