### PR TITLE
 feat(Player): enable smooth PiP transition

### DIFF
--- a/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
+++ b/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
@@ -1,13 +1,25 @@
 package com.github.libretube.compat
 
 import android.app.Activity
+import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.PackageManager
 
 object PictureInPictureCompat {
-
+    /**
+     * Returns whether the system supports Picture-in-Picture mode.
+     */
     fun isPictureInPictureAvailable(context: Context) =
         context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+
+    /**
+     * Returns whether the user has enabled Picture-in-Picture mode.
+     */
+    fun isPictureInPictureEnabled(context: Context) =
+        (context.getSystemService(Context.APP_OPS_SERVICE) as? AppOpsManager?)?.checkOpNoThrow(
+            AppOpsManager.OPSTR_PICTURE_IN_PICTURE, android.os.Process.myUid(), context.packageName
+        ) == AppOpsManager.MODE_ALLOWED
+
 
     fun isInPictureInPictureMode(activity: Activity) = activity.isInPictureInPictureMode
 

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -10,6 +10,7 @@ import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.Rect
 import android.media.session.PlaybackState
 import android.os.Bundle
 import android.os.Handler
@@ -24,6 +25,7 @@ import android.view.ViewGroup.LayoutParams
 import androidx.activity.BackEventCompat
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.trackPipAnimationHintView
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.TransitionAdapter
 import androidx.core.content.ContextCompat
@@ -42,6 +44,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -434,6 +437,12 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
 
         if (PlayerHelper.autoFullscreenEnabled && resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             setFullscreen()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                requireActivity().trackPipAnimationHintView(binding.player)
+            }
         }
 
         chaptersViewModel.chaptersLiveData.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
+++ b/app/src/main/java/com/github/libretube/ui/fragments/PlayerFragment.kt
@@ -1394,9 +1394,9 @@ class PlayerFragment : Fragment(R.layout.fragment_player), CustomPlayerCallback 
     /**
      * Detect whether PiP is supported and enabled
      */
-    private fun isPipAvailable(): Boolean {
-        return PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
-    }
+    private fun isPipAvailable() =
+        PictureInPictureCompat.isPictureInPictureAvailable(requireContext())
+                && PictureInPictureCompat.isPictureInPictureEnabled(requireContext())
 
     private fun shouldStartPiP(): Boolean {
         return isPipAvailable() && ::playerController.isInitialized && playerController.isPlaying


### PR DESCRIPTION
Automatically tracks the position of the player view, making the transition between PiP and non-PiP smoother.

Ref: https://developer.android.com/develop/ui/views/picture-in-picture#set-sourcerecthint

Also hides the PiP button, if the user disabled PiP mode.

Closes https://github.com/libre-tube/LibreTube/issues/8716