### PR TITLE
fix: Showing shorts in feed when using full local mode

### DIFF
--- a/app/src/main/java/com/github/libretube/extensions/ToID.kt
+++ b/app/src/main/java/com/github/libretube/extensions/ToID.kt
@@ -14,6 +14,7 @@ fun String.toID(): String {
         .removePrefix(YOUTUBE_MUSIC_URL)
         .removePrefix(YOUTUBE_SHORT_URL)
         .replace("/watch?v=", "") // videos
+        .replace("/shorts/", "") // shorts
         .replace("/channel/", "") // channels
         .replace("/playlist?list=", "") // playlists
         // channel urls for different categories than the main one

--- a/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
+++ b/app/src/main/java/com/github/libretube/repo/LocalFeedRepository.kt
@@ -124,7 +124,7 @@ class LocalFeedRepository : FeedRepository {
     ): Pair<Subscription?, List<StreamItem>> {
         val channelUrl = "$YOUTUBE_FRONTEND_URL/channel/${channelId}"
         val feedInfo = FeedInfo.getInfo(channelUrl)
-        val feedInfoItems = feedInfo.relatedItems.associateBy { it.url }
+        val feedInfoItems = feedInfo.relatedItems.associateBy { it.url.toID() }
 
         val mostRecentChannelVideo = feedInfo.relatedItems.maxBy {
             it.uploadDate?.offsetDateTime()?.toInstant()?.toEpochMilli() ?: 0
@@ -166,7 +166,7 @@ class LocalFeedRepository : FeedRepository {
             item.toStreamItem(
                 channelAvatar,
                 // shorts fetched via the shorts tab don't have upload dates so we fall back to the feedInfo
-                feedInfoItems[item.url]
+                feedInfoItems[item.url.toID()]
             )
         }.filter { it.uploaded > minimumDateMillis }
         return Pair(subscription, streamItems)


### PR DESCRIPTION
RSS entries for shorts use /shorts/<id> links while the shorts tab returns /watch?v=<id>, so the date fallback never matched and every short was dropped by the upload date filter.

Normalize both forms to the video ID via toID() and use that as key  for feedInfo.

Fixes a regression from a04265764901f26262b71c7d4160f1f92c565bca

Fixes #8427