### PR TITLE
fix: Open the trends page in Piped mode

### DIFF
--- a/app/src/main/java/com/github/libretube/api/PipedMediaServiceRepository.kt
+++ b/app/src/main/java/com/github/libretube/api/PipedMediaServiceRepository.kt
@@ -16,7 +16,7 @@ import com.github.libretube.helpers.PreferenceHelper
 import retrofit2.HttpException
 
 open class PipedMediaServiceRepository : MediaServiceRepository {
-    override fun getTrendingCategories(): List<TrendingCategory> = emptyList()
+    override fun getTrendingCategories(): List<TrendingCategory> = listOf(TrendingCategory.LIVE)
 
     override suspend fun getTrending(region: String, category: TrendingCategory): List<StreamItem> =
         api.getTrending(region)

--- a/app/src/test/java/com/github/libretube/api/PipedMediaServiceRepositoryTest.kt
+++ b/app/src/test/java/com/github/libretube/api/PipedMediaServiceRepositoryTest.kt
@@ -1,0 +1,13 @@
+package com.github.libretube.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PipedMediaServiceRepositoryTest {
+    @Test
+    fun getTrendingCategoriesReturnsLiveCategory() {
+        val repository = PipedMediaServiceRepository()
+
+        assertEquals(listOf(TrendingCategory.LIVE), repository.getTrendingCategories())
+    }
+}


### PR DESCRIPTION
Change `PipedMediaServiceRepository.getTrendingCategories()` to expose `TrendingCategory.LIVE` as its single supported pager category, matching the existing Piped `getTrending` implementation that ignores category distinctions and fetches the instance's general trending feed. Opening the full Trends page from the home section in Piped mode produces an empty pager, and using its region action then crashes with an `IndexOutOfBoundsException`.

In a unit test, a fresh `PipedMediaServiceRepository` returns exactly `TrendingCategory.LIVE` from `getTrendingCategories()`, not an empty list or the multi-category NewPipe set; In Piped mode, selecting the Trends heading from Home opens a single-page trends feed while the category tab strip remains hidden.

Closes #8290
