### PR TITLE
feat(downloads): add support for exporting downloaded video including audio

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragment)
+    implementation(libs.androidx.media3.transformer)
     implementation(libs.androidx.navigation.fragment)
     implementation(libs.androidx.navigation.ui)
     implementation(libs.androidx.preference)

--- a/app/src/main/java/com/github/libretube/constants/IntentData.kt
+++ b/app/src/main/java/com/github/libretube/constants/IntentData.kt
@@ -62,4 +62,5 @@ object IntentData {
     const val customInstance = "customInstance"
     const val audioOnly = "audioOnly"
     const val category = "category"
+    const val outputUri = "outputUri"
 }

--- a/app/src/main/java/com/github/libretube/ui/dialogs/DownloadExportDialog.kt
+++ b/app/src/main/java/com/github/libretube/ui/dialogs/DownloadExportDialog.kt
@@ -1,0 +1,106 @@
+package com.github.libretube.ui.dialogs
+
+import android.app.Dialog
+import android.net.Uri
+import android.os.Bundle
+import androidx.annotation.OptIn
+import androidx.appcompat.app.AlertDialog
+import androidx.core.net.toUri
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import androidx.media3.common.util.UnstableApi
+import com.github.libretube.R
+import com.github.libretube.constants.IntentData
+import com.github.libretube.db.DatabaseHolder
+import com.github.libretube.enums.FileType
+import com.github.libretube.extensions.toAndroidUri
+import com.github.libretube.extensions.toastFromMainThread
+import com.github.libretube.util.MediaExporter
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.loadingindicator.LoadingIndicator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.File
+
+class DownloadExportDialog : DialogFragment() {
+    @OptIn(UnstableApi::class)
+    private suspend fun exportDownload(videoId: String, outputUri: Uri, onCompletion: () -> Unit) {
+        val activity = requireActivity()
+
+        val downloadItems =
+            DatabaseHolder.Database.downloadDao().getDownloadById(videoId)!!.downloadItems
+        val video = downloadItems.firstOrNull { it.type == FileType.VIDEO }
+        val audio = downloadItems.firstOrNull { it.type == FileType.AUDIO }
+        if (audio == null && video == null) return
+
+        if (audio == null) {
+            MediaExporter.copyFileContents(activity, video!!.path.toAndroidUri(), outputUri)
+            onCompletion()
+        } else if (video == null) {
+            MediaExporter.copyFileContents(activity, audio.path.toAndroidUri(), outputUri)
+            onCompletion()
+        } else {
+            // output stream has to be opened shortly after the file picker was shown, otherwise
+            // the URI gets invalid
+            val outputStream = activity.contentResolver.openOutputStream(outputUri)!!
+
+            // we write everything to a temporary file first because the `MediaExporter`
+            // can't write to URIs directly, only to paths
+            val tempFile = File.createTempFile("mux", ".mp4", activity.cacheDir)
+
+            MediaExporter.muxMedia(
+                activity,
+                audio.path.toAndroidUri(),
+                video.path.toAndroidUri(),
+                tempFile.path,
+                onCompletion = {
+                    // copy to user-specified file
+                    MediaExporter.copyFileContents(
+                        activity.contentResolver.openInputStream(tempFile.toUri())!!,
+                        outputStream
+                    )
+                    tempFile.delete()
+                    onCompletion()
+                },
+                onError = { exportException ->
+                    exportException.printStackTrace()
+                    activity.toastFromMainThread(exportException.message.orEmpty())
+                    dismiss()
+                }
+            )
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val videoId = requireArguments().getString(IntentData.videoId)!!
+        val outputUri = requireArguments().getString(IntentData.outputUri)!!.toUri()
+
+        var dialog: AlertDialog? = null
+        val loadingIndicator = LoadingIndicator(requireContext())
+
+        CoroutineScope(Dispatchers.IO).launch {
+            exportDownload(videoId, outputUri) {
+                dialog?.setTitle(R.string.exportsuccess)
+                // remove loading indicator and show button to close dialog
+                loadingIndicator.isVisible = false
+                dialog?.getButton(Dialog.BUTTON_POSITIVE)?.isVisible = true
+            }
+        }
+
+        // prevent user from closing dialog
+        isCancelable = false
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.exporting)
+            .setView(loadingIndicator)
+            .setPositiveButton(R.string.okay, null)
+            .setCancelable(false)
+            .show()
+            .also {
+                it.getButton(Dialog.BUTTON_POSITIVE)?.isGone = true
+                dialog = it
+            }
+    }
+}

