### PR TITLE
fix(Player): catch PiP exceptions

### DIFF
--- a/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
+++ b/app/src/main/java/com/github/libretube/compat/PictureInPictureCompat.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.PackageManager
+import android.util.Log
+import com.github.libretube.extensions.TAG
+import com.github.libretube.extensions.toastFromMainThread
 
 object PictureInPictureCompat {
     /**
@@ -25,7 +28,14 @@ object PictureInPictureCompat {
 
     fun setPictureInPictureParams(activity: Activity, params: PictureInPictureParamsCompat) {
         if (isPictureInPictureAvailable(activity)) {
-            activity.setPictureInPictureParams(params.toPictureInPictureParams())
+            try {
+                activity.setPictureInPictureParams(params.toPictureInPictureParams())
+            } catch (e: IllegalStateException) {
+                // some devices claim to support PiP, but produce an exception when using PiP
+                // https://github.com/libre-tube/LibreTube/issues/8163
+                Log.e(TAG(), e.stackTraceToString())
+                activity.toastFromMainThread(e.localizedMessage.orEmpty())
+            }
         }
     }
 


### PR DESCRIPTION
Some devices claim to support PictureInPicture, but throw an exception when setting PictureInPicture parameters.

Closes: https://github.com/libre-tube/LibreTube/issues/8163
Ref: https://stackoverflow.com/questions/55288858/error-device-doesnt-support-picture-in-picture-mode-entering-pip-picture-in