### PR TITLE
refactor: remove option to disable showing skip buttons

### DIFF
--- a/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/github/libretube/constants/PreferenceKeys.kt
@@ -61,7 +61,6 @@ object PreferenceKeys {
     const val PLAYER_AUDIO_QUALITY = "player_audio_quality"
     const val PLAYER_AUDIO_QUALITY_MOBILE = "player_audio_quality_mobile"
     const val DEFAULT_SUBTITLE = "default_subtitle"
-    const val SKIP_BUTTONS = "skip_buttons"
     const val PLAYER_RESIZE_MODE = "current_player_resize_mode"
     const val PLAYER_SWIPE_CONTROLS = "player_swipe_controls"
     const val PLAYER_PINCH_CONTROL = "player_pinch_control"

--- a/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PlayerHelper.kt
@@ -249,12 +249,6 @@ object PlayerHelper {
             return code
         }
 
-    val skipButtonsEnabled: Boolean
-        get() = PreferenceHelper.getBoolean(
-            PreferenceKeys.SKIP_BUTTONS,
-            false
-        )
-
     var autoPlayEnabled: Boolean
         get() = PreferenceHelper.getBoolean(
             PreferenceKeys.AUTOPLAY,

--- a/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
+++ b/app/src/main/java/com/github/libretube/helpers/PreferenceHelper.kt
@@ -161,6 +161,9 @@ object PreferenceHelper {
             remove("autoplay_playlists")
             remove("queue_insert_related_videos")
         },
+        PreferenceMigration(10, 11) {
+            remove("skip_buttons")
+        }
     )
 
     /**

--- a/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
+++ b/app/src/main/java/com/github/libretube/ui/views/CustomExoPlayerView.kt
@@ -414,8 +414,6 @@ class CustomExoPlayerView(
     }
 
     private fun syncQueueButtons() {
-        if (!PlayerHelper.skipButtonsEnabled) return
-
         // toggle the visibility of next and prev buttons based on queue and whether the player view is locked
         binding.skipPrev.isInvisible = !PlayingQueue.hasPrev() || isPlayerLocked
         binding.skipNext.isInvisible = !PlayingQueue.hasNext() || isPlayerLocked

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -218,8 +218,6 @@
     <string name="copied">نُسخ</string>
     <string name="share_with_time">شارك مع رمز الوقت</string>
     <string name="export_subscriptions">تصدير الاشتراكات</string>
-    <string name="skip_buttons">أزرار التخطي</string>
-    <string name="skip_buttons_summary">إظهار الأزرار للتخطي إلى الفيديو التالي أو السابق</string>
     <string name="history_size">الحد الأقصى لحجم السجل</string>
     <string name="unlimited">غير محدود</string>
     <string name="background_mode">وضع الخلفية</string>

--- a/app/src/main/res/values-as/strings.xml
+++ b/app/src/main/res/values-as/strings.xml
@@ -248,8 +248,6 @@
     <string name="copied">কপি কৰা হৈছে</string>
     <string name="share_with_time">টাইম ক’ডৰ সৈতে ভাগ-বতৰা</string>
     <string name="export_subscriptions">চাবস্ক্ৰিপচন এক্সপ’ৰ্ট কৰক</string>
-    <string name="skip_buttons">এৰাই যোৱা বুটাম</string>
-    <string name="skip_buttons_summary">পৰৱৰ্তী বা পূৰ্বৱৰ্তী ভিডিঅ’লৈ এৰাই যাবলৈ বুটাম দেখুৱাওক</string>
     <string name="history_size">সৰ্বাধিক ইতিহাসৰ আকাৰ</string>
     <string name="unlimited">অসীম</string>
     <string name="background_mode">পটভূমি মোড</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -218,8 +218,6 @@
     <string name="error_occurred">Xəta</string>
     <string name="share_with_time">Vaxt koduyla paylaş</string>
     <string name="export_subscriptions">Abunəlikləri İxrac et</string>
-    <string name="skip_buttons">Ötürmə düymələri</string>
-    <string name="skip_buttons_summary">Növbəti və ya əvvəlki videoya ötürmək üçün düymələr göstər</string>
     <string name="history_size">Maksimum tarixçə həcmi</string>
     <string name="unlimited">Qeyri-məhdud</string>
     <string name="background_mode">Arxa plan rejimi</string>

--- a/app/src/main/res/values-b+en+Shaw/strings.xml
+++ b/app/src/main/res/values-b+en+Shaw/strings.xml
@@ -163,8 +163,6 @@
     <string name="no_search_result">𐑯𐑴 𐑮𐑦𐑟𐑳𐑤𐑑𐑕.</string>
     <string name="copied">𐑒𐑪𐑐𐑦𐑛</string>
     <string name="share_with_time">𐑖𐑺 𐑢𐑦𐑞 𐑑𐑲𐑥 𐑒𐑴𐑛</string>
-    <string name="skip_buttons">𐑕𐑒𐑦𐑐 𐑚𐑳𐑑𐑩𐑯𐑟</string>
-    <string name="skip_buttons_summary">𐑖𐑴 𐑚𐑳𐑑𐑩𐑯𐑟 𐑑 𐑕𐑒𐑦𐑐 𐑑 𐑞 𐑯𐑧𐑒𐑕𐑑 𐑹 𐑐𐑮𐑰𐑝𐑾𐑕 𐑝𐑦𐑛𐑦𐑴</string>
     <string name="background_mode">𐑚𐑨𐑒𐑜𐑮𐑬𐑯𐑛 𐑥𐑴𐑛</string>
     <string name="add_to_queue">𐑨𐑛 𐑑 𐑒𐑿</string>
     <string name="misc">𐑥𐑦𐑕𐑤.</string>

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -229,8 +229,6 @@
     <string name="take_a_break">Es hora de tomar un descanso</string>
     <string name="error_occurred">Error</string>
     <string name="copied">Copiado</string>
-    <string name="skip_buttons">Botones de omisión</string>
-    <string name="skip_buttons_summary">Mostrar botones para pasar al vídeo siguiente o anterior</string>
     <string name="history_size">Tamaño máximo del historial</string>
     <string name="unlimited">Ilimitado</string>
     <string name="background_mode">Modo segundo plano</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -223,8 +223,6 @@
     <string name="no_search_result">Няма вынікаў.</string>
     <string name="error_occurred">Памылка</string>
     <string name="copied">Скапіравана</string>
-    <string name="skip_buttons">Кнопкі пропуску</string>
-    <string name="skip_buttons_summary">Паказаць кнопкі для пераходу да наступнага або папярэдняга відэа</string>
     <string name="history_size">Максімальны памер гісторыі</string>
     <string name="unlimited">Неабмежаваны</string>
     <string name="background_mode">Фонавы рэжым</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -312,7 +312,6 @@
     <string name="areYouSure">Изтрий плейлистът?</string>
     <string name="download_paused">Изтеглянето е на пауза</string>
     <string name="sleep_timer">Таймер за заспиване</string>
-    <string name="skip_buttons">Бутони за прескачане</string>
     <string name="add_to_queue">Добави към опашката</string>
     <string name="color_yellow">Жълт</string>
     <string name="captions">Надписи</string>
@@ -407,7 +406,6 @@
     <string name="empty">Трябва да въведете потребителско име и парола.</string>
     <string name="playlistUrl">Плейлист URL</string>
     <string name="time_code">Времеви код (секунди)</string>
-    <string name="skip_buttons_summary">Покажи бутони за прескачане към следващия или предишен видеоклип</string>
     <string name="watch_positions_title">Запомнени позиции на възпроизвеждане</string>
     <string name="yt_shorts">Кратки видеа</string>
     <string name="worst_quality">Лошо</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -199,8 +199,6 @@
     <string name="network_wifi">শুধু ওয়াই-ফাইতে</string>
     <string name="translate">অনুবাদ</string>
     <string name="general_summary">ভাষা এবং এলাকা</string>
-    <string name="skip_buttons">স্কিপ বাটন</string>
-    <string name="skip_buttons_summary">আগের অথবা পরের ভিডিওতে যাওয়ার জন্য বাটন দেখান</string>
     <string name="required_network">নেটওয়ার্ক প্রয়োজন</string>
     <string name="take_a_break">বিরতি নেয়ার সময় চলে এসেছে</string>
     <string name="no_subtitles_available">কোনো সাবটাইটেল পাওয়া যায় নি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -207,7 +207,6 @@
     <string name="show_stream_thumbnails_summary">Mostra les miniatures de les noves retransmissions. Activar-ho consumirà dades addicionals</string>
     <string name="network_all">Totes</string>
     <string name="download_paused">Descàrrega en pausa</string>
-    <string name="skip_buttons">Botons de saltar</string>
     <string name="reset_watch_positions">Restableix</string>
     <string name="add_to_queue">Afegir a la cua</string>
     <string name="captions">Subtítols</string>
@@ -248,7 +247,6 @@
     <string name="music_artists">Artistes de YT Music</string>
     <string name="data_saver_mode_summary">Omet les miniatures i altres imatges</string>
     <string name="never">Mai</string>
-    <string name="skip_buttons_summary">Mostra els botons per passar al vídeo següent o anterior</string>
     <string name="watch_positions_title">Posicions de reproducció recordades</string>
     <string name="yt_shorts">Curts</string>
     <string name="worst_quality">La pitjor</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -181,7 +181,6 @@
     <string name="default_subtitle_language">زمانی ژێرنووس</string>
     <string name="network_all">هەمووی</string>
     <string name="export_subscriptions">هەڵگرتنی هاوبەشیكردنەکان</string>
-    <string name="skip_buttons">دوگمەکانی پەڕاندن</string>
     <string name="backup">پاشکەوتکردن</string>
     <string name="open_copied">کردنەوە</string>
     <string name="audio_video_summary">کوالێتی و شێواز</string>
@@ -258,7 +257,6 @@
     <string name="error_occurred">هەڵە هەیە</string>
     <string name="copied">لەبەریگیرایەوە</string>
     <string name="share_with_time">بڵاوکردنەوە لەگەڵ هەمان کاتدا</string>
-    <string name="skip_buttons_summary">پیشاندانی دوگمەکانی پێشخستن و دواخستنی ڤیدیۆ</string>
     <string name="background_mode">دۆخی پشت شاشە</string>
     <string name="add_to_queue">زیادکردن بۆ دواخراو</string>
     <string name="misc">هەمەجۆر</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -218,10 +218,8 @@
     <string name="copied">Zkopírováno</string>
     <string name="share_with_time">Sdílet s časovým kódem</string>
     <string name="export_subscriptions">Exportovat odběry</string>
-    <string name="skip_buttons">Tlačítka přeskočení</string>
     <string name="history_size">Maximální velikost historie</string>
     <string name="background_mode">Režim na pozadí</string>
-    <string name="skip_buttons_summary">Zobrazit tlačítka k přeskočení na další nebo předchozí video</string>
     <string name="unlimited">Neomezená</string>
     <string name="add_to_queue">Přidat do fronty</string>
     <string name="misc">Různé</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -218,8 +218,6 @@
     <string name="copied">Kopieret</string>
     <string name="share_with_time">Del med tidskode</string>
     <string name="export_subscriptions">Eksportér abonnementer</string>
-    <string name="skip_buttons">Spring over-knapper</string>
-    <string name="skip_buttons_summary">Vis knapper for at springe til næste eller forrige video</string>
     <string name="unlimited">Ubegrænset</string>
     <string name="history_size">Maksimal historikstørrelse</string>
     <string name="background_mode">Baggrundstilstand</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -232,7 +232,6 @@
     <string name="navigation_bar">Navigationsleiste</string>
     <string name="download_channel_name">Download-Service</string>
     <string name="push_channel_name">Benachrichtigungsdienst</string>
-    <string name="skip_buttons">Überspringen-Buttons</string>
     <string name="history_size">Maximale Verlaufsgröße</string>
     <string name="resize_mode_fill">Ausfüllen</string>
     <string name="audio_video_summary">Qualität und Format</string>
@@ -249,7 +248,6 @@
     <string name="share_with_time">Mit Zeitstempel teilen</string>
     <string name="export_subscriptions">Abos exportieren</string>
     <string name="delete">Aus Downloads löschen</string>
-    <string name="skip_buttons_summary">Schaltflächen anzeigen, um zum nächsten oder vorherigen Video zu springen</string>
     <string name="resize_mode_zoom">Vergrößern</string>
     <string name="repeat_mode">Endlosschleife</string>
     <string name="resize_mode_fit">Anpassen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -185,7 +185,6 @@
     <string name="none">Κανένα</string>
     <string name="watch_positions_title">Αποθηκευμένες θέσεις παρακολούθησης</string>
     <string name="general_summary">Γλώσσα και περιοχή</string>
-    <string name="skip_buttons_summary">Εμφάνιση κουμπιών για να μεταβείτε στο επόμενο ή το προηγούμενο βίντεο</string>
     <string name="unlimited">Απεριόριστο</string>
     <string name="resize_mode_zoom">Μεγέθυνση</string>
     <string name="history_size">Μέγιστο μέγεθος ιστορικού</string>
@@ -215,7 +214,6 @@
     <string name="share_with_time">Μοιραστείτε με κωδικό χρόνου</string>
     <string name="chapters">Κεφάλαια</string>
     <string name="export_subscriptions">Εξαγωγή εγγραφών</string>
-    <string name="skip_buttons">Κουμπιά παράκαμψης</string>
     <string name="background_mode">Λειτουργία παρασκηνίου</string>
     <string name="add_to_queue">Προσθήκη στην ουρά</string>
     <string name="misc">Διάφορα</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -229,8 +229,6 @@
     <string name="take_a_break">Es hora de tomar un descanso</string>
     <string name="error_occurred">Error</string>
     <string name="copied">Copiado</string>
-    <string name="skip_buttons">Botones de omisión</string>
-    <string name="skip_buttons_summary">Mostrar botones para pasar al vídeo siguiente o anterior</string>
     <string name="history_size">Tamaño máximo del historial</string>
     <string name="unlimited">Ilimitado</string>
     <string name="background_mode">Modo segundo plano</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -285,7 +285,6 @@
     <string name="least_views">Kõige vähem vaatamisi</string>
     <string name="translate">Tõlge</string>
     <string name="network_wifi">Vaid WiFi</string>
-    <string name="skip_buttons">Vahelejätmise nupud</string>
     <string name="category_preview_summary">Segmentide jaoks, mis kirjeldavad tulevast sisu ilma olulise lisateabeta. Kui see sisaldab videoklippe, mis leiduvad vaid siin, siis ilmselgelt on tegemist vale kategooriaga</string>
     <string name="category_highlight_summary">See võib olla reklaampealkiri, pisipilt või video kõige huvitavam koht. Klõpsides peatükkide loendile saad sa selle lõigu vahele jätta</string>
     <string name="turnInternetOn">Internetiühenduse loomiseks palun lülita sisse WiFi või mobiilne andmesideühendus.</string>
@@ -317,7 +316,6 @@
     <string name="most_views">Kõige rohkem vaatamisi</string>
     <string name="least_recent">Vanim</string>
     <string name="unlimited">Piiramatu</string>
-    <string name="skip_buttons_summary">Näita nuppe, mis võimaldavad sul hüpata eelmise või järgmise video juurde</string>
     <string name="history_size">Ajaloo suurim lubatud maht</string>
     <string name="change_region">Populaarsust koguvate videote valik pole selle piirkonna jaoks saadaval. Palun vali seadistustest mõni muu eelistus.</string>
     <string name="time_code">Ajamärge (sekundites)</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -217,7 +217,6 @@
     <string name="copied">Kopiatuta</string>
     <string name="share_with_time">Partekatu denbora kodearekin</string>
     <string name="error_occurred">Akatsa</string>
-    <string name="skip_buttons">Omititzeko botoiak</string>
     <string name="history_size">Historiaren gehienezko tamaina</string>
     <string name="unlimited">Mugagabea</string>
     <string name="background_mode">Atzeko planoko modua</string>
@@ -225,7 +224,6 @@
     <string name="misc">Anitza</string>
     <string name="take_a_break">Atsedena hartzeko ordua</string>
     <string name="export_subscriptions">Harpidetzak esportatu</string>
-    <string name="skip_buttons_summary">Erakutsi botoiak hurrengo edo aurreko bideora joateko</string>
     <string name="yt_shorts">Motzak</string>
     <string name="device_info">Gailuaren informazioa</string>
     <string name="no_subtitles_available">Ez dago azpititulurik erabilgarri</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -138,7 +138,6 @@
     <string name="pauseOnScreenOff">مکث خودکار</string>
     <string name="notify_new_streams">نمایش آگاهی برای جریان‌های جدید</string>
     <string name="default_subtitle_language">زبان زیرنویس</string>
-    <string name="skip_buttons">دکمه‌های پرش</string>
     <string name="player_summary">پیش‌گزیده‌ها و رفتار</string>
     <string name="watch_history">سابقه تماشا</string>
     <string name="deleteAccount">حذف حساب</string>
@@ -280,7 +279,6 @@
     <string name="delete">حذف از دانلودها</string>
     <string name="change_region">به نظر می رسد پرطرفدار ها برای منطقه فعلی در دسترس نیست. لطفاً یکی دیگر را در تنظیمات انتخاب کنید.</string>
     <string name="pauseOnScreenOff_summary">مکث پخش هنگام خاموش بودن صفحه</string>
-    <string name="skip_buttons_summary">نمایش دکمه ها برای پرش به ویدیو بعدی یا قبلی</string>
     <string name="instance_frontend_url">آدرس اینترنتی برای رابط جلویی نمونه (اختیاری)</string>
     <string name="seek_increment">پیشروی جویش</string>
     <string name="auth_instances">گزینش نمونه‌ای برای هویت‌سنجی</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -219,8 +219,6 @@
     <string name="network_wifi">Vain Wi-Fi</string>
     <string name="translate">Käännös</string>
     <string name="error_occurred">Virhe</string>
-    <string name="skip_buttons">Ohituspainikkeet</string>
-    <string name="skip_buttons_summary">Näytä painikkeet siirtyäksesi seuraavaan tai edelliseen videoon</string>
     <string name="history_size">Historian enimmäiskoko</string>
     <string name="background_mode">Taustatila</string>
     <string name="resize_mode_fit">Sovita</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -218,7 +218,6 @@
     <string name="error_occurred">Erreur</string>
     <string name="share_with_time">Partager avec l’horodatage</string>
     <string name="export_subscriptions">Exporter les abonnements</string>
-    <string name="skip_buttons">Boutons de saut</string>
     <string name="unlimited">Illimité</string>
     <string name="history_size">Taille maximale de l’historique</string>
     <string name="background_mode">Mode arrière-plan</string>
@@ -226,7 +225,6 @@
     <string name="yt_shorts">Shorts</string>
     <string name="misc">Divers</string>
     <string name="take_a_break">Il est temps de faire une pause</string>
-    <string name="skip_buttons_summary">Afficher les boutons pour sauter à la vidéo suivante ou précédente</string>
     <string name="backup_restore">Sauvegarde et restauration</string>
     <string name="backup">Sauvegarder</string>
     <string name="picture_in_picture">Image dans l’image</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -105,7 +105,6 @@
     <string name="network_all">તમામ</string>
     <string name="network_wifi">ફક્ત વાઇ-ફાઇ પર</string>
     <string name="no_search_result">પરિણામ નથી.</string>
-    <string name="skip_buttons">બટનો છોડો</string>
     <string name="background_mode">પાશ્વભાગ સ્થિતિ</string>
     <string name="misc">મિશ્ર</string>
     <string name="take_a_break">વિરામ લેવાનો સમય છે</string>
@@ -150,7 +149,6 @@
     <string name="watch_history">ઇતિહાસ જુઓ</string>
     <string name="privacy_alert">ગોપનીયતા ચેતવણી</string>
     <string name="login">પ્રવેશ કરો</string>
-    <string name="skip_buttons_summary">પછીની અથવા પહેલાંની વિડિયો પર જવા માટે બટનો બતાવો</string>
     <string name="startpage">ઘર</string>
     <string name="subscriptions">સબસ્ક્રિપ્શન્સ</string>
     <string name="library">પુસ્તકાલય</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -170,8 +170,6 @@
     <string name="gradientIcon">ग्लिब ग्रेडिएंट</string>
     <string name="fireIcon">फैशनेबल आग</string>
     <string name="torchIcon">ट्रेंडी मशाल</string>
-    <string name="skip_buttons">स्किप बटन</string>
-    <string name="skip_buttons_summary">अगले या पिछले वीडियो पर जाने के लिए बटन दिखाएं</string>
     <string name="category_preview_summary">अतिरिक्त जानकारी के बिना भविष्य की सामग्री का विवरण देने वाले सेगमेंट के लिए। यदि इसमें क्लिप शामिल हैं जो केवल यहां दिखाई देती हैं, तो बहुत संभव है कि यह गलत श्रेणी हो</string>
     <string name="category_filler_summary">केवल फिलर या हास्य के लिए जोड़े गए स्पर्शरेखा दृश्यों के लिए वीडियो की मुख्य सामग्री को समझने की आवश्यकता नहीं है</string>
     <string name="update_available">अपडेट उपलब्ध है</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -132,8 +132,6 @@
     <string name="category_filler">Időkitöltés/viccek</string>
     <string name="category_preview">Előnézet/visszatekintés</string>
     <string name="watch_history">Megtekintési előzmények</string>
-    <string name="skip_buttons">Kihagyás gombok</string>
-    <string name="skip_buttons_summary">Gombok megjelenítése a következő vagy az előző videóra való ugráshoz</string>
     <string name="category_filler_summary">A felesleges jelenetekhez, amelyek csak időkitöltésre lettek hozzáadva, illetve olyan humorhoz amely nem szükséges a videó fő témájának a megértéséhez</string>
     <string name="category_music_offtopic_summary">Kizárólag zenei videókban való felhasználásra. A videó olyan részeit kell lefednie, amelyek nem részei a hivatalos mixeknek. Végül a videónak a lehető legjobban kell hasonlítania a Spotify vagy bármely más mix változathoz, vagy csökkenteni kell a beszédet vagy más zavaró elemeket</string>
     <string name="category_preview_summary">A jövőbeli tartalmakat részletező szakaszokhoz, melyek nem nyújtanak további információt. Ha olyan klipeket tartalmaz, amelyek csak itt jelennek meg, akkor nagyon valószínű, hogy nem ez a megfelelő kategória</string>

--- a/app/src/main/res/values-ia/strings.xml
+++ b/app/src/main/res/values-ia/strings.xml
@@ -240,7 +240,6 @@
     <string name="maximum_image_cache">Dimension maxime del cache de imagines</string>
     <string name="export_subscriptions">Exportar subscriptiones</string>
     <string name="local_subscriptions">Subscriptiones local</string>
-    <string name="skip_buttons">Buttones de salto</string>
     <string name="add_to_queue">Adder al cauda</string>
     <string name="backup">Copia de securitate</string>
     <string name="skip_segment">Saltar</string>
@@ -253,7 +252,6 @@
     <string name="autoRotatePlayer_summary">Reproduction in schermo plen quando le apparato es girate</string>
     <string name="resize_mode_zoom">Zoom</string>
     <string name="backup_customInstances">Instantias personalisate</string>
-    <string name="skip_buttons_summary">Monstrar le buttones pro saltar al video sequente o previe</string>
     <string name="picture_in_picture">Imagine-in-imagine</string>
     <string name="play_next">Reproducer le sequente</string>
     <string name="no_subtitles_available">Necun subtitulos disponibile</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -216,8 +216,6 @@
     <string name="history_empty">Belum ada riwayat.</string>
     <string name="required_network">Dibutuhkan koneksi</string>
     <string name="export_subscriptions">Ekspor langganan</string>
-    <string name="skip_buttons">Tombol lewat</string>
-    <string name="skip_buttons_summary">Tampilkan tombol untuk melewati ke video berikutnya atau sebelumnya</string>
     <string name="history_size">Ukuran riwayat maksimum</string>
     <string name="unlimited">Tidak terbatas</string>
     <string name="add_to_queue">Tambahkan ke antrean</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -376,10 +376,8 @@
     <string name="export_subscriptions">Flytja út áskriftir</string>
     <string name="unlimited">Ótakmarkað</string>
     <string name="translate">Þýðing</string>
-    <string name="skip_buttons">Sleppa-hnappar</string>
     <string name="share_with_time">Deila með tímakóða</string>
     <string name="history_size">Hámarksstærð ferils</string>
-    <string name="skip_buttons_summary">Birta hnappa til að hoppa yfir á næsta eða fyrra myndskeið</string>
     <string name="repeat_mode_all">Endurtaka allt</string>
     <string name="backup_restore">Afrita og endurheimta</string>
     <string name="backup">Öryggisafrit</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -224,8 +224,6 @@
     <string name="irreversible">Sei sicuro\? Non può essere annullato!</string>
     <string name="most_recent">Più recenti</string>
     <string name="export_subscriptions">Esporta iscrizioni</string>
-    <string name="skip_buttons">Pulsanti di skip</string>
-    <string name="skip_buttons_summary">Mostra pulsanti per saltare al video successivo o precedente</string>
     <string name="history_size">Dimensione massima della cronologia</string>
     <string name="unlimited">Illimitata</string>
     <string name="resize_mode_fill">Riempi</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -218,8 +218,6 @@
     <string name="error_occurred">שגיאה</string>
     <string name="share_with_time">שיתוף עם קוד זמן</string>
     <string name="export_subscriptions">ייצוא מינויים</string>
-    <string name="skip_buttons">כפתורי דילוג</string>
-    <string name="skip_buttons_summary">להציג כפתורים לדילוג לסרטון הקודם או הבא</string>
     <string name="background_mode">מצב רקע</string>
     <string name="history_size">גודל ההיסטוריה המרבי</string>
     <string name="unlimited">לא מוגבל</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -229,7 +229,6 @@
     <string name="network_all">すべて</string>
     <string name="network_metered">モバイルデータ通信</string>
     <string name="network_wifi">Wi-Fiのみ</string>
-    <string name="skip_buttons_summary">次の動画、前の動画にスキップするボタンを表示します</string>
     <string name="history_size">履歴の最大保持数</string>
     <string name="background_mode">バックグラウンドモード</string>
     <string name="misc">その他</string>
@@ -255,7 +254,6 @@
     <string name="least_recent">最古</string>
     <string name="no_search_result">結果がありません。</string>
     <string name="added_to_playlist">再生リスト %1$s に追加しました</string>
-    <string name="skip_buttons">スキップボタン</string>
     <string name="livestreams">ライブ</string>
     <string name="download_channel_name">ダウンロードサービス</string>
     <string name="push_channel_name">通知の実行</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -177,7 +177,6 @@
     <string name="export_subscriptions">នាំចេញការជាវ</string>
     <string name="network_all">ទាំងអស់</string>
     <string name="download_paused">ការទាញយកបានផ្អាក</string>
-    <string name="skip_buttons">ប៊ូតុងរំលង</string>
     <string name="reset_watch_positions">កំណត់ជាថ្មី</string>
     <string name="add_to_queue">បន្ថែមទៅជួរ</string>
     <string name="captions">អក្សររត់</string>
@@ -217,7 +216,6 @@
     <string name="data_saver_mode_summary">រំលងរូបតូចៗ និងរូបភាពផ្សេងទៀត</string>
     <string name="quality">គុណភាព</string>
     <string name="never">មិនដែល</string>
-    <string name="skip_buttons_summary">បង្ហាញប៊ូតុងដើម្បីរំលងទៅវីដេអូបន្ទាប់ ឬមុន</string>
     <string name="worst_quality">អាក្រក់បំផុត</string>
     <string name="general_summary">ភាសា និងតំបន់</string>
     <string name="player">ការីចាក់</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -305,8 +305,6 @@
     <string name="no_subtitles_available">사용 가능한 자막 없음</string>
     <string name="take_a_break">휴식을 취할 시간</string>
     <string name="history_size">최대 기록 크기</string>
-    <string name="skip_buttons_summary">다음 또는 이전 비디오로 건너뛰기 위한 버튼을 표시합니다</string>
-    <string name="skip_buttons">건너뛰기 버튼</string>
     <string name="trending">최신 유행</string>
     <string name="mobile_data">모바일 데이터</string>
     <string name="color_violet">화려한 보라색</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -111,8 +111,6 @@
     <string name="notify_new_streams">Pranešimai apie naujas transliacijas</string>
     <string name="irreversible">Ar tikrai\? To nebus galima atšaukti!</string>
     <string name="export_subscriptions">Eksportuoti prenumeratas</string>
-    <string name="skip_buttons">Praleidimo mygtukai</string>
-    <string name="skip_buttons_summary">Rodyti mygtukus, kad pereitumėte prie kito arba ankstesnio vaizdo įrašo</string>
     <string name="history_size">Didžiausias istorijos dydis</string>
     <string name="unlimited">Neribotas</string>
     <string name="background_mode">Fono režimas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -218,8 +218,6 @@
     <string name="copied">Nokopēts</string>
     <string name="export_subscriptions">Izgūt abonementus</string>
     <string name="share_with_time">Sākot no</string>
-    <string name="skip_buttons">Izlaišanas pogas</string>
-    <string name="skip_buttons_summary">Rādīt pogas, kas ļauj pāriet uz nākamo vai iepriekšējo video</string>
     <string name="history_size">Maksimālais vēstures izmērs</string>
     <string name="background_mode">Fona režīms</string>
     <string name="unlimited">Neierobežots</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -226,7 +226,6 @@
     <string name="download_channel_description">मीडिया डाऊनलोड करताना नोटिफिकेशन दाखवते.</string>
     <string name="auto">ऑटो</string>
     <string name="history_size">अधिकतम इतिहास आकार</string>
-    <string name="skip_buttons_summary">पुढील किंवा मागील व्हिडिओवर जाण्यासाठी बटणे दर्शवा</string>
     <string name="add_to_queue">रांगेत जोडा</string>
     <string name="misc">विविध</string>
     <string name="take_a_break">विश्रांती घेण्याची वेळ आली आहे</string>
@@ -271,7 +270,6 @@
     <string name="least_views">किमान व्ह्यूज</string>
     <string name="required_network">आवश्यक कनेक्शन</string>
     <string name="network_all">सर्व</string>
-    <string name="skip_buttons">स्किप बटन</string>
     <string name="unlimited">अमर्यादित</string>
     <string name="background_mode">बॅकग्राऊंड मोड</string>
     <string name="repeat_mode_current">चालू</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -218,8 +218,6 @@
     <string name="caption_settings">Undertekster</string>
     <string name="navLabelVisibility">Etikettsynlighet</string>
     <string name="export_subscriptions">Eksporter abonnementer</string>
-    <string name="skip_buttons">Knapper for sporveksling</string>
-    <string name="skip_buttons_summary">Vis knapper for å hoppe til neste eller forrige video</string>
     <string name="history_size">Maks. historikkstørrelse</string>
     <string name="unlimited">Ubegrenset</string>
     <string name="background_mode">Bakgrunnsmodus</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -307,7 +307,6 @@
     <string name="watch_positions_title">Afspeel­posities onthouden</string>
     <string name="system_caption_style">Ondertitelstijl van systeem</string>
     <string name="export_subscriptions">Abonnementen exporteren</string>
-    <string name="skip_buttons">Knoppen voor volgende/vorige</string>
     <string name="player_resize_mode">Beeldformaat</string>
     <string name="device_info">Apparaat­info</string>
     <string name="mobile_data">Mobiele gegevens</string>
@@ -416,7 +415,6 @@
     <string name="show_stream_thumbnails">Stream-miniaturen</string>
     <string name="watch_history_summary">Houd bekeken video\'s lokaal bij</string>
     <string name="history_summary">Kijk- en zoek­geschiedenis</string>
-    <string name="skip_buttons_summary">Toon knoppen om naar de volgende of vorige video te gaan</string>
     <string name="sb_custom_colors">Aangepaste segment­kleuren</string>
     <string name="invalid_color">Ongeldige kleur­waarde ingevoerd!</string>
     <string name="original_or_main_audio_track">Origineel</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -172,7 +172,6 @@
     <string name="irreversible">ଆପଣ ନିଶ୍ଚିତ କି!</string>
     <string name="history_empty">ବର୍ତ୍ତମାନ ସୁଦ୍ଧା କୌଣସି ଇତିହାସ ନାହିଁ ।</string>
     <string name="copied">କପି ହୋଇଛି</string>
-    <string name="skip_buttons">ଏଡ଼ାଇବା ବଟନ୍</string>
     <string name="history_size">ସର୍ବାଧିକ ଇତିହାସ ଆକାର</string>
     <string name="unlimited">ଅସଂଖ୍ୟ</string>
     <string name="yt_shorts">ସର୍ଟ ଗୁଡ଼ିକ</string>
@@ -254,7 +253,6 @@
     <string name="misc">ବିବିଧ</string>
     <string name="background_mode">ପୃଷ୍ଠଭୂମି ସ୍ଥିତି</string>
     <string name="backup">ନକଲ</string>
-    <string name="skip_buttons_summary">ପରବର୍ତ୍ତୀ କିମ୍ବା ପୂର୍ବ ଭିଡିଓକୁ ଯିବାକୁ ବଟନ୍ ଦେଖାନ୍ତୁ</string>
     <string name="take_a_break">ବିରତି ପାଇଁ ସମୟ</string>
     <string name="add_to_queue">ଧାଡିରେ ଯୋଡନ୍ତୁ</string>
     <string name="picture_in_picture">ଛବି ରେ ଛବି</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -219,8 +219,6 @@
     <string name="copied">ਕਾਪੀ ਕੀਤਾ</string>
     <string name="share_with_time">ਟਾਈਮ ਕੋਡ ਨਾਲ ਸਾਂਝਾ ਕਰੋ</string>
     <string name="export_subscriptions">ਸਬਸਕ੍ਰਿਪਸ਼ਨਾਂ ਨਿਰਯਾਤ ਕਰੋ</string>
-    <string name="skip_buttons">ਸਕਿਪ ਬਟਨ</string>
-    <string name="skip_buttons_summary">ਅਗਲੇ ਜਾਂ ਪਿਛਲੇ ਵੀਡੀਓ \'ਤੇ ਜਾਣ ਲਈ ਬਟਨ ਦਿਖਾਓ</string>
     <string name="history_size">ਇਤਿਹਾਸ ਦਾ ਅਧਿਕਤਮ ਆਕਾਰ</string>
     <string name="unlimited">ਅਸੀਮਤ</string>
     <string name="background_mode">ਬੈਕਗਰਾਊਂਡ ਮੋਡ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -157,8 +157,6 @@
     <string name="required_network">Wymagane połączenie</string>
     <string name="network_all">Każdy typ sieci</string>
     <string name="no_search_result">Brak wyników.</string>
-    <string name="skip_buttons">Przyciski pomijania</string>
-    <string name="skip_buttons_summary">Pokaż przyciski umożliwiające przejście do następnego lub poprzedniego filmu</string>
     <string name="watch_positions">Zapamiętaj pozycję</string>
     <string name="github">GitHub</string>
     <string name="landscape">Wymuś tryb poziomy</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -223,8 +223,6 @@
     <string name="local_subscriptions">Inscrições locais</string>
     <string name="preferences">Preferências</string>
     <string name="backup_customInstances">Instâncias personalizadas</string>
-    <string name="skip_buttons_summary">Mostrar botões para pular para o próximo vídeo ou anterior</string>
-    <string name="skip_buttons">Ativar botões \'Anterior/Próximo\'</string>
     <string name="background_mode">Modo em segundo plano</string>
     <string name="add_to_queue">Adicionar à fila</string>
     <string name="error_occurred">Erro</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -217,8 +217,6 @@
     <string name="add_to_queue">Adicionar à fila</string>
     <string name="yt_shorts">Curtos</string>
     <string name="player_resize_mode">Redimensionamento</string>
-    <string name="skip_buttons">Botões para avançar/recuar</string>
-    <string name="skip_buttons_summary">Mostrar botões para avançar/recuar para o vídeo seguinte/anterior</string>
     <string name="unlimited">Sem limite</string>
     <string name="background_mode">Modo de segundo plano</string>
     <string name="misc">Outras</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -146,7 +146,6 @@
     <string name="most_views">Cele mai multe vizualizări</string>
     <string name="copied">Copiat</string>
     <string name="take_a_break">Este timpul să luați o pauză</string>
-    <string name="skip_buttons_summary">Afișați butoanele pentru a trece la videoclipul următor sau anterior</string>
     <string name="background_mode">Modul de fundal</string>
     <string name="picture_in_picture">Suprapunere imagine</string>
     <string name="player_resize_mode">Mod redimensionare</string>
@@ -341,7 +340,6 @@
     <string name="autoplay_countdown">Numărătoarea inversă pentru redarea automată</string>
     <string name="video_id">ID video</string>
     <string name="landscape">Peisaj</string>
-    <string name="skip_buttons">Butoane de omitere</string>
     <string name="resize_mode_fit">Potrivire</string>
     <string name="local_playlists">Liste de redare locale</string>
     <string name="import_playlists">Importați liste de redare</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -218,11 +218,9 @@
     <string name="share_with_time">Поделиться с тайм-кодом</string>
     <string name="worst_quality">Наихудшее</string>
     <string name="export_subscriptions">Экспорт подписок</string>
-    <string name="skip_buttons">Кнопки перехода</string>
     <string name="background_mode">Фоновый режим</string>
     <string name="history_size">Максимальный размер истории</string>
     <string name="unlimited">Неограниченно</string>
-    <string name="skip_buttons_summary">Показывать кнопки для перехода к следующему или предыдущему видео</string>
     <string name="yt_shorts">Shorts</string>
     <string name="misc">Прочее</string>
     <string name="add_to_queue">Добавить в очередь</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -165,7 +165,6 @@
     <string name="copied">පිටපත් කර ඇත</string>
     <string name="share_with_time">කාල කේතය සමඟ බෙදා ගන්න</string>
     <string name="export_subscriptions">දායකත්වයන් අපනයනය කරන්න</string>
-    <string name="skip_buttons_summary">ඊළඟ හෝ පෙර වීඩියෝවට යාමට බොත්තම් පෙන්වන්න</string>
     <string name="history_size">උපරිම ඉතිහාස ප්‍රමාණය</string>
     <string name="background_mode">පසුබිම් ප්‍රකාරය</string>
     <string name="misc">වෙනත්</string>
@@ -298,7 +297,6 @@
     <string name="notify_new_streams_summary">ඔබ අනුගමනය කරන නිර්මාණකරුවන්ගෙන් නව ප්‍රවාහ සඳහා දැනුම්දීම් පෙන්වන්න</string>
     <string name="history_empty">තවමත් ඉතිහාසයක් නැත.</string>
     <string name="required_network">සම්බන්ධතාවයක් අවශ්‍ය</string>
-    <string name="skip_buttons">මඟ හරින බොත්තම්</string>
     <string name="new_videos_badge">නව වීඩියෝ සඳහා දර්ශකය</string>
     <string name="resize_mode_zoom">විශාලනය කරන්න</string>
     <string name="repeat_mode_none">කිසිවක් නැත</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -174,8 +174,6 @@
     <string name="no_search_result">Žiadne výsledky.</string>
     <string name="share_with_time">Zdieľať s časovým kódom</string>
     <string name="watch_history">História sledovania</string>
-    <string name="skip_buttons">Tlačidlá prechodu</string>
-    <string name="skip_buttons_summary">Zobrazí tlačidlá prechodu na ďalšie alebo predchádzajúce video</string>
     <string name="watch_positions">Zapamätať pozíciu</string>
     <string name="auth_instance">Overovacia inštancia</string>
     <string name="github">GitHub</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -218,8 +218,6 @@
     <string name="worst_quality">Најгори</string>
     <string name="share_with_time">Дели са временским кодом</string>
     <string name="export_subscriptions">Изези праћења</string>
-    <string name="skip_buttons">Дугмад за прескакање</string>
-    <string name="skip_buttons_summary">Прикажите дугмад за прескакање на следећи или претходни видео снимак</string>
     <string name="history_size">Максимална величина историје</string>
     <string name="background_mode">Позадински режим</string>
     <string name="unlimited">Неограничено</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -204,7 +204,6 @@
     <string name="show_stream_thumbnails_summary">Visa förhandsbilder för nya videor. Detta använder mer data.</string>
     <string name="network_all">Alla</string>
     <string name="download_paused">Nedladdningen är pausad</string>
-    <string name="skip_buttons">Knappar för nästa/föregående</string>
     <string name="reset_watch_positions">Återställ uppspelningspositioner</string>
     <string name="add_to_queue">Lägg till i kön</string>
     <string name="captions">Textning</string>
@@ -244,7 +243,6 @@
     <string name="data_saver_mode_summary">Hoppa över förhandsbilder och andra bilder</string>
     <string name="quality">Kvalitet</string>
     <string name="never">Aldrig</string>
-    <string name="skip_buttons_summary">Visa knappar för att byta till nästa eller föregående video</string>
     <string name="watch_positions_title">Sparade positioner för uppspelning</string>
     <string name="yt_shorts">Shorts</string>
     <string name="worst_quality">Lägsta</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -503,12 +503,10 @@
     <string name="flameIcon">பறக்கும் சுடர்</string>
     <string name="auth_instance">அங்கீகார நிகழ்வு</string>
     <string name="auth_instance_summary">அங்கீகரிக்கப்பட்ட அழைப்புகளுக்கு வேறு நிகழ்வைப் பயன்படுத்தவும்</string>
-    <string name="skip_buttons_summary">அடுத்த அல்லது முந்தைய வீடியோவுக்கு தவிர்க்க பொத்தான்களைக் காட்டு</string>
     <string name="history_size">அதிகபட்ச வரலாற்று அளவு</string>
     <string name="network_metered">அளவிடப்பட்ட</string>
     <string name="unlimited">வரம்பற்றது</string>
     <string name="background_mode">பின்னணி முறை</string>
-    <string name="skip_buttons">பொத்தான்களைத் தவிர்க்கவும்</string>
     <string name="repeat_mode_all">அனைத்தையும் மீண்டும் செய்யவும்</string>
     <string name="backup">காப்புப்பிரதி</string>
     <string name="picture_in_picture">படம்-படம்</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -96,9 +96,7 @@
     <string name="start_time">เริ่ม</string>
     <string name="app_icon">ไอคอน</string>
     <string name="trends">เทรนด์</string>
-    <string name="skip_buttons">ปุ่มข้าม</string>
     <string name="import_watch_history">นำเข้าประวัติการดู</string>
-    <string name="skip_buttons_summary">แสดงปุ่มเพื่อข้ามไปยังวิดีโอถัดไปหรือก่อนหน้า</string>
     <string name="brightness">ความสว่าง</string>
     <string name="no_comments_available">วิดีโอนี้ยังไม่มีการแสดงความคิดเห็น</string>
     <string name="comments_disabled">การแสดงความคิดเห็นถูกปิดโดยผู้อัพโหลด</string>

--- a/app/src/main/res/values-tk/strings.xml
+++ b/app/src/main/res/values-tk/strings.xml
@@ -169,14 +169,12 @@
     <string name="required_network">Gerekli birikme</string>
     <string name="network_all">Ählisi</string>
     <string name="network_wifi">Diňe Wi-Fi-da</string>
-    <string name="skip_buttons_summary">Indiki ýa-da öňki wideo geçmek üçin düwmeleri görkez</string>
     <string name="add_to_queue">Nobata goşuň</string>
     <string name="open_copied">Aç</string>
     <string name="notify_new_streams">Täze wideolar üçin bildirişler</string>
     <string name="most_views">Iň köp görülen</string>
     <string name="least_views">Iň az görülen</string>
     <string name="share_with_time">Başlangyç wagty bilen paýlaşyň</string>
-    <string name="skip_buttons">Geçirme düwmesi</string>
     <string name="history_size">Bellikleriň maksimum ululygy</string>
     <string name="unlimited">Çäklendirilmedik</string>
     <string name="background_mode">Fon tertibi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -217,8 +217,6 @@
     <string name="error_occurred">Hata</string>
     <string name="copied">Kopyalandı</string>
     <string name="share_with_time">Zaman koduyla paylaş</string>
-    <string name="skip_buttons">Atlama düğmeleri</string>
-    <string name="skip_buttons_summary">Sonraki veya önceki videoya atlamak için düğmeleri göster</string>
     <string name="history_size">Maksimum geçmiş boyutu</string>
     <string name="unlimited">Sınırsız</string>
     <string name="background_mode">Arka plan modu</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -239,8 +239,6 @@
     <string name="checking_frequency">Перевірка кожні …</string>
     <string name="most_views">Найбільше переглядів</string>
     <string name="least_views">Найменше переглядів</string>
-    <string name="skip_buttons">Кнопки пропуску</string>
-    <string name="skip_buttons_summary">Показувати кнопки для переходу до наступного або попереднього відео</string>
     <string name="history_size">Максимальний розмір історії</string>
     <string name="background_mode">Фоновий режим</string>
     <string name="misc">Різне</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -162,8 +162,6 @@
     <string name="copied">Nusxa olindi</string>
     <string name="share_with_time">Vaqt kodi bilan ulashish</string>
     <string name="export_subscriptions">Obunalarni eksport qilish</string>
-    <string name="skip_buttons">O‘tkazib yuborish tugmalari</string>
-    <string name="skip_buttons_summary">Keyingi yoki oldingi videoga o‘tish uchun tugmalarni ko‘rsatish</string>
     <string name="update_available">Yangilanish mavjud</string>
     <string name="appearance">Tashqi ko‘rinish</string>
     <string name="downloads">Yuklab olishlar</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -240,8 +240,6 @@
     <string name="network_wifi">Chỉ trên Wi-Fi</string>
     <string name="copied">Đã sao chép</string>
     <string name="export_subscriptions">Xuất danh sách đăng ký</string>
-    <string name="skip_buttons">Nút bỏ qua</string>
-    <string name="skip_buttons_summary">Hiện nút để bỏ qua đến đoạn phim tiếp theo hoặc trước đó</string>
     <string name="history_size">Dung lượng lịch sử tối đa</string>
     <string name="unlimited">Không giới hạn</string>
     <string name="background_mode">Chế độ nền</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -218,8 +218,6 @@
     <string name="copied">已复制</string>
     <string name="share_with_time">带时间码分享</string>
     <string name="export_subscriptions">导出订阅</string>
-    <string name="skip_buttons_summary">显示按钮跳到下一个或上一个视频</string>
-    <string name="skip_buttons">跳跃按钮</string>
     <string name="history_size">最大历史记录大小</string>
     <string name="unlimited">无限制</string>
     <string name="background_mode">后台模式</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -225,7 +225,6 @@
     <string name="history_summary">觀看和搜尋歷史</string>
     <string name="playerAudioQuality">音訊品質</string>
     <string name="captions_size">字幕大小</string>
-    <string name="skip_buttons_summary">顯示按鈕，跳至上一部或下一部影片</string>
     <string name="take_a_break">是時候休息一下了</string>
     <string name="maximum_image_cache">最大圖片快取大小</string>
     <string name="device_info">裝置資訊</string>
@@ -296,7 +295,6 @@
     <string name="play_latest_videos">播放最新影片</string>
     <string name="audio_track">音訊曲目</string>
     <string name="export_subscriptions">匯出訂閱播放清單</string>
-    <string name="skip_buttons">跳過按鈕</string>
     <string name="no_search_result">無結果。</string>
     <string name="error_occurred">錯誤</string>
     <string name="copied">已複製</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,8 +263,6 @@
     <string name="copied">Copied</string>
     <string name="share_with_time">Share with time code</string>
     <string name="export_subscriptions">Export subscriptions</string>
-    <string name="skip_buttons">Skip buttons</string>
-    <string name="skip_buttons_summary">Show buttons to skip to the next or previous video</string>
     <string name="history_size">Maximum history size</string>
     <string name="unlimited">Unlimited</string>
     <string name="background_mode">Background mode</string>

--- a/app/src/main/res/xml/player_settings.xml
+++ b/app/src/main/res/xml/player_settings.xml
@@ -52,13 +52,6 @@
             app:valueTo="60.0" />
 
         <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:icon="@drawable/ic_next"
-            android:summary="@string/skip_buttons_summary"
-            app:key="skip_buttons"
-            app:title="@string/skip_buttons" />
-
-        <SwitchPreferenceCompat
             android:disableDependentsState="true"
             android:icon="@drawable/ic_rotating_circle"
             android:summary="@string/autoRotatePlayer_summary"


### PR DESCRIPTION
The option only exists because the skip buttons don't look that nice.

I think that having an option for the skip buttons that is disabled by default is definitely unexpected because it is part of the core functionality to switch between videos.

I thought about making the buttons look better, but idk how, so I kept them looking as before.

Pref migration missing to not conflict with https://github.com/libre-tube/LibreTube/pull/8733. Thus also a draft for now.
closes #8725