--- a/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/BaseBottomSheet.kt
@@ -1,7 +1,6 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.annotation.LayoutRes
@@ -14,8 +13,8 @@ import com.github.libretube.databinding.BottomSheetBinding
 import com.github.libretube.extensions.dpToPx
 import com.github.libretube.obj.BottomSheetItem
 import com.github.libretube.ui.adapters.BottomSheetAdapter
-import kotlinx.coroutines.launch
 import com.github.libretube.ui.extensions.onSystemInsets
+import kotlinx.coroutines.launch
 
 
 open class BaseBottomSheet(@LayoutRes layoutResId: Int = R.layout.bottom_sheet) : ExpandedBottomSheet(layoutResId) {
@@ -23,6 +22,8 @@ open class BaseBottomSheet(@LayoutRes layoutResId: Int = R.layout.bottom_sheet) 
     private var title: String? = null
     private lateinit var items: List<BottomSheetItem>
     private lateinit var listener: (index: Int) -> Unit
+
+    protected var autoDismiss: Boolean = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val binding = BottomSheetBinding.bind(view)
@@ -60,7 +61,7 @@ open class BaseBottomSheet(@LayoutRes layoutResId: Int = R.layout.bottom_sheet) 
                 dialog?.hide()
                 listener?.invoke(index)
                 runCatching {
-                    dismiss()
+                    if (autoDismiss) dismiss()
                 }
             }
         }

--- a/app/src/main/java/com/github/libretube/ui/sheets/DownloadOptionsBottomSheet.kt
+++ b/app/src/main/java/com/github/libretube/ui/sheets/DownloadOptionsBottomSheet.kt
@@ -1,8 +1,10 @@
 package com.github.libretube.ui.sheets
 
 import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
+import androidx.media3.common.util.UnstableApi
 import com.github.libretube.R
 import com.github.libretube.api.obj.StreamItem
 import com.github.libretube.constants.IntentData
@@ -16,22 +18,41 @@ import com.github.libretube.helpers.NavigationHelper
 import com.github.libretube.obj.ShareData
 import com.github.libretube.parcelable.PlayerData
 import com.github.libretube.ui.activities.NoInternetActivity
+import com.github.libretube.ui.dialogs.DownloadExportDialog
 import com.github.libretube.ui.dialogs.ShareDialog
 import com.github.libretube.ui.fragments.DownloadTab
 import com.github.libretube.util.PlayingQueue
 import com.github.libretube.util.PlayingQueueMode
 
