### PR TITLE
feat(BottomSheet): use bold font for title

### DIFF
--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -41,6 +41,7 @@
                     android:maxLines="2"
                     android:ellipsize="end"
                     android:textSize="27sp"
+                    android:textStyle="bold"
                     tools:text="Very long text that is going across more than two lines in total"/>
 
                 <com.google.android.material.divider.MaterialDivider


### PR DESCRIPTION
The title of the bottom sheet could feel a bit unbalanced compared to the sheet content.

<img width="368" height="303" alt="Screenshot From 2026-08-30 09-59-23" src="https://github.com/user-attachments/assets/702d3bc3-27ff-4066-a6db-15c11f453646" />
<img width="368" height="303" alt="Screenshot From 2026-08-30 09-59-03" src="https://github.com/user-attachments/assets/6b937af4-0b27-424e-bd9d-a9cbca15a7a7" />
