### PR TITLE
fix(SABR): set `MediaCapabilities`

### DIFF
--- a/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
+++ b/app/src/main/java/com/github/libretube/player/parser/SabrClient.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.github.libretube.LibreTubeApp
 import com.github.libretube.api.poToken.PoTokenGenerator
+import com.github.libretube.helpers.DisplayHelper
 import com.github.libretube.player.manifest.Representation
 import com.github.libretube.player.manifest.SabrManifest
 import com.github.libretube.ui.dialogs.ShareDialog
@@ -24,6 +25,8 @@ import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import video_streaming.BufferedRangeOuterClass.BufferedRange
 import video_streaming.ClientAbrStateOuterClass.ClientAbrState
 import video_streaming.FormatInitializationMetadataOuterClass.FormatInitializationMetadata
+import video_streaming.MediaCapabilitiesOuterClass.MediaCapabilities
+import video_streaming.MediaCapabilitiesOuterClass.MediaCapabilities.VideoFormatCapability
 import video_streaming.MediaHeaderOuterClass.MediaHeader
 import video_streaming.NextRequestPolicyOuterClass.NextRequestPolicy
 import video_streaming.PlaybackCookieOuterClass.PlaybackCookie
@@ -365,7 +368,21 @@ class SabrClient private constructor(
         val playerTimeMs = playbackRequest.segmentStartTimeMs
         val clientState = ClientAbrState.newBuilder()
             .setPlayerTimeMs(playerTimeMs)
-            //TODO: setMediaCapabilities for Android client: https://github.com/coletdjnz/yt-dlp-dev/blob/effe62991b1b87aafcc8f77a374d7ead9d461803/yt_dlp/extractor/youtube/_streaming/sabr/processor.py#L239
+            // only set for mobile clients
+            .setMediaCapabilities(
+                MediaCapabilities.newBuilder()
+                    .setHdrModeBitmask(if (DisplayHelper.supportsHdr(LibreTubeApp.instance)) 3 else 0)
+                    .addAllVideoFormatCapabilities(
+                        VideoFormatCapability.VideoCodec.entries.map {
+                            VideoFormatCapability.newBuilder()
+                                .setVideoCodec(it.ordinal)
+                                .setIs10BitSupported(true)
+                                .setEfficient(true)
+                                .build()
+                        }
+                    )
+                    .build()
+            )
             .setEnabledTrackTypesBitfield(if (videoFormat == null) 1 else 0)
             .setPlaybackRate(playbackRequest.playbackSpeed)
             .setElapsedWallTimeMs(lastRequestMs?.let { now -  it } ?: 0 )

--- a/app/src/main/proto/video_streaming/media_capabilities.proto
+++ b/app/src/main/proto/video_streaming/media_capabilities.proto
@@ -7,7 +7,22 @@ message MediaCapabilities {
   optional int32 hdr_mode_bitmask = 5;
 
   message VideoFormatCapability {
+    enum VideoCodec {
+      UNKNOWN_CODEC = 0;
+      H263 = 1;
+      H264 = 2;
+      VP8 = 3;
+      VP9 = 4;
+      H262 = 5;
+      VP6 = 6;
+      MPEG4 = 7;
+      AV1 = 8;
+      H265 = 9;
+      FLV1 = 10;
+    }
+
     optional int32 video_codec = 1;
+    optional bool efficient = 2;
     optional int32 max_height = 3;
     optional int32 max_width = 4;
     optional int32 max_framerate = 11;


### PR DESCRIPTION
Fixes an issue, where videos could not be played, as the server did not accept the selected format.

Closes: https://github.com/libre-tube/LibreTube/issues/8698

Thanks to @AudricV for reminding me to set the properties.