+@UnstableApi
 class DownloadOptionsBottomSheet : BaseBottomSheet() {
+    private lateinit var videoId: String
+
+    private val exportFilePicker =
+        registerForActivityResult(ActivityResultContracts.CreateDocument("video/mp4")) { outputUri ->
+            if (outputUri == null) return@registerForActivityResult
+
+            DownloadExportDialog().apply {
+                arguments = Bundle().apply {
+                    putString(IntentData.videoId, videoId)
+                    putString(IntentData.outputUri, outputUri.toString())
+                }
+            }.show(requireActivity().supportFragmentManager, null)
+
+            dismiss()
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val streamItem = arguments?.parcelable<StreamItem>(IntentData.streamItem)!!
-        val videoId = streamItem.url!!.toID()
+        videoId = streamItem.url!!.toID()
         val downloadTab = arguments?.serializable<DownloadTab>(IntentData.downloadTab)!!
         val playlistId = arguments?.getString(IntentData.playlistId)
 
         val options = mutableListOf(
             R.string.playOnBackground,
             R.string.share,
-            R.string.delete
+            R.string.delete,
+            R.string.export
         )
 
         // can't navigate to video while in offline activity
@@ -76,7 +97,6 @@ class DownloadOptionsBottomSheet : BaseBottomSheet() {
 
                 R.string.delete -> {
                     setFragmentResult(DELETE_DOWNLOAD_REQUEST_KEY, bundleOf())
-                    dialog?.dismiss()
                 }
 
                 R.string.play_next -> {
@@ -85,6 +105,13 @@ class DownloadOptionsBottomSheet : BaseBottomSheet() {
 
                 R.string.add_to_queue -> {
                     PlayingQueue.add(streamItem)
+                }
+
+                R.string.export -> {
+                    exportFilePicker.launch(streamItem.title)
+                    // dismissing now would cause the exportFilePicker to be dropped before
+                    // the file is actually chosen by the user
+                    autoDismiss = false
                 }
             }
         }

--- a/app/src/main/java/com/github/libretube/util/MediaExporter.kt
+++ b/app/src/main/java/com/github/libretube/util/MediaExporter.kt
@@ -1,0 +1,74 @@
+package com.github.libretube.util
+
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.transformer.Composition
+import androidx.media3.transformer.EditedMediaItem
+import androidx.media3.transformer.EditedMediaItemSequence
+import androidx.media3.transformer.ExportException
+import androidx.media3.transformer.ExportResult
+import androidx.media3.transformer.Transformer
+import java.io.InputStream
+import java.io.OutputStream
+
+object MediaExporter {
+    /**
+     * Asynchronously starts muxing an audio and a video file into a single file.
+     */
+    @OptIn(UnstableApi::class)
+    fun muxMedia(
+        context: Context,
+        audioUri: Uri,
+        videoUri: Uri,
+        outputPath: String,
+        onCompletion: () -> Unit,
+        onError: (ExportException) -> Unit
+    ) {
+        val video = EditedMediaItem.Builder(MediaItem.fromUri(videoUri)).build()
+        val audio = EditedMediaItem.Builder(MediaItem.fromUri(audioUri)).build()
+
+        val videoSequence = EditedMediaItemSequence.withVideoFrom(listOf(video))
+        val audioSequence = EditedMediaItemSequence.withAudioFrom(listOf(audio))
+        val composition = Composition.Builder(videoSequence, audioSequence).build()
+
+        val transformer = Transformer.Builder(context).build()
+        val handler = Handler(transformer.applicationLooper)
+
+        handler.post {
+            transformer.addListener(object : Transformer.Listener {
+                override fun onCompleted(composition: Composition, exportResult: ExportResult) {
+                    onCompletion()
+                }
+
+                override fun onError(
+                    composition: Composition,
+                    exportResult: ExportResult,
+                    exportException: ExportException
+                ) {
+                    onError(exportException)
+                }
+            })
+
+            transformer.start(composition, outputPath)
+        }
+    }
+
+    fun copyFileContents(input: InputStream, output: OutputStream) {
+        output.use { outputStream ->
+            input.use { inputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        }
+    }
+
+    fun copyFileContents(context: Context, input: Uri, output: Uri) {
+        copyFileContents(
+            context.contentResolver.openInputStream(input)!!,
+            context.contentResolver.openOutputStream(output)!!
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,6 +438,8 @@
     <string name="update_information">Update information</string>
     <string name="mode_of_operation">Mode of operation</string>
     <string name="delete_playlist_include_vidoes">Also delete all videos from the playlist?</string>
+    <string name="export">Export</string>
+    <string name="exporting">Export in progress…</string>
 
     <!-- Backup & Restore Settings -->
     <string name="import_subscriptions_from">Import subscriptions from</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ androidx-media3-exoplayer-hls = { group = "androidx.media3", name="media3-exopla
 androidx-media3-exoplayer-dash = { group = "androidx.media3", name="media3-exoplayer-dash", version.ref="media3" }
 androidx-media3-session = { group="androidx.media3", name="media3-session", version.ref="media3" }
 androidx-media3-ui = { group="androidx.media3", name="media3-ui", version.ref="media3" }
+androidx-media3-transformer = { group = "androidx.media3", name = "media3-transformer", version.ref = "media3" }
 newpipeextractor = { module = "com.github.libre-tube:NewPipeExtractor", version.ref = "newpipeextractor" }
 square-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }


### PR DESCRIPTION
Because it was requested a lot of times (e.g. https://github.com/libre-tube/LibreTube/issues/3572, https://github.com/libre-tube/LibreTube/issues/8083, ...), I decided to give this a chance now.

If both audio and video are downloaded, we have to mux them together using media3. See https://developer.android.com/media/media3/transformer/getting-started.

Muxing audio and video is extremely slow for some reason, don't ask me why.
